### PR TITLE
Potential fix for crash loops

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1092,15 +1092,19 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener {
         updateTv()
 
         // backup when we update the app, I don't trust myself to not boot lock users, might want to make this a setting?
-        try {
+        normalSafeApiCall {
             val appVer = BuildConfig.VERSION_NAME
             val lastAppAutoBackup: String = getKey("VERSION_NAME") ?: ""
             if (appVer != lastAppAutoBackup) {
                 setKey("VERSION_NAME", BuildConfig.VERSION_NAME)
-                backup()
+                normalSafeApiCall {
+                    backup()
+                }
+                normalSafeApiCall {
+                    // Recompile oat on new version
+                    PluginManager.deleteAllOatFiles(this)
+                }
             }
-        } catch (t: Throwable) {
-            logError(t)
         }
 
         // just in case, MAIN SHOULD *NEVER* BOOT LOOP CRASH

--- a/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
@@ -137,6 +137,20 @@ object PluginManager {
         }
     }
 
+    /**
+     * Deletes all generated oat files which will force Android to recompile the dex extensions.
+     * This might fix unrecoverable SIGSEGV exceptions when old oat files are loaded in a new app update.
+     */
+    fun deleteAllOatFiles(context: Context) {
+        File("${context.filesDir}/${ONLINE_PLUGINS_FOLDER}").listFiles()?.forEach { repo ->
+            repo.listFiles { file -> file.name == "oat" && file.isDirectory }?.forEach { file ->
+                val success = file.deleteRecursively()
+                Log.i(TAG, "Deleted oat directory: ${file.absolutePath} Success=$success")
+            }
+        }
+    }
+
+
     fun getPluginsOnline(): Array<PluginData> {
         return getKey(PLUGINS_KEY) ?: emptyArray()
     }


### PR DESCRIPTION
Untested but should theoretically fix unrecoverable plugin exceptions.
The .cs3 files are compiled against an old version of the app with pointers to methods which may have changed, leading to a low level NPE.
Recompiling the dex files hopefully fixes outdated pointers.