### PR TITLE
Old APIs focus fixes

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
@@ -575,6 +575,7 @@ class ResultFragmentTv : Fragment() {
         observeNullable(viewModel.movie) { data ->
             binding?.apply {
                 resultPlayMovie.isVisible = data is Resource.Success
+                resultPlaySeries.isVisible = data == null
                 seriesHolder.isVisible = data == null
                 resultEpisodesShow.isVisible = data == null
 

--- a/app/src/main/res/layout/cast_item.xml
+++ b/app/src/main/res/layout/cast_item.xml
@@ -9,7 +9,7 @@
     android:layout_margin="5dp"
     android:foreground="@drawable/outline_drawable"
     app:cardBackgroundColor="@color/transparent"
-
+    android:focusable="true"
     app:cardCornerRadius="@dimen/rounded_image_radius"
     app:cardElevation="0dp">
 

--- a/app/src/main/res/layout/fragment_home_tv.xml
+++ b/app/src/main/res/layout/fragment_home_tv.xml
@@ -140,6 +140,7 @@
                 android:layout_gravity="end"
                 android:background="@drawable/player_button_tv_attr_no_bg"
                 android:contentDescription="@string/account"
+                android:focusable="true"
                 android:nextFocusLeft="@id/home_preview_search_button"
                 android:nextFocusRight="@id/home_switch_account"
                 android:nextFocusDown="@id/home_change_api"

--- a/app/src/main/res/layout/fragment_result_tv.xml
+++ b/app/src/main/res/layout/fragment_result_tv.xml
@@ -418,6 +418,7 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
                         android:fadingEdgeLength="30dp"
                         android:foreground="@drawable/outline_drawable"
                         android:maxLines="7"
+                        android:focusable="true"
                         android:nextFocusUp="@id/result_back"
                         android:nextFocusDown="@id/result_bookmark_button"
                         android:padding="5dp"


### PR DESCRIPTION
Fixes the below focus behavior for old APIs (tested for API 25) in TV layout:
- Movie button focus in result layout.
- Cast item focus in result layout.
- Media description focus in result layout.
- Switch account button focus, in Homepage during loading.