### PR TITLE
Use FFmpegMediaMetadataRetriever for generating previews

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -264,7 +264,7 @@ dependencies {
 
     // https://github.com/wseemann/FFmpegMediaMetadataRetriever
     implementation("com.github.wseemann:FFmpegMediaMetadataRetriever-core:1.0.19")
-    implementation(:com.github.wseemann:FFmpegMediaMetadataRetriever-native:1.0.19")
+    implementation("com.github.wseemann:FFmpegMediaMetadataRetriever-native:1.0.19")
 }
 
 tasks.register("androidSourcesJar", Jar::class) {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -258,8 +258,13 @@ dependencies {
 
     // color palette for images -> colors
     implementation("androidx.palette:palette-ktx:1.0.0")
+
     // seekbar https://github.com/rubensousa/PreviewSeekBar
     implementation("com.github.rubensousa:previewseekbar-media3:1.1.1.0")
+
+    // https://github.com/wseemann/FFmpegMediaMetadataRetriever
+    implementation("com.github.wseemann:FFmpegMediaMetadataRetriever-core:1.0.19")
+    implementation(:com.github.wseemann:FFmpegMediaMetadataRetriever-native:1.0.19")
 }
 
 tasks.register("androidSourcesJar", Jar::class) {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -225,7 +225,7 @@ class CS3IPlayer : IPlayer {
         releasePlayer()
         if (link != null) {
             // only video and m3u8 support atm (DASH is untested)
-            val isSupportedType == link.type == ExtractorLinkType.VIDEO || link.type == ExtractorLinkType.M3U8 
+            val isSupportedType = link.type == ExtractorLinkType.VIDEO || link.type == ExtractorLinkType.M3U8 
             if (isSupportedType && preview) {
                 val headers = if (link.referer.isBlank()) {
                     link.headers

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -224,8 +224,9 @@ class CS3IPlayer : IPlayer {
         // release the current exoplayer and cache
         releasePlayer()
         if (link != null) {
-            // only video support atm
-            if (link.type == ExtractorLinkType.VIDEO && preview) {
+            // only video and m3u8 support atm (DASH is untested)
+            val isSupportedType == link.type == ExtractorLinkType.VIDEO || link.type == ExtractorLinkType.M3U8 
+            if (isSupportedType && preview) {
                 val headers = if (link.referer.isBlank()) {
                     link.headers
                 } else {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PreviewGenerator.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PreviewGenerator.kt
@@ -2,7 +2,6 @@ package com.lagradost.cloudstream3.ui.player
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.util.Log
 import androidx.annotation.WorkerThread
@@ -13,6 +12,7 @@ import kotlinx.coroutines.isActive
 import kotlin.math.absoluteValue
 import kotlin.math.ceil
 import kotlin.math.log2
+import wseemann.media.FFmpegMediaMetadataRetriever
 
 const val MAX_LOD = 6
 const val MIN_LOD = 3
@@ -67,8 +67,7 @@ class PreviewGenerator {
         }
     }
 
-    // also check out https://github.com/wseemann/FFmpegMediaMetadataRetriever
-    private val retriever: MediaMetadataRetriever = MediaMetadataRetriever()
+    private val retriever: FFmpegMediaMetadataRetriever = FFmpegMediaMetadataRetriever()
 
     fun clear(keepCache: Boolean = false) {
         if (keepCache) return
@@ -111,11 +110,11 @@ class PreviewGenerator {
         Log.i(TAG, "Started loading preview")
 
         val durationMs =
-            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLong()
+            retriever.extractMetadata(FFmpegMediaMetadataRetriever.METADATA_KEY_DURATION)?.toLong()
                 ?: throw IllegalArgumentException("Bad video duration")
         val durationUs = (durationMs * 1000L).toFloat()
-        //val width = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toInt() ?: throw IllegalArgumentException("Bad video width")
-        //val height = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toInt() ?: throw IllegalArgumentException("Bad video height")
+        //val width = retriever.extractMetadata(FFmpegMediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toInt() ?: throw IllegalArgumentException("Bad video width")
+        //val height = retriever.extractMetadata(FFmpegMediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toInt() ?: throw IllegalArgumentException("Bad video height")
 
         // log2 # 10s durations in the video ~= how many segments we have
         val maxLod = ceil(log2((durationMs / 10_000).toFloat())).toInt().coerceIn(MIN_LOD, MAX_LOD)
@@ -130,7 +129,7 @@ class PreviewGenerator {
                 val frame = durationUs * fraction
                 val img = retriever.getFrameAtTime(
                     frame.toLong(),
-                    MediaMetadataRetriever.OPTION_CLOSEST_SYNC
+                    FFmpegMediaMetadataRetriever.OPTION_CLOSEST_SYNC
                 )
                 if (!scope.isActive) return
                 synchronized(images) {


### PR DESCRIPTION
For HLS support

Resolves #641 

Note this might make generation a little slower, we might want to instead only use FFmpegMediaMetadataRetriever for m3u8, but this also technically works for both, so I just used it for both, but it does seem to make it a little slower before preview becomes available.