### PR TITLE
Separate loading view from homepage

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeLoadFailedFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeLoadFailedFragment.kt
@@ -1,0 +1,57 @@
+package com.lagradost.cloudstream3.ui.home
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import com.lagradost.cloudstream3.APIHolder
+import com.lagradost.cloudstream3.R
+import com.lagradost.cloudstream3.mvvm.Resource
+import com.lagradost.cloudstream3.mvvm.logError
+import com.lagradost.cloudstream3.ui.home.HomeFragment.Companion.selectHomepage
+import com.lagradost.cloudstream3.utils.UIHelper.popupMenuNoIconsAndNoStringRes
+import kotlinx.android.synthetic.main.fragment_home_load_failed.*
+
+class HomeLoadFailedFragment : Fragment() {
+    private val homeViewModel: HomeViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_home_load_failed, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        home_reload_connectionerror.setOnClickListener {
+            requireContext().selectHomepage(homeViewModel.apiNameString) { api ->
+                homeViewModel.loadAndCancel(api)
+            }
+        }
+        home_reload_connection_open_in_browser.setOnClickListener { button ->
+            val validAPIs = APIHolder.apis//.filter { api -> api.hasMainPage }
+
+            button.popupMenuNoIconsAndNoStringRes(validAPIs.mapIndexed { index, api ->
+                Pair(
+                    index,
+                    api.name
+                )
+            }) {
+                try {
+                    val i = Intent(Intent.ACTION_VIEW)
+                    i.data = Uri.parse(validAPIs[itemId].mainUrl)
+                    startActivity(i)
+                } catch (e: Exception) {
+                    logError(e)
+                }
+            }
+        }
+        result_error_text.text = (homeViewModel.page.value as? Resource.Failure)?.errorString
+    }
+}

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeLoadingFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeLoadingFragment.kt
@@ -1,0 +1,44 @@
+package com.lagradost.cloudstream3.ui.home
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import com.lagradost.cloudstream3.R
+import com.lagradost.cloudstream3.ui.home.HomeFragment.Companion.selectHomepage
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment
+import com.lagradost.cloudstream3.utils.UIHelper.fixPaddingStatusbar
+import kotlinx.android.synthetic.main.fragment_home_loading.*
+
+class HomeLoadingFragment : Fragment() {
+    private val homeViewModel: HomeViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_home_loading, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        home_loading_shimmer?.startShimmer()
+        requireContext().fixPaddingStatusbar(home_loading_statusbar)
+        home_change_api_loading.setOnClickListener {
+            requireContext().selectHomepage(homeViewModel.apiNameString) { api ->
+                homeViewModel.loadAndCancel(api)
+            }
+        }
+        if (SettingsFragment.isTrueTvSettings()) {
+            home_change_api_loading?.isVisible = true
+            home_change_api_loading?.isFocusable = true
+            home_change_api_loading?.isFocusableInTouchMode = true
+        } else {
+            home_change_api_loading?.isVisible = false
+        }
+    }
+}

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
@@ -76,6 +76,8 @@ class HomeViewModel : ViewModel() {
 
     private val _apiName = MutableLiveData<String>()
     val apiName: LiveData<String> = _apiName
+    
+    val apiNameString: String? get() = apiName.value
 
     private val _randomItems = MutableLiveData<List<SearchResponse>?>(null)
     val randomItems: LiveData<List<SearchResponse>?> = _randomItems

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -4,154 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/home_root"
     android:layout_width="match_parent"
-
     android:layout_height="match_parent"
     tools:context=".ui.home.HomeFragment">
-
-    <FrameLayout
-        android:id="@+id/home_loading"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone"
-        tools:visibility="gone">
-
-        <ProgressBar
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_gravity="center"
-            android:visibility="gone"
-            tools:visibility="gone" />
-
-        <com.facebook.shimmer.ShimmerFrameLayout
-            android:id="@+id/home_loading_shimmer"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:layout_marginTop="15dp"
-            android:orientation="vertical"
-            android:paddingTop="40dp"
-            app:shimmer_auto_start="true"
-            app:shimmer_base_alpha="0.2"
-            app:shimmer_duration="@integer/loading_time"
-            app:shimmer_highlight_alpha="0.3">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <FrameLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-
-                    <androidx.cardview.widget.CardView
-                        android:layout_width="125dp"
-                        android:layout_height="200dp"
-                        android:layout_gravity="center"
-                        android:layout_margin="@dimen/loading_margin"
-                        android:background="@color/grayShimmer"
-                        android:translationX="-164dp"
-                        app:cardCornerRadius="@dimen/loading_radius" />
-
-                    <androidx.cardview.widget.CardView
-                        android:layout_width="148dp"
-                        android:layout_height="234dp"
-                        android:layout_gravity="center"
-                        android:layout_margin="@dimen/loading_margin"
-                        android:background="@color/grayShimmer"
-                        app:cardCornerRadius="@dimen/loading_radius" />
-
-                    <androidx.cardview.widget.CardView
-                        android:layout_width="125dp"
-                        android:layout_height="200dp"
-                        android:layout_gravity="center"
-                        android:layout_margin="@dimen/loading_margin"
-                        android:background="@color/grayShimmer"
-                        android:translationX="164dp"
-                        app:cardCornerRadius="@dimen/loading_radius" />
-                </FrameLayout>
-
-                <include layout="@layout/loading_line_short_center" />
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/result_padding"
-                    android:layout_marginTop="@dimen/result_padding"
-
-                    android:layout_marginEnd="@dimen/result_padding"
-                    android:orientation="vertical">
-
-                    <include layout="@layout/loading_list" />
-
-                    <include layout="@layout/loading_list" />
-
-                    <include layout="@layout/loading_list" />
-                </LinearLayout>
-            </LinearLayout>
-        </com.facebook.shimmer.ShimmerFrameLayout>
-
-        <FrameLayout
-            android:id="@+id/home_loading_statusbar"
-            android:layout_width="match_parent"
-            android:layout_height="70dp">
-
-            <ImageView
-                android:id="@+id/home_change_api_loading"
-                android:layout_width="30dp"
-                android:layout_height="30dp"
-                android:layout_gravity="center_vertical|end"
-
-                android:layout_margin="10dp"
-                android:background="?android:attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/home_change_provider_img_des"
-                android:src="@drawable/ic_baseline_keyboard_arrow_down_24" />
-        </FrameLayout>
-    </FrameLayout>
-
-    <LinearLayout
-        android:id="@+id/home_loading_error"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:orientation="vertical"
-        android:visibility="gone"
-        tools:visibility="gone">
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/home_reload_connectionerror"
-            style="@style/WhiteButton"
-
-            android:layout_width="wrap_content"
-
-            android:layout_gravity="center"
-            android:layout_margin="5dp"
-            android:minWidth="200dp"
-            android:text="@string/reload_error"
-            app:icon="@drawable/ic_baseline_autorenew_24" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/home_reload_connection_open_in_browser"
-            style="@style/BlackButton"
-
-            android:layout_width="wrap_content"
-
-            android:layout_gravity="center"
-            android:layout_margin="5dp"
-            android:minWidth="200dp"
-            android:text="@string/result_open_in_browser"
-            app:icon="@drawable/ic_baseline_public_24" />
-
-        <TextView
-            android:id="@+id/result_error_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_margin="5dp"
-            android:gravity="center"
-            android:textColor="?attr/textColor" />
-    </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
         android:id="@+id/home_loaded"
@@ -582,6 +436,11 @@
                 tools:listitem="@layout/homepage_parent" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
+
+    <FrameLayout
+        android:id="@+id/home_load_status_holder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
         android:id="@+id/home_api_fab"

--- a/app/src/main/res/layout/fragment_home_load_failed.xml
+++ b/app/src/main/res/layout/fragment_home_load_failed.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/home_loading_error"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/home_reload_connectionerror"
+        style="@style/WhiteButton"
+        android:layout_width="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="5dp"
+        android:minWidth="200dp"
+        android:text="@string/reload_error"
+        app:icon="@drawable/ic_baseline_autorenew_24" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/home_reload_connection_open_in_browser"
+        style="@style/BlackButton"
+        android:layout_width="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="5dp"
+        android:minWidth="200dp"
+        android:text="@string/result_open_in_browser"
+        app:icon="@drawable/ic_baseline_public_24" />
+
+    <TextView
+        android:id="@+id/result_error_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="5dp"
+        android:gravity="center"
+        android:textColor="?attr/textColor" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_home_loading.xml
+++ b/app/src/main/res/layout/fragment_home_loading.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/home_loading"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:id="@+id/home_loading_shimmer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:layout_marginTop="15dp"
+        android:orientation="vertical"
+        android:paddingTop="40dp"
+        app:shimmer_auto_start="true"
+        app:shimmer_base_alpha="0.2"
+        app:shimmer_duration="@integer/loading_time"
+        app:shimmer_highlight_alpha="0.3">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <androidx.cardview.widget.CardView
+                    android:layout_width="125dp"
+                    android:layout_height="200dp"
+                    android:layout_gravity="center"
+                    android:layout_margin="@dimen/loading_margin"
+                    android:background="@color/grayShimmer"
+                    android:translationX="-164dp"
+                    app:cardCornerRadius="@dimen/loading_radius" />
+
+                <androidx.cardview.widget.CardView
+                    android:layout_width="148dp"
+                    android:layout_height="234dp"
+                    android:layout_gravity="center"
+                    android:layout_margin="@dimen/loading_margin"
+                    android:background="@color/grayShimmer"
+                    app:cardCornerRadius="@dimen/loading_radius" />
+
+                <androidx.cardview.widget.CardView
+                    android:layout_width="125dp"
+                    android:layout_height="200dp"
+                    android:layout_gravity="center"
+                    android:layout_margin="@dimen/loading_margin"
+                    android:background="@color/grayShimmer"
+                    android:translationX="164dp"
+                    app:cardCornerRadius="@dimen/loading_radius" />
+            </FrameLayout>
+
+            <include layout="@layout/loading_line_short_center" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/result_padding"
+                android:layout_marginTop="@dimen/result_padding"
+
+                android:layout_marginEnd="@dimen/result_padding"
+                android:orientation="vertical">
+
+                <include layout="@layout/loading_list" />
+
+                <include layout="@layout/loading_list" />
+
+                <include layout="@layout/loading_list" />
+            </LinearLayout>
+        </LinearLayout>
+    </com.facebook.shimmer.ShimmerFrameLayout>
+
+    <FrameLayout
+        android:id="@+id/home_loading_statusbar"
+        android:layout_width="match_parent"
+        android:layout_height="70dp">
+
+        <ImageView
+            android:id="@+id/home_change_api_loading"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_gravity="center_vertical|end"
+            android:layout_margin="10dp"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/home_change_provider_img_des"
+            android:src="@drawable/ic_baseline_keyboard_arrow_down_24" />
+    </FrameLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_home_tv.xml
+++ b/app/src/main/res/layout/fragment_home_tv.xml
@@ -4,154 +4,8 @@
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-
         android:id="@+id/home_root"
         tools:context=".ui.home.HomeFragment">
-
-    <FrameLayout
-            android:visibility="gone"
-            tools:visibility="gone"
-            android:id="@+id/home_loading"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-        <ProgressBar
-                android:layout_gravity="center"
-                android:visibility="gone"
-                tools:visibility="gone"
-                android:layout_width="50dp"
-                android:layout_height="50dp" />
-
-        <com.facebook.shimmer.ShimmerFrameLayout
-                android:id="@+id/home_loading_shimmer"
-                app:shimmer_base_alpha="0.2"
-                app:shimmer_highlight_alpha="0.3"
-                app:shimmer_duration="@integer/loading_time"
-                app:shimmer_auto_start="true"
-                android:paddingTop="40dp"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_gravity="center"
-                android:layout_marginTop="15dp"
-                android:orientation="vertical">
-
-            <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                <FrameLayout
-                        android:orientation="horizontal"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
-
-                    <androidx.cardview.widget.CardView
-                            android:layout_margin="@dimen/loading_margin"
-                            android:layout_gravity="center"
-                            app:cardCornerRadius="@dimen/loading_radius"
-                            android:background="@color/grayShimmer"
-                            android:translationX="-164dp"
-                            android:layout_width="125dp"
-                            android:layout_height="200dp" />
-
-                    <androidx.cardview.widget.CardView
-                            android:layout_margin="@dimen/loading_margin"
-                            android:layout_gravity="center"
-                            app:cardCornerRadius="@dimen/loading_radius"
-                            android:background="@color/grayShimmer"
-                            android:layout_width="148dp"
-                            android:layout_height="234dp" />
-
-                    <androidx.cardview.widget.CardView
-                            android:layout_margin="@dimen/loading_margin"
-                            android:layout_gravity="center"
-                            app:cardCornerRadius="@dimen/loading_radius"
-                            android:background="@color/grayShimmer"
-                            android:translationX="164dp"
-                            android:layout_width="125dp"
-                            android:layout_height="200dp" />
-                </FrameLayout>
-
-                <include layout="@layout/loading_line_short_center" />
-
-                <LinearLayout
-                        android:orientation="vertical"
-                        android:layout_marginTop="@dimen/result_padding"
-                        android:layout_marginStart="@dimen/result_padding"
-                        android:layout_marginEnd="@dimen/result_padding"
-
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
-
-                    <include layout="@layout/loading_list" />
-
-                    <include layout="@layout/loading_list" />
-
-                    <include layout="@layout/loading_list" />
-                </LinearLayout>
-            </LinearLayout>
-        </com.facebook.shimmer.ShimmerFrameLayout>
-
-        <FrameLayout
-                android:id="@+id/home_loading_statusbar"
-                android:layout_width="match_parent"
-                android:layout_height="70dp">
-
-            <ImageView
-                    android:id="@+id/home_change_api_loading"
-                    android:layout_margin="10dp"
-                    android:layout_gravity="center_vertical|end"
-                    android:background="?android:attr/selectableItemBackgroundBorderless"
-
-                    android:src="@drawable/ic_baseline_keyboard_arrow_down_24"
-                    android:layout_width="30dp"
-                    android:layout_height="30dp"
-                    android:contentDescription="@string/home_change_provider_img_des" />
-        </FrameLayout>
-    </FrameLayout>
-
-    <LinearLayout
-            android:visibility="gone"
-            tools:visibility="gone"
-            android:id="@+id/home_loading_error"
-            android:orientation="vertical"
-            android:layout_gravity="center"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-        <com.google.android.material.button.MaterialButton
-                android:layout_gravity="center"
-                style="@style/WhiteButton"
-
-                android:layout_margin="5dp"
-
-                app:icon="@drawable/ic_baseline_autorenew_24"
-                android:text="@string/reload_error"
-                android:id="@+id/home_reload_connectionerror"
-                android:layout_width="wrap_content"
-                android:minWidth="200dp" />
-
-        <com.google.android.material.button.MaterialButton
-                android:layout_gravity="center"
-                style="@style/BlackButton"
-
-                android:layout_margin="5dp"
-
-                app:icon="@drawable/ic_baseline_public_24"
-                android:text="@string/result_open_in_browser"
-                android:id="@+id/home_reload_connection_open_in_browser"
-                android:layout_width="wrap_content"
-                android:minWidth="200dp" />
-
-        <TextView
-                android:layout_margin="5dp"
-                android:gravity="center"
-                android:layout_gravity="center"
-                android:id="@+id/result_error_text"
-                android:textColor="?attr/textColor"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-    </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
             android:background="?attr/primaryBlackBackground"
@@ -436,6 +290,11 @@
                     tools:listitem="@layout/homepage_parent_tv" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
+
+    <FrameLayout
+        android:id="@+id/home_load_status_holder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
             android:visibility="gone"

--- a/app/src/main/res/layout/loading_list.xml
+++ b/app/src/main/res/layout/loading_list.xml
@@ -15,43 +15,43 @@
 
         <include layout="@layout/loading_poster" />
 
-        <View
+        <Space
                 android:layout_height="wrap_content"
                 android:layout_width="@dimen/loading_margin" />
 
         <include layout="@layout/loading_poster" />
 
-        <View
+        <Space
                 android:layout_height="wrap_content"
                 android:layout_width="@dimen/loading_margin" />
 
         <include layout="@layout/loading_poster" />
 
-        <View
+        <Space
                 android:layout_height="wrap_content"
                 android:layout_width="@dimen/loading_margin" />
 
         <include layout="@layout/loading_poster" />
 
-        <View
+        <Space
                 android:layout_height="wrap_content"
                 android:layout_width="@dimen/loading_margin" />
 
         <include layout="@layout/loading_poster" />
 
-        <View
+        <Space
                 android:layout_height="wrap_content"
                 android:layout_width="@dimen/loading_margin" />
 
         <include layout="@layout/loading_poster" />
 
-        <View
+        <Space
                 android:layout_height="match_parent"
                 android:layout_width="@dimen/loading_margin" />
 
         <include layout="@layout/loading_poster" />
 
-        <View
+        <Space
                 android:layout_height="wrap_content"
                 android:layout_width="@dimen/loading_margin" />
 


### PR DESCRIPTION
Thanks for your project, it helped me a lot.

I have a device with poor performance, when cloudstream is running on it, some operations cause stuttering, so I want to optimize its performance.

I first found that the home page has a lot of unnecessary loading status views, and we can remove them completely when the loading is over. I added a framelayout as the fragment's container, and loaded the loading state as a fragment into the container.

In this way we can separate the loading part from the home page, which will make the code more maintainable.