### PR TITLE
Bump libraries

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,14 +50,14 @@ android {
         }
     }
 
-    // https://developer.android.com/about/versions/14/behavior-changes-14#safer-dynamic-code-loading
-    compileSdk = 33 // android 14 is fucked
+    compileSdk = 34
     buildToolsVersion = "34.0.0"
 
     defaultConfig {
         applicationId = "com.lagradost.cloudstream3"
         minSdk = 21
-        targetSdk = 33
+        // https://developer.android.com/about/versions/14/behavior-changes-14#safer-dynamic-code-loading
+        targetSdk = 33 // android 14 is fucked
 
         versionCode = 62
         versionName = "4.2.1"
@@ -157,18 +157,17 @@ dependencies {
     implementation("androidx.test.ext:junit-ktx:1.1.5")
     testImplementation("org.json:json:20230618")
 
-    implementation("androidx.core:core-ktx:1.10.1") // need 34 for higher
+    implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1") // need target 32 for 1.5.0
 
     // dont change this to 1.6.0 it looks ugly af
-    implementation("com.google.android.material:material:1.5.0")
+    implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
-    // need 34 for higher
-    implementation("androidx.navigation:navigation-fragment-ktx:2.6.0")
-    implementation("androidx.navigation:navigation-ui-ktx:2.6.0")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.6.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.7.4")
+    implementation("androidx.navigation:navigation-ui-ktx:2.7.4")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.6.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
@@ -180,7 +179,7 @@ dependencies {
     // DONT UPDATE, WILL CRASH ANDROID TV ????
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
 
-    implementation("androidx.preference:preference-ktx:1.2.0")
+    implementation("androidx.preference:preference-ktx:1.2.1")
 
     implementation("com.github.bumptech.glide:glide:4.13.1")
     kapt("com.github.bumptech.glide:compiler:4.13.1")

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -187,13 +187,13 @@ class SettingsFragment : Fragment() {
         }
         binding?.apply {
             listOf(
-                settingsGeneral to R.id.action_navigation_global_to_navigation_settings_general,
-                settingsPlayer to R.id.action_navigation_global_to_navigation_settings_player,
-                settingsCredits to R.id.action_navigation_global_to_navigation_settings_account,
-                settingsUi to R.id.action_navigation_global_to_navigation_settings_ui,
-                settingsProviders to R.id.action_navigation_global_to_navigation_settings_providers,
-                settingsUpdates to R.id.action_navigation_global_to_navigation_settings_updates,
-                settingsExtensions to R.id.action_navigation_global_to_navigation_settings_extensions,
+                settingsGeneral to R.id.action_navigation_settings_to_navigation_settings_general,
+                settingsPlayer to R.id.action_navigation_settings_to_navigation_settings_player,
+                settingsCredits to R.id.action_navigation_settings_to_navigation_settings_account,
+                settingsUi to R.id.action_navigation_settings_to_navigation_settings_ui,
+                settingsProviders to R.id.action_navigation_settings_to_navigation_settings_providers,
+                settingsUpdates to R.id.action_navigation_settings_to_navigation_settings_updates,
+                settingsExtensions to R.id.action_navigation_settings_to_navigation_settings_extensions,
             ).forEach { (view, navigationId) ->
                 view.apply {
                     setOnClickListener {

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -331,56 +331,57 @@
         app:exitAnim="@anim/exit_anim"
         app:popEnterAnim="@anim/enter_anim"
         app:popExitAnim="@anim/exit_anim"
-        tools:layout="@layout/main_settings" />
-    <action
-        android:id="@+id/action_navigation_global_to_navigation_settings_ui"
-        app:destination="@id/navigation_settings_ui"
-        app:enterAnim="@anim/enter_anim"
-        app:exitAnim="@anim/exit_anim"
-        app:popEnterAnim="@anim/enter_anim"
-        app:popExitAnim="@anim/exit_anim" />
-    <action
-        android:id="@+id/action_navigation_global_to_navigation_settings_providers"
-        app:destination="@id/navigation_settings_providers"
-        app:enterAnim="@anim/enter_anim"
-        app:exitAnim="@anim/exit_anim"
-        app:popEnterAnim="@anim/enter_anim"
-        app:popExitAnim="@anim/exit_anim" />
-    <action
-        android:id="@+id/action_navigation_global_to_navigation_settings_player"
-        app:destination="@id/navigation_settings_player"
-        app:enterAnim="@anim/enter_anim"
-        app:exitAnim="@anim/exit_anim"
-        app:popEnterAnim="@anim/enter_anim"
-        app:popExitAnim="@anim/exit_anim" />
-    <action
-        android:id="@+id/action_navigation_global_to_navigation_settings_updates"
-        app:destination="@id/navigation_settings_updates"
-        app:enterAnim="@anim/enter_anim"
-        app:exitAnim="@anim/exit_anim"
-        app:popEnterAnim="@anim/enter_anim"
-        app:popExitAnim="@anim/exit_anim" />
-    <action
-        android:id="@+id/action_navigation_global_to_navigation_settings_account"
-        app:destination="@id/navigation_settings_account"
-        app:enterAnim="@anim/enter_anim"
-        app:exitAnim="@anim/exit_anim"
-        app:popEnterAnim="@anim/enter_anim"
-        app:popExitAnim="@anim/exit_anim" />
-    <action
-        android:id="@+id/action_navigation_global_to_navigation_settings_general"
-        app:destination="@id/navigation_settings_general"
-        app:enterAnim="@anim/enter_anim"
-        app:exitAnim="@anim/exit_anim"
-        app:popEnterAnim="@anim/enter_anim"
-        app:popExitAnim="@anim/exit_anim" />
-    <action
-        android:id="@+id/action_navigation_global_to_navigation_settings_extensions"
-        app:destination="@id/navigation_settings_extensions"
-        app:enterAnim="@anim/enter_anim"
-        app:exitAnim="@anim/exit_anim"
-        app:popEnterAnim="@anim/enter_anim"
-        app:popExitAnim="@anim/exit_anim" />
+        tools:layout="@layout/main_settings">
+        <action
+            android:id="@+id/action_navigation_settings_to_navigation_settings_ui"
+            app:destination="@id/navigation_settings_ui"
+            app:enterAnim="@anim/enter_anim"
+            app:exitAnim="@anim/exit_anim"
+            app:popEnterAnim="@anim/enter_anim"
+            app:popExitAnim="@anim/exit_anim" />
+        <action
+            android:id="@+id/action_navigation_settings_to_navigation_settings_providers"
+            app:destination="@id/navigation_settings_providers"
+            app:enterAnim="@anim/enter_anim"
+            app:exitAnim="@anim/exit_anim"
+            app:popEnterAnim="@anim/enter_anim"
+            app:popExitAnim="@anim/exit_anim" />
+        <action
+            android:id="@+id/action_navigation_settings_to_navigation_settings_player"
+            app:destination="@id/navigation_settings_player"
+            app:enterAnim="@anim/enter_anim"
+            app:exitAnim="@anim/exit_anim"
+            app:popEnterAnim="@anim/enter_anim"
+            app:popExitAnim="@anim/exit_anim" />
+        <action
+            android:id="@+id/action_navigation_settings_to_navigation_settings_updates"
+            app:destination="@id/navigation_settings_updates"
+            app:enterAnim="@anim/enter_anim"
+            app:exitAnim="@anim/exit_anim"
+            app:popEnterAnim="@anim/enter_anim"
+            app:popExitAnim="@anim/exit_anim" />
+        <action
+            android:id="@+id/action_navigation_settings_to_navigation_settings_account"
+            app:destination="@id/navigation_settings_account"
+            app:enterAnim="@anim/enter_anim"
+            app:exitAnim="@anim/exit_anim"
+            app:popEnterAnim="@anim/enter_anim"
+            app:popExitAnim="@anim/exit_anim" />
+        <action
+            android:id="@+id/action_navigation_settings_to_navigation_settings_general"
+            app:destination="@id/navigation_settings_general"
+            app:enterAnim="@anim/enter_anim"
+            app:exitAnim="@anim/exit_anim"
+            app:popEnterAnim="@anim/enter_anim"
+            app:popExitAnim="@anim/exit_anim" />
+        <action
+            android:id="@+id/action_navigation_settings_to_navigation_settings_extensions"
+            app:destination="@id/navigation_settings_extensions"
+            app:enterAnim="@anim/enter_anim"
+            app:exitAnim="@anim/exit_anim"
+            app:popEnterAnim="@anim/enter_anim"
+            app:popExitAnim="@anim/exit_anim" />
+    </fragment>
 
     <fragment
         android:id="@+id/navigation_subtitles"


### PR DESCRIPTION
Unless we change targetSdk this doesn't enable runtime changes for android 14, only changes for compiling, never affecting actual runtime. However I can not be certain a specific library will not cause some issues, bumping compileSdk itself should not cause runtime issues as compilesdk is not used on runtime. This only really affects compiling and the primary reason for this is fixinf navigation issues:

* Double  backpress causing navigation graph to be lost
* Sometimes on TV clicking next episode or it automicilly going to next episode at the very end results in it creating a dual audio, the first one which can not be closed, without force stoping the app, as far as I can tell this happens fairly often before, but appears to not (or not as often/ I didn't properly reproduce this time). It seems the issue had something to do withglobal_to_navigation_playeI could be wrong), which this seemingly fixes.

This also reverts #688 since that had no effect, and personally that doesn't seem something to be global navigation, if you want me to undo reverting that I can.

If I am totally wrong in opening this, I apologize, please close it. Thanks!