### PR TITLE
getTracker: add matching with year & type as fallback

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainAPI.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainAPI.kt
@@ -199,6 +199,8 @@ object APIHolder {
 
                 val matchingTypes = types?.any { it.name.equals(media.type, true) } == true
                 matchingTitles && matchingTypes && matchingYears
+            } ?: search.results?.find { media ->
+                (year == null || media.releaseDate == year) && types?.any { it.name.equals(media.type, true) } == true
             } ?: return null
 
             Tracker(res.malId, res.aniId, res.image, res.cover)


### PR DESCRIPTION
[tested] I noticed that some anime still missing when using getTracker, so i added matching with year & type as fallback to increase accuracy. idk about non english site but as long as that website provide romanji/english title it should work fine and anilist search is awesome..
