### PR TITLE
Upgrade SDK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,13 +50,13 @@ android {
         }
     }
 
-    compileSdk = 34
+    compileSdk = 33
     buildToolsVersion = "34.0.0"
 
     defaultConfig {
         applicationId = "com.lagradost.cloudstream3"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 33
 
         versionCode = 59
         versionName = "4.1.8"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,13 +50,13 @@ android {
         }
     }
 
-    compileSdk = 33
-    buildToolsVersion = "30.0.3"
+    compileSdk = 34
+    buildToolsVersion = "34.0.0"
 
     defaultConfig {
         applicationId = "com.lagradost.cloudstream3"
         minSdk = 21
-        targetSdk = 29
+        targetSdk = 34
 
         versionCode = 59
         versionName = "4.1.8"


### PR DESCRIPTION
The previous reason for downgrading the SDK was that the app could not properly query all installed apps even with `QUERY_ALL_PACKAGES`. It turns out that https://github.com/recloudstream/cloudstream/commit/c92ac3e8b3502f26ed812647134dc0977218831e#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR18 actually fixed `QUERY_ALL_PACKAGES` not working. This makes it possible to upgrade the SDK again :smiley: 

Note: targetSdk not updated to 34 because I have not tested it against https://developer.android.com/about/versions/14/behavior-changes-14