### PR TITLE
Add more info on homepage to emulator layout

### DIFF
--- a/app/src/androidTest/java/com/lagradost/cloudstream3/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/lagradost/cloudstream3/ExampleInstrumentedTest.kt
@@ -19,6 +19,7 @@ import com.lagradost.cloudstream3.databinding.FragmentSearchBinding
 import com.lagradost.cloudstream3.databinding.FragmentSearchTvBinding
 import com.lagradost.cloudstream3.databinding.HomeResultGridBinding
 import com.lagradost.cloudstream3.databinding.HomepageParentBinding
+import com.lagradost.cloudstream3.databinding.HomepageParentEmulatorBinding
 import com.lagradost.cloudstream3.databinding.HomepageParentTvBinding
 import com.lagradost.cloudstream3.databinding.PlayerCustomLayoutBinding
 import com.lagradost.cloudstream3.databinding.PlayerCustomLayoutTvBinding
@@ -119,8 +120,9 @@ class ExampleInstrumentedTest {
                // testAllLayouts<HomeScrollViewBinding>(activity, R.layout.home_scroll_view, R.layout.home_scroll_view_tv)
                // testAllLayouts<HomeScrollViewTvBinding>(activity, R.layout.home_scroll_view, R.layout.home_scroll_view_tv)
 
-                testAllLayouts<HomepageParentTvBinding>(activity, R.layout.homepage_parent_tv, R.layout.homepage_parent)
-                testAllLayouts<HomepageParentBinding>(activity, R.layout.homepage_parent_tv, R.layout.homepage_parent)
+                testAllLayouts<HomepageParentTvBinding>(activity, R.layout.homepage_parent_tv, R.layout.homepage_parent_emulator, R.layout.homepage_parent)
+                testAllLayouts<HomepageParentEmulatorBinding>(activity, R.layout.homepage_parent_tv, R.layout.homepage_parent_emulator, R.layout.homepage_parent)
+                testAllLayouts<HomepageParentBinding>(activity, R.layout.homepage_parent_tv, R.layout.homepage_parent_emulator, R.layout.homepage_parent)
 
                 testAllLayouts<FragmentLibraryTvBinding>(activity, R.layout.fragment_library_tv, R.layout.fragment_library)
                 testAllLayouts<FragmentLibraryBinding>(activity, R.layout.fragment_library_tv, R.layout.fragment_library)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapter.kt
@@ -15,7 +15,8 @@ import com.lagradost.cloudstream3.ui.result.FOCUS_SELF
 import com.lagradost.cloudstream3.ui.result.setLinearListLayout
 import com.lagradost.cloudstream3.ui.search.SearchClickCallback
 import com.lagradost.cloudstream3.ui.search.SearchFragment.Companion.filterSearchResponse
-import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.isTvSettings
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.isEmulatorSettings
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.isTrueTvSettings
 import com.lagradost.cloudstream3.utils.AppUtils.isRecyclerScrollable
 
 class LoadClickCallback(
@@ -34,11 +35,13 @@ open class ParentItemAdapter(
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
 
-        val root = LayoutInflater.from(parent.context).inflate(
-            if (isTvSettings()) R.layout.homepage_parent_tv else R.layout.homepage_parent,
-            parent,
-            false
-        )
+        val layoutResId = when {
+            isTrueTvSettings() -> R.layout.homepage_parent_tv
+            parent.context.isEmulatorSettings() -> R.layout.homepage_parent_emulator
+            else -> R.layout.homepage_parent
+        }
+
+        val root = LayoutInflater.from(parent.context).inflate(layoutResId, parent, false)
 
         val binding = HomepageParentBinding.bind(root)
 
@@ -234,7 +237,7 @@ open class ParentItemAdapter(
             })
 
             //(recyclerView.adapter as HomeChildItemAdapter).notifyDataSetChanged()
-            if (!isTvSettings()) {
+            if (!isTrueTvSettings()) {
                 title.setOnClickListener {
                     moreInfoClickCallback.invoke(expand)
                 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
@@ -35,6 +35,7 @@ import com.lagradost.cloudstream3.ui.result.setLinearListLayout
 import com.lagradost.cloudstream3.ui.search.SEARCH_ACTION_LOAD
 import com.lagradost.cloudstream3.ui.search.SEARCH_ACTION_SHOW_METADATA
 import com.lagradost.cloudstream3.ui.search.SearchClickCallback
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.isEmulatorSettings
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.isTvSettings
 import com.lagradost.cloudstream3.utils.DataStoreHelper
 import com.lagradost.cloudstream3.utils.SingleSelectionHelper.showBottomDialog
@@ -81,6 +82,28 @@ class HomeParentItemAdapterPreview(
                     parent,
                     false
                 ) else FragmentHomeHeadBinding.inflate(inflater, parent, false)
+
+                if (binding is FragmentHomeHeadTvBinding && parent.context.isEmulatorSettings()) {
+                    binding.homeBookmarkParentItemMoreInfo.isVisible = true
+
+                    val marginInDp = 50
+                    val density = binding.horizontalScrollChips.context.resources.displayMetrics.density
+                    val marginInPixels = (marginInDp * density).toInt()
+
+                    val params = binding.horizontalScrollChips.layoutParams as ViewGroup.MarginLayoutParams
+                    params.marginEnd = marginInPixels
+                    binding.horizontalScrollChips.layoutParams = params
+                    binding.homeWatchParentItemTitle.setCompoundDrawablesWithIntrinsicBounds(
+                        null,
+                        null,
+                        ContextCompat.getDrawable(
+                            parent.context,
+                            R.drawable.ic_baseline_arrow_forward_24
+                        ),
+                        null
+                    )
+                }
+
                 HeaderViewHolder(
                     binding,
                     viewModel,
@@ -553,12 +576,19 @@ class HomeParentItemAdapterPreview(
             resumeHolder.isVisible = resumeWatching.isNotEmpty()
             resumeAdapter.updateList(resumeWatching)
 
-            if (binding is FragmentHomeHeadBinding) {
-                binding.homeWatchParentItemTitle.setOnClickListener {
+            if (
+                binding is FragmentHomeHeadBinding ||
+                binding is FragmentHomeHeadTvBinding &&
+                binding.root.context.isEmulatorSettings()
+            ) {
+                val title = (binding as? FragmentHomeHeadBinding)?.homeWatchParentItemTitle
+                    ?: (binding as? FragmentHomeHeadTvBinding)?.homeWatchParentItemTitle
+
+                title?.setOnClickListener {
                     viewModel.popup(
                         HomeViewModel.ExpandableHomepageList(
                             HomePageList(
-                                binding.homeWatchParentItemTitle.text.toString(),
+                                title.text.toString(),
                                 resumeWatching,
                                 false
                             ), 1, false
@@ -576,8 +606,15 @@ class HomeParentItemAdapterPreview(
             bookmarkHolder.isVisible = visible
             bookmarkAdapter.updateList(list)
 
-            if (binding is FragmentHomeHeadBinding) {
-                binding.homeBookmarkParentItemTitle.setOnClickListener {
+            if (
+                binding is FragmentHomeHeadBinding ||
+                binding is FragmentHomeHeadTvBinding &&
+                binding.root.context.isEmulatorSettings()
+            ) {
+                val title = (binding as? FragmentHomeHeadBinding)?.homeBookmarkParentItemTitle
+                    ?: (binding as? FragmentHomeHeadTvBinding)?.homeBookmarkParentItemTitle
+
+                title?.setOnClickListener {
                     val items = toggleList.map { it.first }.filter { it.isChecked }
                     if (items.isEmpty()) return@setOnClickListener // we don't want to show an empty dialog
                     val textSum = items

--- a/app/src/main/res/layout/fragment_home_head_tv.xml
+++ b/app/src/main/res/layout/fragment_home_head_tv.xml
@@ -232,7 +232,9 @@
             android:layout_marginStart="@dimen/navbar_width"
             android:layout_marginEnd="0dp"
             android:padding="12dp"
-            android:text="@string/continue_watching" />
+            android:text="@string/continue_watching"
+            android:background="?android:attr/selectableItemBackground"
+            app:drawableTint="?attr/white" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/home_watch_child_recyclerview"
@@ -258,7 +260,15 @@
         android:visibility="gone"
         tools:visibility="visible">
 
+        <FrameLayout
+            android:id="@+id/home_bookmark_parent_item_title"
+
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/selectableItemBackground">
+
         <HorizontalScrollView
+            android:id="@+id/horizontal_scroll_chips"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fadingEdge="horizontal"
@@ -343,6 +353,18 @@
                     android:text="@string/type_completed" />
             </com.google.android.material.chip.ChipGroup>
         </HorizontalScrollView>
+
+        <ImageView
+            android:id="@+id/home_bookmark_parent_item_more_info"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_gravity="end"
+            android:layout_marginEnd="12dp"
+            android:contentDescription="@string/home_more_info"
+            android:src="@drawable/ic_baseline_arrow_forward_24"
+            android:visibility="gone"
+            app:drawableTint="?attr/white" />
+        </FrameLayout>
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/home_bookmarked_child_recyclerview"

--- a/app/src/main/res/layout/homepage_parent_emulator.xml
+++ b/app/src/main/res/layout/homepage_parent_emulator.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/home_child_more_info"
+        style="@style/WatchHeaderText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/navbar_width"
+        android:layout_marginEnd="0dp"
+        android:padding="12dp"
+        tools:text="@string/continue_watching"
+        app:drawableRightCompat="@drawable/ic_baseline_arrow_forward_24"
+        app:drawableTint="?attr/white"
+        android:background="?android:attr/selectableItemBackground"
+        android:contentDescription="@string/home_more_info"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/home_child_recyclerview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:descendantFocusability="afterDescendants"
+        android:nextFocusUp="@id/home_child_more_info"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/navbar_width"
+        android:paddingEnd="5dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/home_result_grid" />
+</LinearLayout>


### PR DESCRIPTION
Fixes #662 

It does some manual changes to avoid having to duplicate the entire layout for minor changes

Eventually things like this, in particular visibility might do good by using DataBinding, but for now I just did some manual layout changes (outside XML) so that we did not have to duplicate 350 lines of layout code for very few changes. We can keep the same TV layout just make some changes for proper emulator support.

**Part 1 of emulator layout improvements**