### PR TITLE
Stream button type switch support

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/LinkGenerator.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/LinkGenerator.kt
@@ -67,9 +67,8 @@ class LinkGenerator(
                         link.name ?: link.url,
                         unshortenLinkSafe(link.url), // unshorten because it might be a raw link
                         referer ?: "",
-                        Qualities.Unknown.value, isM3u8 ?: normalSafeApiCall {
-                            URI(link.url).path?.substringAfterLast(".")?.contains("m3u")
-                        } ?: false
+                        Qualities.Unknown.value,
+                        type = INFER_TYPE,
                     ) to null
                 )
             }

--- a/app/src/main/res/layout/stream_input.xml
+++ b/app/src/main/res/layout/stream_input.xml
@@ -49,7 +49,8 @@
             android:layout_marginTop="10dp"
             android:text="@string/hls_playlist"
             android:textColor="?attr/textColor"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:visibility="invisible" />
     </LinearLayout>
 
 


### PR DESCRIPTION
- Use INFER_TYPE to detect type for Stream button.
- Hide "HLS playlist" switch for no use (maybe we can use it for ClearKey drm support later).