### PR TITLE
More meaningful errors when adding repositories

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/ExtensionsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/ExtensionsFragment.kt
@@ -224,14 +224,31 @@ class ExtensionsFragment : Fragment() {
                             showToast(R.string.error_invalid_data, Toast.LENGTH_SHORT)
                         }
                     } else {
+                        val repository = RepositoryManager.parseRepository(url)
+
+                        // Exit if wrong repository
+                        if (repository == null) {
+                            showToast(R.string.no_repository_found_error, Toast.LENGTH_LONG)
+                            return@ioSafe
+                        }
+
                         val fixedName = if (!name.isNullOrBlank()) name
-                        else RepositoryManager.parseRepository(url)?.name ?: "No name"
+                        else repository.name
 
                         val newRepo = RepositoryData(fixedName, url)
                         RepositoryManager.addRepository(newRepo)
                         extensionViewModel.loadStats()
                         extensionViewModel.loadRepositories()
-                        this@ExtensionsFragment.activity?.downloadAllPluginsDialog(url, fixedName)
+
+                        val plugins = RepositoryManager.getRepoPlugins(url)
+                        if (plugins.isNullOrEmpty()) {
+                            showToast(R.string.no_plugins_found_error, Toast.LENGTH_LONG)
+                        } else {
+                            this@ExtensionsFragment.activity?.downloadAllPluginsDialog(
+                                url,
+                                fixedName
+                            )
+                        }
                     }
                 }
                 dialog.dismissSafe(activity)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginsViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginsViewModel.kt
@@ -86,13 +86,17 @@ class PluginsViewModel : ViewModel() {
                 }.also { list ->
                     main {
                         showToast(
-                            if (list.isEmpty()) {
-                                txt(
+                            when {
+                                // No plugins at all
+                                plugins.isEmpty() -> txt(
+                                    R.string.no_plugins_found_error,
+                                )
+                                // All plugins downloaded
+                                list.isEmpty() -> txt(
                                     R.string.batch_download_nothing_to_download_format,
                                     txt(R.string.plugin)
                                 )
-                            } else {
-                                txt(
+                                else -> txt(
                                     R.string.batch_download_start_format,
                                     list.size,
                                     txt(if (list.size == 1) R.string.plugin_singular else R.string.plugin)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,6 +572,8 @@
     <string name="batch_download_start_format" formatted="true">Started downloading %d %s…</string>
     <string name="batch_download_finish_format" formatted="true">Downloaded %d %s</string>
     <string name="batch_download_nothing_to_download_format" formatted="true">All %s already downloaded</string>
+    <string name="no_plugins_found_error">No plugins found in repository</string>
+    <string name="no_repository_found_error">Repository not found, check the URL and try VPN</string>
     <string name="batch_download">Batch download</string>
     <string name="plugin_singular">plugin</string>
     <string name="plugin">plugins</string>


### PR DESCRIPTION
When adding repositories the app now checks the repository validity and gives error messages to help the user.

The download all prompt does not appear if there are no plugins to download.