### PR TITLE
Only disable PreviewGenerator if it is really a TV

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PreviewGenerator.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PreviewGenerator.kt
@@ -9,7 +9,7 @@ import android.util.Log
 import androidx.annotation.WorkerThread
 import androidx.core.graphics.scale
 import com.lagradost.cloudstream3.mvvm.logError
-import com.lagradost.cloudstream3.ui.settings.SettingsFragment
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.isAutoTv
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.ExtractorLinkType
@@ -63,7 +63,7 @@ interface IPreviewGenerator {
     companion object {
         fun new(): IPreviewGenerator {
             /** because TV has low ram + not show we disable this for now */
-            return if (SettingsFragment.isTrueTvSettings()) {
+            return if (isAutoTv()) {
                 empty()
             } else {
                 PreviewGenerator()

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -33,6 +33,7 @@ class SettingsFragment : Fragment() {
         var beneneCount = 0
 
         private var isTv: Boolean = false
+        private var isAutoTv: Boolean = false
         private var isTrueTv: Boolean = false
 
         fun PreferenceFragmentCompat?.getPref(id: Int): Preference? {
@@ -121,7 +122,12 @@ class SettingsFragment : Fragment() {
 
         fun Context.updateTv() {
             isTrueTv = isTrueTvSettings()
+            isAutoTv = isAutoTv()
             isTv = isTvSettings()
+        }
+
+        fun isAutoTv(): Boolean {
+            return isAutoTv
         }
 
         fun isTrueTvSettings(): Boolean {


### PR DESCRIPTION
That way it can still be used if using the TV layout manually (IE on emulator)