### PR TITLE
Fix StreamSB stream break: support audiotracks

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/StreamSB.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/StreamSB.kt
@@ -130,7 +130,7 @@ open class StreamSB : ExtractorApi() {
             it.value.replace(Regex("(embed-|/e/)"), "")
         }.first()
 //        val master = "$mainUrl/sources48/6d6144797752744a454267617c7c${bytesToHex.lowercase()}7c7c4e61755a56456f34385243727c7c73747265616d7362/6b4a33767968506e4e71374f7c7c343837323439333133333462353935333633373836643638376337633462333634663539343137373761333635313533333835333763376333393636363133393635366136323733343435323332376137633763373337343732363536313664373336327c7c504d754478413835306633797c7c73747265616d7362"
-        val master = "$mainUrl/sources50/" + bytesToHex("||$id||||streamsb".toByteArray()) + "/"
+        val master = "$mainUrl/sources51/" + bytesToHex("||$id||||streamsb".toByteArray()) + "/"
         val headers = mapOf(
             "watchsb" to "sbstream",
         )

--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/StreamSB.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/StreamSB.kt
@@ -3,9 +3,10 @@ package com.lagradost.cloudstream3.extractors
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.mvvm.safeApiCall
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
-import com.lagradost.cloudstream3.utils.M3u8Helper
+import com.lagradost.cloudstream3.utils.Qualities
 
 class Sbspeed : StreamSB() {
     override var name = "Sbspeed"
@@ -140,14 +141,22 @@ open class StreamSB : ExtractorApi() {
             referer = url,
         ).parsedSafe<Main>()
         // val urlmain = mapped.streamData.file.substringBefore("/hls/")
-        M3u8Helper.generateM3u8(
-            name,
-            mapped?.streamData?.file ?: return,
-            url,
-            headers = headers
-        ).forEach(callback)
 
-        mapped.streamData.subs?.map {sub ->
+        safeApiCall {
+            callback.invoke(
+                ExtractorLink(
+                    name,
+                    name,
+                    mapped?.streamData?.file ?: return@safeApiCall,
+                    url,
+                    Qualities.Unknown.value,
+                    true,
+                    headers
+                )
+            )
+        }
+
+        mapped?.streamData?.subs?.map {sub ->
             subtitleCallback.invoke(
                 SubtitleFile(
                     sub.label.toString(),


### PR DESCRIPTION
The previous method,
`M3u8Helper.generateM3u8()`
caused the stream break, which caused the extractor to not be able to support multi-audio tracks.

My method involves not using `M3u8Helper.generateM3u8()` it uses `ExtractorLink()` (Psychopath Method)
Which allows the player to automatically detect audio tracks.

The code change,
```
safeApiCall {
            callback.invoke(
                ExtractorLink(
                    name,
                    name,
                    mapped?.streamData?.file ?: return@safeApiCall,
                    url,
                    Qualities.Unknown.value,
                    true,
                    headers
                )
            )
        }
```
Any my crappy code fixes are welcomed 🙏🏼

**A proof of concept can be found [Here](https://github.com/LikDev-256/likdev256-tamil-providers/blob/master/ShowFlixProvider/src/main/kotlin/com/likdev256/ShowFlixProvider.kt#L447)**