### PR TITLE
Add Native Crash Handler

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Set this to the minimum version your project supports.
+cmake_minimum_required(VERSION 3.18)
+project(CrashHandler)
+find_library(log-lib log)
+add_library(native-lib SHARED src/main/cpp/native-lib.cpp)
+target_link_libraries(native-lib ${log-lib})

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,12 @@ android {
         enable = true
     }
 
+    externalNativeBuild {
+        cmake {
+            path("CMakeLists.txt")
+        }
+    }
+
     signingConfigs {
         create("prerelease") {
             if (prereleaseStoreFile != null) {

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -1,0 +1,28 @@
+#include <jni.h>
+#include <csignal>
+#include <android/log.h>
+
+#define TAG "CloudStream Crash Handler"
+volatile sig_atomic_t gSignalStatus = 0;
+void handleNativeCrash(int signal) {
+    gSignalStatus = signal;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_lagradost_cloudstream3_NativeCrashHandler_initNativeCrashHandler(JNIEnv *env, jobject) {
+    #define REGISTER_SIGNAL(X) signal(X, handleNativeCrash);
+    REGISTER_SIGNAL(SIGSEGV)
+    #undef REGISTER_SIGNAL
+}
+
+//extern "C" JNIEXPORT void JNICALL
+//Java_com_lagradost_cloudstream3_NativeCrashHandler_triggerNativeCrash(JNIEnv *env, jobject thiz) {
+//    int *p = nullptr;
+//    *p = 0;
+//}
+
+extern "C" JNIEXPORT int JNICALL
+Java_com_lagradost_cloudstream3_NativeCrashHandler_getSignalStatus(JNIEnv *env, jobject) {
+    //__android_log_print(ANDROID_LOG_INFO, TAG, "Got signal status %d", gSignalStatus);
+    return gSignalStatus;
+}

--- a/app/src/main/java/com/lagradost/cloudstream3/AcraApplication.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/AcraApplication.kt
@@ -106,6 +106,7 @@ class ExceptionHandler(val errorFile: File, val onError: (() -> Unit)) :
 class AcraApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        NativeCrashHandler.initCrashHandler()
         Thread.setDefaultUncaughtExceptionHandler(ExceptionHandler(filesDir.resolve("last_error")) {
             val intent = context!!.packageManager.getLaunchIntentForPackage(context!!.packageName)
             startActivity(Intent.makeRestartActivityTask(intent!!.component))

--- a/app/src/main/java/com/lagradost/cloudstream3/NativeCrashHandler.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/NativeCrashHandler.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3
 
 import com.lagradost.cloudstream3.MainActivity.Companion.lastError
+import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.plugins.PluginManager.checkSafeModeFile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,8 +29,16 @@ object NativeCrashHandler {
     }
 
     fun initCrashHandler() {
-        System.loadLibrary("native-lib")
-        initNativeCrashHandler()
+        try {
+            System.loadLibrary("native-lib")
+            initNativeCrashHandler()
+        } catch (t: Throwable) {
+            // Make debug crash.
+            if (BuildConfig.DEBUG) throw t
+            logError(t)
+            return
+        }
+
         initSignalPolling()
     }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/NativeCrashHandler.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/NativeCrashHandler.kt
@@ -1,0 +1,35 @@
+package com.lagradost.cloudstream3
+
+import com.lagradost.cloudstream3.MainActivity.Companion.lastError
+import com.lagradost.cloudstream3.plugins.PluginManager.checkSafeModeFile
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+object NativeCrashHandler {
+    // external fun triggerNativeCrash()
+    private external fun initNativeCrashHandler()
+    private external fun getSignalStatus(): Int
+
+    private fun initSignalPolling() = CoroutineScope(Dispatchers.IO).launch {
+        while (true) {
+            delay(10_000)
+            val signal = getSignalStatus()
+            // Signal is initialized to zero
+            if (signal == 0) continue
+
+            // Do not crash in safe mode!
+            if (lastError != null) continue
+            if (checkSafeModeFile()) continue
+
+            throw RuntimeException("Native crash with code: $signal. Try uninstalling extensions.\n")
+        }
+    }
+
+    fun initCrashHandler() {
+        System.loadLibrary("native-lib")
+        initNativeCrashHandler()
+        initSignalPolling()
+    }
+}


### PR DESCRIPTION
Arbitrary dex files can lead to arbitrary errors, even low level SIGSEGV. Instead of killing the app this throws an exception which can be handled by the normal crash handlers, properly starting safe mode.

This catches SIGSEGV and sets a variable which can be polled from Kotlin, notifying a crash.
It is [not possible to do much from a signal handler](https://stackoverflow.com/a/12434262), least of all run Kotlin code which is why polling is required. It may be possible to do something better but this seems reliable enough with minimal overhead.