### PR TITLE
Fix duration regex, returning null on first checker

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainAPI.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainAPI.kt
@@ -1143,9 +1143,9 @@ fun getDurationFromString(input: String?): Int? {
         if (values.size == 3) {
             val hours = values[1].toIntOrNull()
             val minutes = values[2].toIntOrNull()
-            return if (minutes != null && hours != null) {
-                hours * 60 + minutes
-            } else null
+            if (minutes != null && hours != null) {
+                return hours * 60 + minutes
+            }
         }
     }
     Regex("([0-9]*)m").find(cleanInput)?.groupValues?.let { values ->


### PR DESCRIPTION
Reason for change: When the first regex matches but the result is invalid on the next checker, it will ignore the other regex checkers and return null. Should at least check for the other regex if its valid.

ready for merge.