### PR TITLE
Larger top poster in TV loading layout

### DIFF
--- a/app/src/main/res/layout/fragment_result_tv.xml
+++ b/app/src/main/res/layout/fragment_result_tv.xml
@@ -124,17 +124,16 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
             android:textColor="?attr/textColor" />
     </LinearLayout>
 
-
     <FrameLayout
         android:id="@+id/background_poster_holder"
         android:layout_width="match_parent"
-        android:layout_height="150dp"
+        android:layout_height="250dp"
         android:visibility="visible">
 
         <ImageView
             android:id="@+id/background_poster"
             android:layout_width="match_parent"
-            android:layout_height="250dp"
+            android:layout_height="275dp"
             android:layout_gravity="center"
             android:alpha="0.8"
             android:scaleType="centerCrop"
@@ -142,10 +141,9 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
 
         <ImageView
             android:layout_width="match_parent"
-            android:layout_height="100dp"
+            android:layout_height="120dp"
             android:layout_gravity="bottom"
             android:src="@drawable/background_shadow">
-
         </ImageView>
     </FrameLayout>
 
@@ -154,7 +152,6 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
         android:id="@+id/result_finish_loading"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -166,8 +163,70 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="100dp"
-                android:orientation="horizontal">
+                android:orientation="vertical"
+                android:layout_marginTop="175dp">
+
+                <TextView
+                    android:id="@+id/result_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="marquee"
+                    android:gravity="center_vertical"
+                    android:singleLine="true"
+                    android:textColor="?attr/textColor"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    tools:text="The Perfect Run The Perfect Run" />
+
+                <LinearLayout
+                    android:id="@+id/result_next_airing_holder"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="start"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/result_episodes_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginEnd="20dp"
+                        android:textColor="?attr/textColor"
+                        android:textSize="17sp"
+                        android:textStyle="normal"
+                        android:visibility="gone"
+                        tools:text="8 Episodes" />
+
+                    <TextView
+                        android:id="@+id/result_next_airing"
+                        android:layout_width="match_parent"
+
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:gravity="center"
+                        android:textColor="?attr/grayTextColor"
+                        android:textSize="17sp"
+                        android:textStyle="normal"
+                        tools:text="Episode 1022 will be released in" />
+
+                    <TextView
+                        android:id="@+id/result_next_airing_time"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:gravity="start"
+                        android:textColor="?attr/textColor"
+                        android:textSize="17sp"
+                        android:textStyle="normal"
+                        tools:text="5d 3h 30m" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="10dp">
 
                 <LinearLayout
                     android:layout_width="250dp"
@@ -176,67 +235,11 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
                     android:layout_weight="0"
                     android:orientation="vertical">
 
-                    <TextView
-                        android:id="@+id/result_title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:ellipsize="marquee"
-                        android:gravity="center_vertical"
-                        android:singleLine="true"
-                        android:textColor="?attr/textColor"
-                        android:textSize="20sp"
-                        android:textStyle="bold"
-                        tools:text="The Perfect Run The Perfect Run" />
-
-                    <LinearLayout
-                        android:id="@+id/result_next_airing_holder"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="start"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:id="@+id/result_episodes_text"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center_vertical"
-                            android:layout_marginEnd="20dp"
-                            android:textColor="?attr/textColor"
-                            android:textSize="17sp"
-                            android:textStyle="normal"
-                            android:visibility="gone"
-                            tools:text="8 Episodes" />
-
-                        <TextView
-                            android:id="@+id/result_next_airing"
-                            android:layout_width="match_parent"
-
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center_vertical"
-                            android:gravity="center"
-                            android:textColor="?attr/grayTextColor"
-                            android:textSize="17sp"
-                            android:textStyle="normal"
-                            tools:text="Episode 1022 will be released in" />
-
-                        <TextView
-                            android:id="@+id/result_next_airing_time"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center_vertical"
-                            android:gravity="start"
-                            android:textColor="?attr/textColor"
-                            android:textSize="17sp"
-                            android:textStyle="normal"
-                            tools:text="5d 3h 30m" />
-                    </LinearLayout>
-
                     <LinearLayout
                         android:id="@+id/result_movie_parent"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="start"
-                        android:layout_marginTop="10dp"
                         android:animateLayoutChanges="true"
                         android:orientation="vertical"
                         tools:visibility="visible">


### PR DESCRIPTION
- Moved the title above buttons and plot, to avoid tight space for long titles.
- Longer posters to fill the space of the TV screen, look nicer.