### PR TITLE
Add clear search query icons

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
@@ -8,12 +8,14 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.FOCUS_AFTER_DESCENDANTS
 import android.view.ViewGroup.FOCUS_BLOCK_DESCENDANTS
 import android.view.animation.AlphaAnimation
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
@@ -136,6 +138,13 @@ class LibraryFragment : Fragment() {
         binding?.libraryRoot?.findViewById<TextView>(R.id.search_src_text)?.apply {
             tag = "tv_no_focus_tag"
         }
+
+        // Set the color for the search exit icon to the correct theme text color
+        val searchExitIcon = binding?.mainSearch?.findViewById<ImageView>(androidx.appcompat.R.id.search_close_btn)
+        val searchExitIconColor = TypedValue()
+
+        activity?.theme?.resolveAttribute(android.R.attr.textColor, searchExitIconColor, true)
+        searchExitIcon?.setColorFilter(searchExitIconColor.data)
 
         binding?.mainSearch?.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/quicksearch/QuickSearchFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/quicksearch/QuickSearchFragment.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -215,10 +216,16 @@ class QuickSearchFragment : Fragment() {
             binding?.quickSearch?.findViewById<ImageView>(androidx.appcompat.R.id.search_close_btn)
 
         //val searchMagIcon =
-        //    binding.quickSearch.findViewById<ImageView>(androidx.appcompat.R.id.search_mag_icon)
+        //    binding?.quickSearch?.findViewById<ImageView>(androidx.appcompat.R.id.search_mag_icon)
 
-        //searchMagIcon?.scaleX = 0.65f
-        //searchMagIcon?.scaleY = 0.65f
+        // searchMagIcon?.scaleX = 0.65f
+        // searchMagIcon?.scaleY = 0.65f
+
+        // Set the color for the search exit icon to the correct theme text color
+        val searchExitIconColor = TypedValue()
+
+        activity?.theme?.resolveAttribute(android.R.attr.textColor, searchExitIconColor, true)
+        searchExitIcon?.setColorFilter(searchExitIconColor.data)
 
         binding?.quickSearch?.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.ui.search
 import android.content.DialogInterface
 import android.content.res.Configuration
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -231,9 +232,15 @@ class SearchFragment : Fragment() {
         val searchExitIcon =
             binding?.mainSearch?.findViewById<ImageView>(androidx.appcompat.R.id.search_close_btn)
         // val searchMagIcon =
-        //    main_search.findViewById<ImageView>(androidx.appcompat.R.id.search_mag_icon)
-        //searchMagIcon.scaleX = 0.65f
-        //searchMagIcon.scaleY = 0.65f
+        //    binding?.mainSearch?.findViewById<ImageView>(androidx.appcompat.R.id.search_mag_icon)
+        // searchMagIcon.scaleX = 0.65f
+        // searchMagIcon.scaleY = 0.65f
+
+        // Set the color for the search exit icon to the correct theme text color
+        val searchExitIconColor = TypedValue()
+
+        activity?.theme?.resolveAttribute(android.R.attr.textColor, searchExitIconColor, true)
+        searchExitIcon?.setColorFilter(searchExitIconColor.data)
 
         selectedApis = DataStoreHelper.searchPreferenceProviders.toMutableSet()
 

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -68,6 +68,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_gravity="center_vertical"
+                    android:layout_marginEnd="25dp"
 
                     android:iconifiedByDefault="false"
                     android:imeOptions="actionSearch"
@@ -81,6 +82,7 @@
                     app:queryBackground="@color/transparent"
                     app:queryHint="@string/search_hint"
                     app:searchIcon="@drawable/search_icon"
+                    app:closeIcon="@drawable/ic_baseline_close_24"
                     tools:ignore="RtlSymmetry">
 
                 </androidx.appcompat.widget.SearchView>

--- a/app/src/main/res/layout/fragment_library_tv.xml
+++ b/app/src/main/res/layout/fragment_library_tv.xml
@@ -102,6 +102,7 @@
                     app:queryBackground="@color/transparent"
                     app:queryHint="@string/search_hint"
                     app:searchIcon="@drawable/search_icon"
+                    app:closeIcon="@drawable/ic_baseline_close_24"
                     tools:ignore="RtlSymmetry">
 
                 </androidx.appcompat.widget.SearchView>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -49,6 +49,7 @@
                     app:queryBackground="@color/transparent"
                     app:queryHint="@string/search_hint"
                     app:searchIcon="@drawable/search_icon"
+                    app:closeIcon="@drawable/ic_baseline_close_24"
                     tools:ignore="RtlSymmetry">
 
                     <requestFocus />

--- a/app/src/main/res/layout/fragment_search_tv.xml
+++ b/app/src/main/res/layout/fragment_search_tv.xml
@@ -50,6 +50,7 @@
                     app:queryBackground="@color/transparent"
                     app:queryHint="@string/search_hint"
                     app:searchIcon="@drawable/search_icon"
+                    app:closeIcon="@drawable/ic_baseline_close_24"
                     tools:ignore="RtlSymmetry">
 
                     <requestFocus />

--- a/app/src/main/res/layout/quick_search.xml
+++ b/app/src/main/res/layout/quick_search.xml
@@ -49,6 +49,8 @@
                     app:queryBackground="@color/transparent"
 
                     app:searchIcon="@drawable/search_icon"
+                    app:closeIcon="@drawable/ic_baseline_close_24"
+
                     android:paddingStart="-10dp"
                     android:iconifiedByDefault="false"
                     app:queryHint="@string/search_hint"


### PR DESCRIPTION
Resolves #381
Resolves #667

I did have to manually set the color of the search_close_btn so it properly works across themes, I am not sure if I did this part correctly. If not, I apologize.