### PR TITLE
Fix some strings

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
@@ -62,7 +62,7 @@ const val LIBRARY_FOLDER = "library_folder"
 
 
 enum class LibraryOpenerType(@StringRes val stringRes: Int) {
-    Default(R.string.default_subtitles), // TODO FIX AFTER MERGE
+    Default(R.string.action_default),
     Provider(R.string.none),
     Browser(R.string.browser),
     Search(R.string.search),

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -74,12 +74,10 @@
     <string name="popup_resume_download">ማውረድ ቀጥል</string>
     <string name="subs_text_color">የጽሑፍ ቀለም</string>
     <string name="type_completed">የተጠናቀቀ</string>
-    <string name="type_none">ምንም</string>
     <string name="play_trailer_button">የፊልም ማስታወቂያ አጫውት</string>
     <string name="play_livestream_button">የቀጥታ ስርጭት አጫውት</string>
     <string name="popup_play_file">ፋይል አጫውት</string>
     <string name="type_re_watching">እንደገና በማየት ላይ</string>
-    <string name="sort_cancel">ሰርዝ</string>
     <string name="go_back">ወደ ኋላ መመለሻ</string>
     <string name="home_info">መረጃ</string>
     <string name="sort_save">ያስቀምጡ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -36,7 +36,6 @@
     <string name="type_completed">مكتمل</string>
     <string name="type_dropped">مهمل</string>
     <string name="type_plan_to_watch">أخطط لمشاهدته</string>
-    <string name="type_none">لا شيء</string>
     <string name="type_re_watching">إعادة المشاهدة</string>
     <string name="play_movie_button">مشاهدة الفيلم</string>
     <string name="play_livestream_button">تشغيل بث حي</string>
@@ -74,7 +73,6 @@
     <string name="action_remove_from_bookmarks">ازالة</string>
     <string name="action_add_to_bookmarks">إعداد حالة المشاهدة</string>
     <string name="sort_apply">تطبيق</string>
-    <string name="sort_cancel">إلغاء</string>
     <string name="sort_copy">نسخ</string>
     <string name="sort_close">إغلاق</string>
     <string name="sort_clear">مسح</string>
@@ -180,6 +178,7 @@
     <string name="no_episodes_found">لم يتم العثور على أي حلقات</string>
     <string name="delete_file">حذف الملف</string>
     <string name="delete">حذف</string>
+    <string name="cancel">إلغاء</string>
     <string name="pause">إيقاف مؤقت</string>
     <string name="resume">إستئناف</string>
     <string name="go_back_30">-٣٠</string>
@@ -198,7 +197,7 @@
     <string name="synopsis">القصة</string>
     <string name="queued">في قائمة الانتظار</string>
     <string name="no_subtitles">الترجمة ليست موجودة</string>
-    <string name="default_subtitles">الإفتراضي</string>
+    <string name="action_default">الإفتراضي</string>
     <string name="free_storage">فارغ</string>
     <string name="used_storage">مستخدم</string>
     <string name="app_storage">التطبيق</string>
@@ -581,7 +580,6 @@
     <string name="unable_to_inflate">تعذر إنشاء واجهة المستخدم بشكل صحيح ، وهذا خطأ كبير ويجب الإبلاغ عنه على الفور %s</string>
     <string name="automatic_plugin_download_mode_title">حدد الوضع لتصفية تنزيل المكونات الإضافية</string>
     <string name="disable">تعطيل</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="no_plugins_found_error">لا توجد اضافة في المستودع</string>
     <string name="no_repository_found_error">المستودع لم يتم العثور عليه، تحقق من العنوان اوجرب شبكة افتراضية خاصة(vpn)</string>
     <string name="already_voted">لقد صوتت بالفعل</string>

--- a/app/src/main/res/values-ars/strings.xml
+++ b/app/src/main/res/values-ars/strings.xml
@@ -34,7 +34,6 @@
     <string name="result_tags">الأنواع</string>
     <string name="download_paused">توقف التنزيل</string>
     <string name="type_plan_to_watch">خطط للمشاهدة</string>
-    <string name="type_none">لا يوجد</string>
     <string name="type_re_watching">إعادة المشاهدة</string>
     <string name="new_update_format" formatted="true">!تم العثور على تحديث جديد
 \n%s-&gt;%s</string>
@@ -125,6 +124,7 @@
     <string name="season">موسم</string>
     <string name="copy_link_toast">تم نسخ الرابط إلى الحافظة</string>
     <string name="delete">مسح</string>
+    <string name="cancel">الغي</string>
     <string name="pause">وقف</string>
     <string name="update_notification_downloading">جارٍ تنزيل تحديث التطبيق…</string>
     <string name="subs_default_reset_toast">إعادة التعيين إلى القيمة العادية</string>
@@ -208,7 +208,6 @@
     <string name="popup_resume_download">استئناف تحميل</string>
     <string name="home_info">معلومات</string>
     <string name="popup_pause_download">وقفة التحميل</string>
-    <string name="sort_cancel">الغي</string>
     <string name="sort_save">احفظ</string>
     <string name="subtitles_settings">إعدادات الترجمة</string>
     <string name="subs_text_color">لون الخط</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -41,7 +41,6 @@
     <string name="type_completed">Завършено</string>
     <string name="type_dropped">Изпуснат</string>
     <string name="type_plan_to_watch">План за гледане</string>
-    <string name="type_none">Нито един</string>
     <string name="type_re_watching">Повторно гледане</string>
     <string name="play_movie_button">Пускане на филм</string>
     <string name="play_livestream_button">Възпроизвеждане на живо</string>
@@ -78,7 +77,6 @@
     <string name="action_remove_from_bookmarks">Премахване</string>
     <string name="action_add_to_bookmarks">Задайте статус на гледане</string>
     <string name="sort_apply">Приложи</string>
-    <string name="sort_cancel">Отказ</string>
     <string name="sort_copy">Копирай</string>
     <string name="sort_close">Затвори</string>
     <string name="sort_clear">Изчисти</string>
@@ -187,6 +185,7 @@
     <string name="no_episodes_found">Няма намерени епизоди</string>
     <string name="delete_file">Изтрий файла</string>
     <string name="delete">Изтрий</string>
+    <string name="cancel">Отказ</string>
     <string name="pause">Пауза</string>
     <string name="resume">Продължи</string>
     <string name="go_back_30">-30</string>
@@ -205,7 +204,7 @@
     <string name="synopsis">Синопсис</string>
     <string name="queued">На опашката</string>
     <string name="no_subtitles">Без субтитри</string>
-    <string name="default_subtitles">По подразбиране</string>
+    <string name="action_default">По подразбиране</string>
     <string name="free_storage">Безплатно</string>
     <string name="used_storage">Използвано</string>
     <string name="app_storage">Приложения</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -43,7 +43,6 @@
     <string name="type_completed">শেষ</string>
     <string name="type_dropped">বাদ</string>
     <string name="type_plan_to_watch">দেখার ইচ্ছায়</string>
-    <string name="type_none">কোন কিছুই না</string>
     <string name="type_re_watching">পুনরায় দেখা হচ্ছে</string>
     <string name="play_torrent_button">টরেন্ট স্ট্রিম করুন</string>
     <string name="pick_source">উৎসসমূহ</string>
@@ -72,7 +71,6 @@
     <string name="action_remove_from_bookmarks">বাদ দিন</string>
     <string name="action_add_to_bookmarks">বুকমার্ক করুন</string>
     <string name="sort_apply">প্রয়োগ করুন</string>
-    <string name="sort_cancel">বাদ দিন</string>
     <string name="sort_copy">কপি করুন</string>
     <string name="sort_close">বন্ধ করুন</string>
     <string name="sort_clear">মুছুন</string>

--- a/app/src/main/res/values-bp/strings.xml
+++ b/app/src/main/res/values-bp/strings.xml
@@ -44,7 +44,6 @@
     <string name="type_completed">Completado</string>
     <string name="type_dropped">Deixado</string>
     <string name="type_plan_to_watch">Planejando assistir</string>
-    <string name="type_none">Nenhum</string>
     <string name="type_re_watching">Reassistindo</string>
     <string name="play_movie_button">Assistir Filme</string>
     <string name="play_torrent_button">Transmitir Torrent</string>
@@ -81,7 +80,6 @@
     <string name="action_remove_from_bookmarks">Remover</string>
     <string name="action_add_to_bookmarks">Selecionar marcador</string>
     <string name="sort_apply">Aplicar</string>
-    <string name="sort_cancel">Cancelar</string>
     <string name="sort_copy">Copiar</string>
     <string name="sort_close">Fechar</string>
     <string name="sort_clear">Limpar</string>
@@ -185,6 +183,7 @@
     <string name="no_episodes_found">Nenhum Episódio encontrado</string>
     <string name="delete_file">Apagar Arquivo</string>
     <string name="delete">Deletar</string>
+    <string name="cancel">Cancelar</string>
     <string name="pause">Pausar</string>
     <string name="resume">Retomar</string>
     <string name="go_back_30">-30</string>
@@ -203,7 +202,7 @@
     <string name="synopsis">Sinopse</string>
     <string name="queued">Na fila</string>
     <string name="no_subtitles">Sem Legendas</string>
-    <string name="default_subtitles">Padrão</string>
+    <string name="action_default">Padrão</string>
     <string name="free_storage">Livre</string>
     <string name="used_storage">Usado</string>
     <string name="app_storage">App</string>
@@ -569,7 +568,6 @@
     <string name="wifi">Wi-Fi</string>
     <string name="player_settings_play_in_web">Lista de videos da web</string>
     <string name="unable_to_inflate">A interface de usuário não foi gerada corretamente. Isto se trata de um bug importante e deve ser reportado imediatamente %s</string>
-    <string name="default_account">Legendas padrão da conta</string>
     <string name="pref_category_ui_features">Características da interface de usuário</string>
     <string name="category_provider_test">Provedor de teste</string>
     <string name="pref_category_player_layout">Layout</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -40,7 +40,6 @@
     <string name="type_completed">Dokončeno</string>
     <string name="type_dropped">Zahozeno</string>
     <string name="type_plan_to_watch">Plánuji sledovat</string>
-    <string name="type_none">Žádné</string>
     <string name="type_re_watching">Opětovné sledování</string>
     <string name="play_movie_button">Přehrát film</string>
     <string name="play_torrent_button">Streamovat torrent</string>
@@ -76,7 +75,6 @@
     <string name="action_remove_from_bookmarks">Odebrat</string>
     <string name="action_add_to_bookmarks">Nastavit stav sledování</string>
     <string name="sort_apply">Použít</string>
-    <string name="sort_cancel">Zrušit</string>
     <string name="sort_copy">Kopírovat</string>
     <string name="sort_close">Zavřít</string>
     <string name="sort_clear">Vymazat</string>
@@ -176,6 +174,7 @@
     <string name="no_episodes_found">Nenalezeny žádné epizody</string>
     <string name="delete_file">Smazat soubor</string>
     <string name="delete">Smazat</string>
+    <string name="cancel">Zrušit</string>
     <string name="pause">Pozastavit</string>
     <string name="resume">Pokračovat</string>
     <string name="go_back_30">-30</string>
@@ -194,7 +193,7 @@
     <string name="synopsis">Synopse</string>
     <string name="queued">ve frontě</string>
     <string name="no_subtitles">Žádné titulky</string>
-    <string name="default_subtitles">Výchozí</string>
+    <string name="action_default">Výchozí</string>
     <string name="free_storage">Volné</string>
     <string name="used_storage">Použito</string>
     <string name="app_storage">Aplikace</string>
@@ -575,6 +574,5 @@
     <string name="automatic_plugin_download_mode_title">Výběr režimu pro filtrování stahování doplňků</string>
     <string name="no_plugins_found_error">V repozitáři nebyly nalezeny žádné doplňky</string>
     <string name="no_repository_found_error">Repozitář nenalezen, zkontrolujte adresu URL a zkuste použít VPN</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="already_voted">Již jste hlasovali</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -52,7 +52,6 @@
     <string name="type_completed">Abgeschlossen</string>
     <string name="type_dropped">Abgebrochen</string>
     <string name="type_plan_to_watch">Geplant</string>
-    <string name="type_none">Nichts</string>
     <string name="type_re_watching">Erneut schauen</string>
     <string name="play_movie_button">Film abspielen</string>
     <string name="play_livestream_button">Livestream abspielen</string>
@@ -89,7 +88,6 @@
     <string name="action_remove_from_bookmarks">Entfernen</string>
     <string name="action_add_to_bookmarks">Status setzen</string>
     <string name="sort_apply">Anwenden</string>
-    <string name="sort_cancel">Abbrechen</string>
     <string name="sort_copy">Kopieren</string>
     <string name="sort_close">Schließen</string>
     <string name="sort_clear">Leeren</string>
@@ -192,6 +190,7 @@
     <string name="episode_short">E</string>
     <string name="no_episodes_found">Keine Episoden gefunden</string>
     <string name="delete">Löschen</string>
+    <string name="cancel">Abbrechen</string>
     <string name="pause">Pause</string>
     <string name="resume">Fortsetzen</string>
     <string name="go_back_30">-30</string>
@@ -210,7 +209,7 @@
     <string name="synopsis">Zusammenfassung</string>
     <string name="queued">In Warteschlange eingereiht</string>
     <string name="no_subtitles">Keine Untertitel</string>
-    <string name="default_subtitles">Standard</string>
+    <string name="action_default">Standard</string>
     <string name="free_storage">Frei</string>
     <string name="used_storage">Belegt</string>
     <string name="app_storage">App</string>
@@ -552,5 +551,4 @@
     <string name="no_repository_found_error">Repository nicht gefunden, überprüf die URL und versuch ein VPN</string>
     <string name="unable_to_inflate">Die Benutzeroberfläche konnte nicht korrekt erstellt werden. Dies ist ein SCHWERWIEGENDER FEHLER und sollte sofort gemeldet werden. %s</string>
     <string name="disable">Deaktivieren</string>
-    <string name="default_account">@string/default_subtitles</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -23,7 +23,6 @@
     <string name="type_completed">Ολοκληρώθηκε</string>
     <string name="type_dropped">Διακόπηκε</string>
     <string name="type_plan_to_watch">Για παρακολούθηση</string>
-    <string name="type_none">Τίποτα</string>
     <string name="play_movie_button">Αναπαραγωγή ταινίας</string>
     <string name="play_torrent_button">Μετάδοση Torrent</string>
     <string name="pick_source">Πηγές</string>
@@ -58,7 +57,6 @@
     <string name="action_remove_from_bookmarks">Αφαίρεση</string>
     <string name="play_episode_toast">Αναπαραγωγή επεισοδίου</string>
     <string name="sort_apply">Υποβολή</string>
-    <string name="sort_cancel">Ακύρωση</string>
     <string name="player_speed">Ταχύτητα αναπαραγωγής</string>
     <string name="subtitles_settings">Ρυθμίσεις υπότιτλων</string>
     <string name="subs_text_color">Χρώμα κειμένου</string>
@@ -155,6 +153,7 @@
     <string name="no_episodes_found">Δεν βρέθηκαν επεισόδια</string>
     <string name="delete_file">Διαγραφή αρχείου</string>
     <string name="delete">Διαγραφή</string>
+    <string name="cancel">Ακύρωση</string>
     <string name="pause">Παύση</string>
     <string name="resume">Συνέχιση</string>
     <string name="delete_message" formatted="true">Αυτό θα διαγράψει μόνιμα το %s
@@ -169,7 +168,7 @@
     <string name="synopsis">Περίληψη</string>
     <string name="queued">προστέθηκε στην ουρά</string>
     <string name="no_subtitles">Δεν υπάρχουν διαθέσιμοι υπότιτλοι</string>
-    <string name="default_subtitles">Προεπιλεγμένοι υπότιτλοι</string>
+    <string name="action_default">Προεπιλεγμένοι υπότιτλοι</string>
     <string name="free_storage">Ελεύθερος</string>
     <string name="used_storage">Σε χρήση</string>
     <string name="app_storage">Εφαρμογή</string>
@@ -547,6 +546,5 @@
     <string name="unable_to_inflate">Το UI δεν ήταν σε θέση να δημιουργηθεί σωστά, είναι ένα σφάλμα και θα πρέπει να αναφερθεί αμέσως %s</string>
     <string name="automatic_plugin_download_mode_title">Επιλέξτε κατάσταση για φιλτράρισμα επεκτάσεων για λήψη</string>
     <string name="disable">Απενεργοποιημένο</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="stop">Τέλος</string>
 </resources>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -22,7 +22,6 @@
     <string name="extension_description">Priskribo</string>
     <string name="extension_version">Versio</string>
     <string name="extension_status">Stato</string>
-    <string name="sort_cancel">Nuligi</string>
     <string name="sort_clear">Forviŝi</string>
     <string name="yes">Jes</string>
     <string name="no">Ne</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -45,7 +45,7 @@
     <string name="player_load_subtitles_online">Cargar desde Internet</string>
     <string name="autoplay_next_settings">Reproducir automáticamente episodio siguiente</string>
     <string name="chromecast_subtitles_settings_des">Configuración de subtítulos de Chromecast</string>
-    <string name="default_subtitles">Predeterminado</string>
+    <string name="action_default">Predeterminado</string>
     <string name="subtitles_outline">Contorno</string>
     <string name="no_subtitles">Sin Subtítulos</string>
     <string name="subtitles_raised">Elevado</string>
@@ -138,7 +138,6 @@
     <string name="type_completed">Completado</string>
     <string name="type_dropped">Descartado</string>
     <string name="type_plan_to_watch">Planeando ver</string>
-    <string name="type_none">Ninguno</string>
     <string name="type_re_watching">Volviendo a mirar</string>
     <string name="play_movie_button">Reproducir película</string>
     <string name="play_trailer_button">Reproducir Trailer</string>
@@ -167,7 +166,6 @@
     <string name="error_bookmarks_text">Marcadores</string>
     <string name="action_remove_from_bookmarks">Remover</string>
     <string name="action_add_to_bookmarks">Seleccionar estado de visualización</string>
-    <string name="sort_cancel">Cancelar</string>
     <string name="sort_copy">Copiar</string>
     <string name="sort_close">Cerrar</string>
     <string name="sort_clear">Limpiar</string>
@@ -256,6 +254,7 @@
     <string name="season_short">T</string>
     <string name="delete_file">Borrar Archivo</string>
     <string name="delete">Borrar</string>
+    <string name="cancel">Cancelar</string>
     <string name="unexpected_error">Error inesperado del reproductor</string>
     <string name="episode_action_chromecast_episode">Episodio en Chromecast</string>
     <string name="episode_action_play_in_app">Reproducir en la aplicación</string>
@@ -549,7 +548,6 @@
     <string name="unable_to_inflate">La interfaz de usuario no se ha podido crear correctamente, se trata de un GRAN BUG y debe ser reportado inmediatamente %s</string>
     <string name="automatic_plugin_download_mode_title">Seleccionar modo para filtrar los plugins descargados</string>
     <string name="disable">Deshabilitar</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="no_plugins_found_error">No se encontraron complementos en el repositorio</string>
     <string name="no_repository_found_error">Repositorio no encontrado, comprueba la URL y prueba la VPN</string>
     <string name="already_voted">Ya has votado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -22,7 +22,6 @@
     <string name="type_completed">Terminé</string>
     <string name="type_dropped">Abandonné</string>
     <string name="type_plan_to_watch">À regarder</string>
-    <string name="type_none">Aucun</string>
     <string name="play_movie_button">Lire</string>
     <string name="play_torrent_button">Streamer le Torrent</string>
     <string name="pick_source">Sources</string>
@@ -60,7 +59,6 @@
     <string name="error_bookmarks_text">Marque-pages</string>
     <string name="action_remove_from_bookmarks">Supprimer</string>
     <string name="sort_apply">Appliquer</string>
-    <string name="sort_cancel">Annuler</string>
     <string name="player_speed">Vitesse de lecture</string>
     <string name="preview_background_img_des">Aperçu de l\'arrière-plan</string>
     <string name="benene">Donner une benene aux devs</string>
@@ -80,6 +78,7 @@
     <string name="episode_short">E</string>
     <string name="delete_file">Supprimer le Fichier</string>
     <string name="delete">Supprimer</string>
+    <string name="cancel">Annuler</string>
     <string name="pause">Pause</string>
     <string name="resume">Reprendre</string>
     <string name="delete_message">Cela va supprimer définitivement %s
@@ -94,7 +93,7 @@
     <string name="synopsis">Synopsis</string>
     <string name="queued">Liste d\'attente</string>
     <string name="no_subtitles">Pas de sous-titres</string>
-    <string name="default_subtitles">Défault</string>
+    <string name="action_default">Défault</string>
     <string name="free_storage">Libre</string>
     <string name="used_storage">Utilisé</string>
     <string name="app_storage">Application</string>
@@ -553,5 +552,4 @@
     <string name="unable_to_inflate">L\'interface utilisateur n\'a pas pu être créée correctement. Il s\'agit d\'un bogue majeur qui doit être signalé immédiatement %s</string>
     <string name="automatic_plugin_download_mode_title">Sélectionnez le mode pour filtrer le téléchargement des plugins</string>
     <string name="profile_background_des">Fond de profil</string>
-    <string name="default_account">@string/default_subtitles</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -29,13 +29,11 @@
     <string name="type_completed">Completado</string>
     <string name="type_dropped">Descartado</string>
     <string name="type_plan_to_watch">Planeando ver</string>
-    <string name="type_none">Ningún</string>
     <string name="type_re_watching">Remirando</string>
     <string name="error_bookmarks_text">Marcadores</string>
     <string name="action_remove_from_bookmarks">Borrar</string>
     <string name="action_add_to_bookmarks">Seleccionar estado de visualización</string>
     <string name="sort_apply">Aplicar</string>
-    <string name="sort_cancel">Cancelar</string>
     <string name="sort_copy">Copiar</string>
     <string name="sort_close">Cerrar</string>
     <string name="sort_clear">Limpar</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -49,7 +49,6 @@
     <string name="error_bookmarks_text">बुकमार्क्स</string>
     <string name="action_remove_from_bookmarks">हटाएँ</string>
     <string name="sort_apply">लागू करें</string>
-    <string name="sort_cancel">रद्द करें</string>
     <string name="player_speed">प्लेयर स्पीड</string>
     <string name="search_provider_text_providers">प्रोवाइडरों का उपयोग कर खोजें</string>
     <string name="search_provider_text_types">प्रकार का उपयोग करके खोजें</string>
@@ -91,6 +90,7 @@
     <string name="acra_report_toast">क्षमा करें, एप्प क्रैश हो गया है । निर्माताओं को एक अनाम बग रिपोर्ट भेजी जाएगी</string>
     <string name="delete_file">फ़ाइल डिलीट करें</string>
     <string name="delete">डिलीट</string>
+    <string name="cancel">रद्द करें</string>
     <string name="pause">रोकें</string>
     <string name="resume">फिर से चलाएं</string>
     <string name="delete_message">इससे %s स्थायी रूप से हट जाएगा

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -54,7 +54,6 @@
     <string name="type_completed">Dovršeno</string>
     <string name="type_dropped">Ispušteno</string>
     <string name="type_plan_to_watch">Planiram pogledati</string>
-    <string name="type_none">Ništa</string>
     <string name="type_re_watching">Ponovno gledam</string>
     <string name="play_movie_button">Pokreni Film</string>
     <string name="play_livestream_button">Pokreni LiveStream</string>
@@ -92,7 +91,6 @@
     <string name="action_remove_from_bookmarks">Ukloni</string>
     <string name="action_add_to_bookmarks">Postavi status gledanja</string>
     <string name="sort_apply">Primijeni</string>
-    <string name="sort_cancel">Poništi</string>
     <string name="sort_copy">Kopiraj</string>
     <string name="sort_close">Zatvori</string>
     <string name="sort_clear">Očisti</string>
@@ -200,6 +198,7 @@
     <string name="no_episodes_found">Nisu pronađene epizode</string>
     <string name="delete_file">Izbriši datoteku</string>
     <string name="delete">Izbriši</string>
+    <string name="cancel">Poništi</string>
     <string name="pause">Pauziraj</string>
     <string name="resume">Nastavi</string>
     <string name="go_back_30">-30</string>
@@ -218,7 +217,7 @@
     <string name="synopsis">Sinopsis</string>
     <string name="queued">u redu čekanja</string>
     <string name="no_subtitles">Bez titlova</string>
-    <string name="default_subtitles">Zadano</string>
+    <string name="action_default">Zadano</string>
     <string name="free_storage">Slobodno</string>
     <string name="used_storage">Iskorišteno</string>
     <string name="app_storage">Aplikacija</string>
@@ -567,7 +566,6 @@
     <string name="unable_to_inflate">Nije bilo moguće ispravno izraditi korisničko sučelje. Ovo je ZNAČAJNA GREŠKA i treba se odmah prijaviti %s</string>
     <string name="automatic_plugin_download_mode_title">Odaberi modus za filtriranje preuzimanja dodataka</string>
     <string name="disable">Onemogući</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="no_plugins_found_error">U repozitoriju nisu pronađeni dodaci</string>
     <string name="no_repository_found_error">Repozitorij nije pronađen, provjerite URL i pokušajte koristiti VPN</string>
     <string name="quality_profile_help">Ovdje možete promijeniti način na koji su izvori poredani. Ako video ima viši prioritet, pojavit će se više u odabiru izvora. Zbroj prioriteta izvora i prioriteta kvalitete je video prioritet.

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -20,6 +20,7 @@
     <string name="download">Letöltés</string>
     <string name="search">Keresés</string>
     <string name="delete">Törlés</string>
+    <string name="cancel">Mégse</string>
     <string name="pause">Szüneteltetés</string>
     <string name="queued">sorba állítva</string>
     <string name="resize_fit">Igazítás</string>
@@ -61,7 +62,6 @@
     <string name="type_watching">Nézés</string>
     <string name="type_completed">Befejezve</string>
     <string name="type_plan_to_watch">Később megnézés</string>
-    <string name="type_none">Nincs</string>
     <string name="type_re_watching">Újranézés</string>
     <string name="play_movie_button">Film lejátszása</string>
     <string name="play_trailer_button">Előzetes lejátszása</string>
@@ -90,7 +90,6 @@
     <string name="action_remove_from_bookmarks">Eltávolítás</string>
     <string name="action_add_to_bookmarks">Megtekintés állapotának beállítása</string>
     <string name="sort_apply">Alkalmazás</string>
-    <string name="sort_cancel">Mégse</string>
     <string name="sort_copy">Másolás</string>
     <string name="sort_close">Bezárás</string>
     <string name="sort_clear">Törlés</string>
@@ -162,7 +161,7 @@
     <string name="rating">Értékelés</string>
     <string name="cartoons">Rajzfilmek</string>
     <string name="livestreams">Élőadások</string>
-    <string name="default_subtitles">Alapértelmezett</string>
+    <string name="action_default">Alapértelmezett</string>
     <string name="movies">Filmek</string>
     <string name="tv_series">TV sorozat</string>
     <string name="anime">Anime</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -39,7 +39,6 @@
     <string name="type_completed">Selesai</string>
     <string name="type_dropped">Dihentikan</string>
     <string name="type_plan_to_watch">Rencana untuk Menonton</string>
-    <string name="type_none">Tidak Ada</string>
     <string name="type_re_watching">Menonton Ulang</string>
     <string name="play_movie_button">Putar Movie</string>
     <string name="play_torrent_button">Streaming Torrent</string>
@@ -75,7 +74,6 @@
     <string name="action_remove_from_bookmarks">Hapus</string>
     <string name="action_add_to_bookmarks">Atur status tontonan</string>
     <string name="sort_apply">Terapkan</string>
-    <string name="sort_cancel">Batalkan</string>
     <string name="sort_copy">Salin</string>
     <string name="sort_close">Tutup</string>
     <string name="sort_clear">Bersihkan</string>
@@ -174,6 +172,7 @@
     <string name="no_episodes_found">Episode Tidak Ditemukan</string>
     <string name="delete_file">Hapus File</string>
     <string name="delete">Hapus</string>
+    <string name="cancel">Batalkan</string>
     <string name="pause">Jeda</string>
     <string name="resume">Lanjutkan</string>
     <string name="go_back_30">-30</string>
@@ -192,7 +191,7 @@
     <string name="synopsis">Sinopsis</string>
     <string name="queued">antri</string>
     <string name="no_subtitles">Tidak Ada Subtitle</string>
-    <string name="default_subtitles">Default</string>
+    <string name="action_default">Default</string>
     <string name="free_storage">Tersedia</string>
     <string name="used_storage">Terpakai</string>
     <string name="app_storage">Aplikasi</string>
@@ -575,5 +574,4 @@
     <string name="no_plugins_found_error">Tidak ada plugin yang ditemukan di repositori</string>
     <string name="no_repository_found_error">Repositori tidak ditemukan, periksa URL dan coba VPN</string>
     <string name="already_voted">Kamu sudah voting</string>
-    <string name="default_account">@string/default_subtitles</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -44,7 +44,6 @@
     <string name="type_completed">Completato</string>
     <string name="type_dropped">Abbandonato</string>
     <string name="type_plan_to_watch">Da guardare</string>
-    <string name="type_none">Nessuno</string>
     <string name="type_re_watching">Riguardando</string>
     <string name="play_movie_button">Riproduci film</string>
     <string name="play_livestream_button">Riproduci Livestream</string>
@@ -81,7 +80,6 @@
     <string name="action_remove_from_bookmarks">Rimuovi</string>
     <string name="action_add_to_bookmarks">Imposta stato riproduzione</string>
     <string name="sort_apply">Applica</string>
-    <string name="sort_cancel">Cancella</string>
     <string name="sort_copy">Copia</string>
     <string name="sort_close">Chiudi</string>
     <string name="sort_clear">Cancella</string>
@@ -190,6 +188,7 @@
     <string name="no_episodes_found">Nessun episodio trovato</string>
     <string name="delete_file">Elimina file</string>
     <string name="delete">Elimina</string>
+    <string name="cancel">Cancella</string>
     <string name="pause">Pausa</string>
     <string name="resume">Riprendi</string>
     <string name="go_back_30">-30</string>
@@ -208,7 +207,7 @@
     <string name="synopsis">Sinossi</string>
     <string name="queued">In coda</string>
     <string name="no_subtitles">Nessun sottotiolo</string>
-    <string name="default_subtitles">Default</string>
+    <string name="action_default">Default</string>
     <string name="free_storage">Libero</string>
     <string name="used_storage">Usato</string>
     <string name="app_storage">App</string>
@@ -572,7 +571,6 @@
     <string name="no_repository_found_error">Repository non trovato, controlla l\'URL e prova la VPN</string>
     <string name="unable_to_inflate">Non è stato possibile creare correttamente l\'interfaccia utente, questo è un GRANDE BUG e dovrebbe essere segnalato immediatamente %s</string>
     <string name="automatic_plugin_download_mode_title">Seleziona la modalità per filtrare il download dei plugin</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="disable">Disabilita</string>
     <string name="already_voted">Hai già votato</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -66,7 +66,6 @@
     <string name="action_remove_from_bookmarks">הסר</string>
     <string name="action_add_to_bookmarks">הגדר מצב צפייה</string>
     <string name="sort_apply">ליישם</string>
-    <string name="sort_cancel">בטל</string>
     <string name="sort_copy">העתק</string>
     <string name="sort_close">לסגור</string>
     <string name="sort_clear">נקה</string>
@@ -78,7 +77,6 @@
     <string name="type_watching">צופה</string>
     <string name="pick_subtitle">כתוביות</string>
     <string name="type_on_hold">בהמתנה</string>
-    <string name="type_none">ללא</string>
     <string name="download">להוריד</string>
     <string name="app_dubbed_text">מדובב</string>
     <string name="home_more_info">יותר מידע</string>
@@ -146,6 +144,7 @@
     <string name="no_episodes_found">לא נמצאו פרקים</string>
     <string name="delete_file">מחק קובץ</string>
     <string name="delete">מחק</string>
+    <string name="cancel">בטל</string>
     <string name="pause">השהה</string>
     <string name="resume">המשך</string>
     <string name="go_back_30">-30</string>
@@ -159,7 +158,7 @@
     <string name="rating">דירוג</string>
     <string name="year">שנה</string>
     <string name="no_subtitles">ללא כתוביות</string>
-    <string name="default_subtitles">ברירת מחדל</string>
+    <string name="action_default">ברירת מחדל</string>
     <string name="free_storage">חינם</string>
     <string name="used_storage">משומש</string>
     <string name="tv_series">סדרת טלוויזיה</string>
@@ -519,7 +518,6 @@
     <string name="edit">עריכה</string>
     <string name="wifi">Wi-Fi</string>
     <string name="profile_background_des">רקע הפרופיל</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="test_log">רשומה</string>
     <string name="help">עזרה</string>
     <string name="start">התחלה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -37,7 +37,6 @@
     <string name="asian_drama_singular">アジアドラマ</string>
     <string name="live_singular">ライブ配信</string>
     <string name="nsfw_singular">NSFW</string>
-    <string name="sort_cancel">キャンセル</string>
     <string name="anime">アニメ</string>
     <string name="video_lock">ロック</string>
     <string name="video_source">ソース</string>
@@ -71,7 +70,6 @@
     <string name="home_source">ソース</string>
     <string name="history">履歴</string>
     <string name="result_poster_img_des">ポスター</string>
-    <string name="type_none">なし</string>
     <string name="sort_copy">コピー</string>
     <string name="sort_close">閉じる</string>
     <string name="sort_save">保存</string>
@@ -135,6 +133,7 @@
     <string name="pause">一時停止</string>
     <string name="play_episode_toast">再生エピソード</string>
     <string name="delete">削除</string>
+    <string name="cancel">キャンセル</string>
     <string name="start">開始</string>
     <string name="status">状態</string>
     <string name="year">年</string>
@@ -155,7 +154,7 @@
     <string name="extension_version">バージョン</string>
     <string name="extension_rating" formatted="true">視聴率 %s</string>
     <string name="rating">視聴率</string>
-    <string name="default_subtitles">デフォルト</string>
+    <string name="action_default">デフォルト</string>
     <string name="download_failed">ダウンロード失敗</string>
     <string name="download_started">ダウンロード開始</string>
     <string name="download_done">ダウンロード完了</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -32,7 +32,6 @@
     <string name="home_info">ಮಾಹಿತಿ</string>
     <string name="action_add_to_bookmarks">ಸೆಟ್ ವಾಚ್ ಸ್ಟೇಟಸ್</string>
     <string name="sort_apply">ಅನ್ವಯಿಸು</string>
-    <string name="sort_cancel">ರದ್ದುಮಾಡು</string>
     <string name="subs_subtitle_elevation">ಸಬ್ ಟೈಟಲ್ಸ್ ಎಲೆವಷನ್</string>
     <string name="subs_font_size">ಫಾಂಟ್ ಸೈಜ್</string>
     <string name="subs_subtitle_languages">ಸಬ್ ಟೈಟಲ್ಸ್ ಭಾಷೆ</string>
@@ -108,7 +107,6 @@
     <string name="result_tags">ಪ್ರಕಾರಗಳು</string>
     <string name="result_open_in_browser">ಬ್ರೌಸರ್ ತೆರೆಯಿರಿ</string>
     <string name="type_on_hold">ಆನ್-ಹೋಲ್ಡ್</string>
-    <string name="type_none">ನನ್</string>
     <string name="reload_error">ಸಂಪರ್ಕವನ್ನು ಮರುಪ್ರಯತ್ನಿಸಿ…</string>
     <string name="download_paused">ಡೌನ್‌ಲೋಡ್ ವಿರಾಮಗೊಳಿಸಲಾಗಿದೆ</string>
     <string name="download_failed">ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -35,7 +35,6 @@
     <string name="type_completed">시청 완료</string>
     <string name="type_dropped">포기</string>
     <string name="type_plan_to_watch">시청 예정</string>
-    <string name="type_none">없음</string>
     <string name="type_re_watching">다시보기</string>
     <string name="play_movie_button">영화 재생</string>
     <string name="play_trailer_button">예고편 재생</string>
@@ -95,7 +94,6 @@
     <string name="pref_category_backup">백업</string>
     <string name="app_dubbed_text">더빙</string>
     <string name="app_subbed_text">자막</string>
-    <string name="sort_cancel">취소</string>
     <string name="filter_bookmarks">북마크 필터</string>
     <string name="error_bookmarks_text">북마크</string>
     <string name="sort_clear">제거</string>
@@ -177,7 +175,7 @@
     <string name="synopsis">개요</string>
     <string name="queued">대기중</string>
     <string name="no_subtitles">자막 없음</string>
-    <string name="default_subtitles">기본</string>
+    <string name="action_default">기본</string>
     <string name="free_storage">남음</string>
     <string name="used_storage">사용됨</string>
     <string name="app_storage">앱</string>
@@ -352,6 +350,7 @@
     <string name="asian_drama_singular">아시아 드라마</string>
     <string name="season">시즌</string>
     <string name="delete">삭제</string>
+    <string name="cancel">취소</string>
     <string name="season_format">%s %d%s</string>
     <string name="delete_file">파일 삭제</string>
     <string name="pause">일시정지</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -65,6 +65,7 @@
     <string name="documentaries">Dokumentika</string>
     <string name="play_torrent_button">Transliuoti Torrentą</string>
     <string name="delete">Ištrinti</string>
+    <string name="cancel">Atšaukti</string>
     <string name="start">Pradėti</string>
     <string name="eigengraumode_settings_des">Prideda greičio pasirinkti grotuve</string>
     <string name="cartoons_singular">Filmukas</string>
@@ -95,7 +96,6 @@
     <string name="subs_text_color">Teksto spalva</string>
     <string name="type_completed">Užbaigta</string>
     <string name="use_system_brightness_settings_des">Naudoti sistemos ryškumą programos grotuve vietoj tamsumo</string>
-    <string name="type_none">Tuščia</string>
     <string name="restore_failed_format" formatted="true">Nepavyko atstatyti duomenis iš failo %s</string>
     <string name="play_trailer_button">Paleisti anonsa</string>
     <string name="play_livestream_button">Paleisti gyva transliacija</string>
@@ -107,7 +107,6 @@
     <string name="type_re_watching">Peržiūrima</string>
     <string name="result_open_in_browser">Atidaryti Naršyklėje</string>
     <string name="use_system_brightness_settings">Naudoti sistemos ryškumą</string>
-    <string name="sort_cancel">Atšaukti</string>
     <string name="no_data">Nėra duomenų</string>
     <string name="subs_font">Šriftas</string>
     <string name="redo_setup_process">Perdaryti nustatymo procesą</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -31,7 +31,6 @@
     <string name="type_completed">Pabeigts</string>
     <string name="type_dropped">Atmests</string>
     <string name="type_plan_to_watch">Plāno skatīties</string>
-    <string name="type_none">Neviena</string>
     <string name="type_re_watching">Atkārtoti skatities</string>
     <string name="play_movie_button">Palaist Filmu</string>
     <string name="play_trailer_button">Palaist Trelleri</string>
@@ -67,7 +66,6 @@
     <string name="action_remove_from_bookmarks">Noņemt</string>
     <string name="action_add_to_bookmarks">Ieliec skatīšanās statusu</string>
     <string name="sort_apply">Izmantot</string>
-    <string name="sort_cancel">Atcelt</string>
     <string name="sort_copy">Kopēt</string>
     <string name="sort_save">Saglabāt</string>
     <string name="player_speed">Atskaņošanas ātrums</string>
@@ -192,6 +190,7 @@
     <string name="no_episodes_found">Epizodes netika atrastas</string>
     <string name="delete_file">Dzēsti faili</string>
     <string name="delete">Dzēst</string>
+    <string name="cancel">Atcelt</string>
     <string name="pause">Pauzēt</string>
     <string name="start">Sākt</string>
     <string name="test_failed">Neizdevās</string>
@@ -483,7 +482,7 @@
     <string name="status_ongoing">Iet</string>
     <string name="free_storage">Bezmaksas</string>
     <string name="poster_ui_settings">Ieslēgt elementus uz plakātiem</string>
-    <string name="default_subtitles">Parastais</string>
+    <string name="action_default">Parastais</string>
     <string name="no_update_found">Nav atjauninājumi atrasti</string>
     <string name="video_buffer_clear_settings">Izdzēst video un bildes atkritne</string>
     <string name="watch_quality_pref_data">Izvēlētā skatīšanās kvalitāte (Mobilie Dati)</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -25,7 +25,6 @@
     <string name="type_completed">Завршени</string>
     <string name="type_dropped">Отфрлени</string>
     <string name="type_plan_to_watch">Планирани за гледање</string>
-    <string name="type_none">Ништо одбрано</string>
     <string name="type_re_watching">Повторно гледање</string>
     <string name="play_movie_button">Пушти филм</string>
     <string name="play_torrent_button">Стримај торент</string>
@@ -58,7 +57,6 @@
     <string name="error_bookmarks_text">Обележувачи</string>
     <string name="action_remove_from_bookmarks">Отстрани</string>
     <string name="sort_apply">Активирај</string>
-    <string name="sort_cancel">Откажи</string>
     <string name="player_speed">Брзина на плеер</string>
     <string name="subtitles_settings">Поставки за преводи</string>
     <string name="subs_text_color">Боја на текстот</string>
@@ -133,6 +131,7 @@
     <string name="episode_short">Е</string>
     <string name="delete_file">Избриши датотека</string>
     <string name="delete">Избриши</string>
+    <string name="cancel">Откажи</string>
     <string name="pause">Паузирај</string>
     <string name="resume">Продолжи</string>
     <string name="delete_message">Ова трајно ќе го избрише %s
@@ -147,7 +146,7 @@
     <string name="synopsis">Крат</string>
     <string name="queued">во редица</string>
     <string name="no_subtitles">Нема преводи</string>
-    <string name="default_subtitles">Стандардно</string>
+    <string name="action_default">Стандардно</string>
     <string name="free_storage">Слободен простор</string>
     <string name="used_storage">Искористен простор</string>
     <string name="app_storage">Апликациски простор</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -54,7 +54,6 @@
     <string name="error_bookmarks_text">ബുക്മാർക്</string>
     <string name="action_remove_from_bookmarks">നീക്കം ചെയ്യുക</string>
     <string name="sort_apply">പ്രയോഗിക്കുക</string>
-    <string name="sort_cancel">റദ്ദാക്കുക</string>
     <string name="player_speed">പ്ലേയർ വേഗത</string>
     <!-- <string name="subtitles_settings">Subtitle Settings</string>
     <string name="subs_text_color">Text Color</string>
@@ -121,6 +120,7 @@
     <string name="episodes">എപ്പിസോഡുകൾ</string>
     <string name="delete_file">ഫയൽ ഡിലീറ്റ് ചെയ്യുക</string>
     <string name="delete">ഡിലീറ്റ്</string>
+    <string name="cancel">റദ്ദാക്കുക</string>
     <string name="pause">നിർത്തുക</string>
     <string name="resume">തുടരുക</string>
     <string name="delete_message">സ്ഥിരമായി %sനെ ഡിലീറ്റ് ചെയ്യുക
@@ -135,7 +135,7 @@
     <string name="synopsis">സംഗ്രഹം</string>
     <!-- <string name="queued">queued</string>
     <string name="no_subtitles">No Subtitles</string>
-    <string name="default_subtitles">Default</string> -->
+    <string name="action_default">Default</string> -->
     <string name="free_storage">ഒഴിവ്</string>
     <string name="used_storage">ഉപയോഗത്തിൽ</string>
     <string name="app_storage">ആപ്പ്</string>
@@ -197,7 +197,6 @@
     <string name="home_change_provider_img_des">ദാതാവിനെ മാറ്റുക</string>
     <string name="loading">ലോഡിംഗ്…</string>
     <string name="browser">ബ്രൗസർ</string>
-    <string name="type_none">ഒന്നുമില്ല</string>
     <string name="type_re_watching">വീണ്ടും കാണുക</string>
     <string name="stream">സ്ട്രീം</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -49,7 +49,6 @@
     <string name="open_with">Buka dengan</string>
     <string name="popup_delete_file">Padam Fail</string>
     <string name="result_open_in_browser">Buka Dalam Pelayar</string>
-    <string name="sort_cancel">Batal</string>
     <string name="no_data">Tiada Data</string>
     <string name="home_info">Info</string>
     <string name="sort_save">Simpan</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -32,7 +32,6 @@
     <string name="type_watching">ကြည့်နေသည်</string>
     <string name="type_completed">ကြည့်ပြီး</string>
     <string name="type_dropped">ကြည့်ခြင်းရပ်ထားသော</string>
-    <string name="type_none">ဘာမျှ</string>
     <string name="error_loading_links_toast">လင့်များချိတ်ဆက်ရာတွင်အချို့အယွင်း</string>
     <string name="download_storage_text">ဖုန်း သိုလှောင်ရုံ</string>
     <string name="filter_bookmarks">စာမှတ်များ စစ်ထုတ်မှု</string>
@@ -127,8 +126,7 @@
     <string name="synopsis">အကျဥ်းချုပ်</string>
     <string name="queued">နောက်အစီအစဥ်</string>
     <string name="no_subtitles">စာတန်းထိုးမထည့်</string>
-    <string name="default_subtitles">ပုံသေ</string>
-    <string name="default_account">@string/default_subtitles</string>
+    <string name="action_default">ပုံသေ</string>
     <string name="free_storage">ကျန်ရှိသော</string>
     <string name="app_storage">အက်ပ်</string>
     <string name="movies">ရုပ်ရှင်များ</string>
@@ -253,7 +251,6 @@
     <string name="subs_subtitle_languages">စာတန်းထိုး ဘာသာစကား</string>
     <string name="subs_import_text" formatted="true">ဒီမှာနေရာချခြင်းဖြင့်ဖောင့်များကိုသွင်းပါ %s</string>
     <string name="sort_apply">အတည်ပြု</string>
-    <string name="sort_cancel">ပယ်ဖျက်ရန်</string>
     <string name="subtitles_settings">စာတန်းထိုး ပြုပြင်ခြင်း</string>
     <string name="subs_text_color">စာသား အရောင်</string>
     <string name="subs_outline_color">အနားကွပ် အရောင်</string>
@@ -301,6 +298,7 @@
     <string name="no_episodes_found">အပိုင်းများမတွေ့ပါ</string>
     <string name="delete_file">ဖိုင်ကိုဖျက်ရန်</string>
     <string name="delete">ဖျက်ရန်</string>
+    <string name="cancel">ပယ်ဖျက်ရန်</string>
     <string name="pause">ရပ်ရန်</string>
     <string name="start">စရန်</string>
     <string name="test_failed">မအောင်မြင်ပါ</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -44,7 +44,6 @@
     <string name="type_completed">Voltooid</string>
     <string name="type_dropped">Dropped</string>
     <string name="type_plan_to_watch">Plan om te kijken</string>
-    <string name="type_none">Geen</string>
     <string name="type_re_watching">Opnieuw kijken</string>
     <string name="play_movie_button">Film afspelen</string>
     <string name="play_livestream_button">Livestream afspelen</string>
@@ -82,7 +81,6 @@
     <string name="action_remove_from_bookmarks">Verwijder</string>
     <string name="action_add_to_bookmarks">Zet kijkstatus</string>
     <string name="sort_apply">Toepassen</string>
-    <string name="sort_cancel">annuleer</string>
     <string name="sort_copy">Kopiëren</string>
     <string name="sort_close">Sluit</string>
     <string name="sort_clear">Wissen</string>
@@ -186,6 +184,7 @@
     <string name="no_episodes_found">Geen afleveringen gevonden</string>
     <string name="delete_file">Verwijder bestand</string>
     <string name="delete">Verwijder</string>
+    <string name="cancel">annuleer</string>
     <string name="pause">Pauze</string>
     <string name="resume">Hervatten</string>
     <string name="go_back_30">-30</string>
@@ -204,7 +203,7 @@
     <string name="synopsis">Korte inhoud</string>
     <string name="queued">wachtrij</string>
     <string name="no_subtitles">Geen ondertiteling</string>
-    <string name="default_subtitles">Standaard</string>
+    <string name="action_default">Standaard</string>
     <string name="free_storage">Vrij</string>
     <string name="used_storage">Gebruikt</string>
     <string name="app_storage">App</string>
@@ -573,6 +572,5 @@
     <string name="automatic_plugin_download_mode_title">Selecteer een modus om het downloaden van plug-ins te filteren</string>
     <string name="disable">Uitzetten</string>
     <string name="unable_to_inflate">De gebruikersinterface kon niet correct worden gemaakt, dit is een ERNSTIG PROBLEEM en moet onmiddellijk gerapporteerd worden %s</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="already_voted">Je hebt al gestemd</string>
 </resources>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -63,7 +63,6 @@
     <string name="action_remove_from_bookmarks">Fjern</string>
     <string name="action_add_to_bookmarks">Sett visingstatus</string>
     <string name="sort_apply">Bruk</string>
-    <string name="sort_cancel">Avbryt</string>
     <string name="sort_copy">Kopier</string>
     <string name="sort_clear">Tøm</string>
     <string name="sort_save">Lagre</string>
@@ -113,6 +112,7 @@
     <string name="no_episodes_found">Ingen episodar blei funnen</string>
     <string name="delete_file">Slett fil</string>
     <string name="delete">Slett</string>
+    <string name="cancel">Avbryt</string>
     <string name="pause">Pause</string>
     <string name="resume">Gjenoppta</string>
     <string name="go_back_30">-30</string>
@@ -129,7 +129,7 @@
     <string name="synopsis">Om</string>
     <string name="queued">i kø</string>
     <string name="no_subtitles">Ingen undertekstar</string>
-    <string name="default_subtitles">Standard</string>
+    <string name="action_default">Standard</string>
     <string name="used_storage">Brukt</string>
     <string name="app_storage">Program</string>
     <string name="movies">Filmar</string>
@@ -166,7 +166,6 @@
     <string name="go_back_img_des">Gå tilbake</string>
     <string name="result_tags">Sjangrar</string>
     <string name="result_share">Dele</string>
-    <string name="type_none">Ingen</string>
     <string name="type_re_watching">Ser om igjen</string>
     <string name="update_started">Oppdatering starta</string>
     <string name="popup_resume_download">Fortsett nedlasting</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -33,7 +33,6 @@
     <string name="type_completed">Fullført</string>
     <string name="type_dropped">Falt</string>
     <string name="type_plan_to_watch">Planlegg å se</string>
-    <string name="type_none">Ingen</string>
     <string name="play_movie_button">Spill filmer</string>
     <string name="play_torrent_button">Strøm Torrent</string>
     <string name="pick_source">Kilder</string>
@@ -67,7 +66,6 @@
     <string name="error_bookmarks_text">Bokmerker</string>
     <string name="action_remove_from_bookmarks">Ta bort</string>
     <string name="sort_apply">Søke om</string>
-    <string name="sort_cancel">Avbryt</string>
     <string name="player_speed">Spillerhastighet</string>
     <string name="subtitles_settings">Innstillinger for teksting</string>
     <string name="subs_text_color">Tekstfarge</string>
@@ -141,6 +139,7 @@
     <string name="episode_short">E</string>
     <string name="delete_file">Slett fil</string>
     <string name="delete">Slett</string>
+    <string name="cancel">Avbryt</string>
     <string name="pause">Stopp</string>
     <string name="resume">Gjenoppta</string>
     <string name="delete_message">Dette vil slette %s
@@ -155,7 +154,7 @@
     <string name="synopsis">Om</string>
     <string name="queued">I kø</string>
     <string name="no_subtitles">Ingen undertekster</string>
-    <string name="default_subtitles">Misligholde</string>
+    <string name="action_default">Misligholde</string>
     <string name="free_storage">Tilgjengelig</string>
     <string name="used_storage">Brukt</string>
     <string name="app_storage">applikasjon</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -19,7 +19,6 @@
     <string name="player_speed_text_format" formatted="true">ଵେଗ (%.2fଗୁଣ)</string>
     <string name="type_dropped">ତ୍ୟାଗିଛନ୍ତି</string>
     <string name="type_plan_to_watch">ଦେଖିବା ପାଇଁ ଇଚ୍ଛୁକ</string>
-    <string name="type_none">କିଛି ନାହିଁ</string>
     <string name="home_more_info">ଅଧିକ ସୂଚନା</string>
     <string name="cast_format" formatted="true">ପାତ୍ର: %s</string>
     <string name="result_poster_img_des">ପୋଷ୍ଟର୍</string>
@@ -42,7 +41,7 @@
     <string name="episode_short">ଅ</string>
     <string name="episode_poster_img_des">ଅଧ୍ୟାୟର ପୋଷ୍ଟର୍</string>
     <string name="home_main_poster_img_des">ମୁଖ୍ୟ ପୋଷ୍ଟର୍</string>
-    <string name="default_subtitles">ଡିଫଲ୍ଟ</string>
+    <string name="action_default">ଡିଫଲ୍ଟ</string>
     <string name="extension_language">ଭାଷା</string>
     <string name="no">ନାହିଁ</string>
     <string name="extension_description">ଵର୍ଣ୍ଣନା</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -35,7 +35,6 @@
     <string name="type_completed">Zakończone</string>
     <string name="type_dropped">Porzucone</string>
     <string name="type_plan_to_watch">Planowane</string>
-    <string name="type_none">Brak</string>
     <string name="type_re_watching">Ponowne oglądanie</string>
     <string name="play_movie_button">Odtwórz film</string>
     <string name="play_livestream_button">Odtwórz transmisję na żywo</string>
@@ -72,7 +71,6 @@
     <string name="action_remove_from_bookmarks">Usuń</string>
     <string name="action_add_to_bookmarks">Ustaw status oglądania</string>
     <string name="sort_apply">Zastosuj</string>
-    <string name="sort_cancel">Anuluj</string>
     <string name="sort_copy">Kopiuj</string>
     <string name="sort_close">Zamknij</string>
     <string name="sort_clear">Wyczyść</string>
@@ -181,6 +179,7 @@
     <string name="no_episodes_found">Nie znaleziono odcinków</string>
     <string name="delete_file">Usuń plik</string>
     <string name="delete">Usuń</string>
+    <string name="cancel">Anuluj</string>
     <string name="pause">Wstrzymaj</string>
     <string name="resume">Odtwórz</string>
     <string name="go_back_30">-30</string>
@@ -199,7 +198,7 @@
     <string name="synopsis">Streszczenie</string>
     <string name="queued">W kolejce</string>
     <string name="no_subtitles">Brak napisów</string>
-    <string name="default_subtitles">Domyślne</string>
+    <string name="action_default">Domyślne</string>
     <string name="free_storage">Wolne</string>
     <string name="used_storage">W użyciu</string>
     <string name="app_storage">Aplikacja</string>
@@ -552,7 +551,6 @@
     <string name="unable_to_inflate">Nie można było poprawnie utworzyć interfejsu użytkownika, jest to POWAŻNY BŁĄD i należy go natychmiast zgłosić %s</string>
     <string name="automatic_plugin_download_mode_title">Wybierz tryb filtrowania pobieranych rozszerzeń</string>
     <string name="disable">Wyłączać</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="no_plugins_found_error">Nie znaleziono żadnych wtyczek w repozytorium</string>
     <string name="already_voted">Już oddano głos</string>
     <string name="no_repository_found_error">Nie znaleziono tego repozytorium, sprawdź adres URL lub spróbuj połączyć się przez VPN</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -42,7 +42,6 @@
     <string name="type_completed">Concluído</string>
     <string name="type_dropped">Desistido</string>
     <string name="type_plan_to_watch">Pretendo assistir</string>
-    <string name="type_none">Nenhum</string>
     <string name="type_re_watching">Reassistindo</string>
     <string name="play_movie_button">Reproduzir filme</string>
     <string name="play_livestream_button">Reproduzir transmissão ao vivo</string>
@@ -78,7 +77,6 @@
     <string name="error_bookmarks_text">Marcadores</string>
     <string name="action_remove_from_bookmarks">Remover</string>
     <string name="sort_apply">Aplicar</string>
-    <string name="sort_cancel">Cancelar</string>
     <string name="sort_copy">Copiar</string>
     <string name="sort_close">Fechar</string>
     <string name="sort_clear">Limpar</string>
@@ -182,6 +180,7 @@
     <string name="no_episodes_found">Nenhum Episódio encontrado</string>
     <string name="delete_file">Eliminar Ficheiro</string>
     <string name="delete">Eliminar</string>
+    <string name="cancel">Cancelar</string>
     <string name="pause">Pôr em Pausa</string>
     <string name="resume">Retomar</string>
     <string name="delete_message" formatted="true">Isto apagará %s permanentemente
@@ -198,7 +197,7 @@
     <string name="synopsis">Sinopse</string>
     <string name="queued">Na fila</string>
     <string name="no_subtitles">Sem Legendas</string>
-    <string name="default_subtitles">Padrão</string>
+    <string name="action_default">Padrão</string>
     <string name="free_storage">Livre</string>
     <string name="used_storage">Usado</string>
     <string name="app_storage">App</string>
@@ -548,7 +547,6 @@
 \nNOTA: Se a soma for 10 ou mais, o leitor saltará automaticamente o carregamento quando essa ligação for carregada!</string>
     <string name="automatic_plugin_download_mode_title">Selecionar o modo para filtrar a transferência de plug-ins</string>
     <string name="unable_to_inflate">Não foi possível criar corretamente a interface do utilizador, trata-se de um GRANDE BUG e deve ser comunicado imediatamente %s</string>
-    <string name="default_account">\@ string/legendas_padrão</string>
     <string name="disable">Desativar</string>
     <string name="no_plugins_found_error">Não foram encontrados plugins no repositório</string>
     <string name="no_repository_found_error">Repositório não encontrado, verifique o URL e tente a VPN</string>

--- a/app/src/main/res/values-qt/strings.xml
+++ b/app/src/main/res/values-qt/strings.xml
@@ -23,7 +23,6 @@
     <string name="type_completed">ahhahooo</string>
     <string name="type_dropped">ooooo haa</string>
     <string name="type_plan_to_watch">aaahhuoh</string>
-    <string name="type_none">aaaghh</string>
     <string name="play_movie_button">aaaaa aaaghh</string>
     <string name="play_torrent_button">aaaghhaaahhu aaaaa</string>
     <string name="pick_source">oha aauuh</string>
@@ -51,7 +50,6 @@
     <string name="error_bookmarks_text">oouuh ooh</string>
     <string name="action_remove_from_bookmarks">aauuh ooh</string>
     <string name="sort_apply">oouuhaooo-ahah</string>
-    <string name="sort_cancel">oooohh</string>
     <string name="player_speed">oouuh aauuh oha</string>
     <string name="subtitles_settings">ouuhhhooooooh ooo-ahah</string>
     <string name="subs_text_color">ohaouuhhh</string>
@@ -122,6 +120,7 @@
     <string name="episode_short">A</string>
     <string name="delete_file">ooha ohahaaahoooa ahahooo</string>
     <string name="delete">oooooah</string>
+    <string name="cancel">oooohh</string>
     <string name="delete_message">aahhaaaaaahooo aauuh aaahhuaooo-ahahoooohh aoouuhoohoohooo-ahah %s</string>
     <string name="status_ongoing">aaaghhaaaaa</string>
     <string name="status_completed">aauuhaauuh</string>
@@ -133,7 +132,7 @@
     <string name="synopsis">aauugghh ohaaauugghh</string>
     <string name="queued">haaouuhhh</string>
     <string name="no_subtitles">ahaaaaaaaaaahaaaauugghh</string>
-    <string name="default_subtitles">ahooooh</string>
+    <string name="action_default">ahooooh</string>
     <string name="free_storage">ooo-ahahaaaaa</string>
     <string name="used_storage">ahhahhh</string>
     <string name="app_storage">aauugghh</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -43,7 +43,6 @@
     <string name="type_completed">Finalizat</string>
     <string name="type_dropped">Renunțat</string>
     <string name="type_plan_to_watch">Planificare pentru a urmări</string>
-    <string name="type_none">Anuleaza</string>
     <string name="type_re_watching">Reurmat</string>
     <string name="play_movie_button">Urmărește</string>
     <string name="play_torrent_button">Stream Torrent</string>
@@ -79,7 +78,6 @@
     <string name="action_remove_from_bookmarks">Eliminează</string>
     <string name="action_add_to_bookmarks">Adaugă</string>
     <string name="sort_apply">Aplică</string>
-    <string name="sort_cancel">Anulează</string>
     <string name="sort_copy">Copiază</string>
     <string name="sort_close">Închide</string>
     <string name="sort_clear">Elimină</string>
@@ -181,6 +179,7 @@
     <string name="no_episodes_found">Nu s-au găsit episoade</string>
     <string name="delete_file">Ștergeți fișierul</string>
     <string name="delete">Ștergeți</string>
+    <string name="cancel">Anulează</string>
     <string name="pause">Pauză</string>
     <string name="resume">Continuă</string>
     <string name="go_back_30">-30</string>
@@ -199,7 +198,7 @@
     <string name="synopsis">Rezumat</string>
     <string name="queued">În coada de așteptare</string>
     <string name="no_subtitles">Nu există subtitrare</string>
-    <string name="default_subtitles">Implicit</string>
+    <string name="action_default">Implicit</string>
     <string name="free_storage">Liber</string>
     <string name="used_storage">Folosit</string>
     <string name="app_storage">Aplicație</string>
@@ -569,6 +568,5 @@
     <string name="use">Utilizați</string>
     <string name="unable_to_inflate">UI nu a putut fi creată corect, acesta este un BUG MAJOR și trebuie raportat imediat %s</string>
     <string name="automatic_plugin_download_mode_title">Selectați modul de filtrare a descărcării plugin-urilor</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="already_voted">Ați votat deja</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -12,6 +12,7 @@
     <string name="download_failed">Скачать неудачный</string>
     <string name="resize_fit">Подогнать</string>
     <string name="delete">Удалить</string>
+    <string name="cancel">Отмена</string>
     <string name="all">Все</string>
     <string name="pause">Пауза</string>
     <string name="cast_format" formatted="true">Актёрский состав: %s</string>
@@ -58,7 +59,6 @@
     <string name="type_completed">Завершено</string>
     <string name="type_dropped">Брошенный</string>
     <string name="type_plan_to_watch">План посмотреть</string>
-    <string name="type_none">Нет</string>
     <string name="type_re_watching">Пересмотрю</string>
     <string name="play_movie_button">Смотреть фильм</string>
     <string name="play_trailer_button">Смотреть трейлер</string>
@@ -82,7 +82,6 @@
     <string name="filter_bookmarks">Фильтр закладки</string>
     <string name="error_bookmarks_text">Закладки</string>
     <string name="sort_apply">Применить</string>
-    <string name="sort_cancel">Отмена</string>
     <string name="sort_copy">Копия</string>
     <string name="sort_close">Закрыть</string>
     <string name="sort_clear">Очистить</string>
@@ -186,7 +185,7 @@
     <string name="rating">Рейтинг</string>
     <string name="duration">Продолжительность</string>
     <string name="no_subtitles">Нет субтитров</string>
-    <string name="default_subtitles">По умолчанию</string>
+    <string name="action_default">По умолчанию</string>
     <string name="app_storage">Приложение</string>
     <string name="anime">Аниме</string>
     <string name="torrent">Торренты</string>
@@ -535,7 +534,6 @@
     <string name="edit">Изменить</string>
     <string name="wifi">Интернет</string>
     <string name="profile_background_des">Задний фон профиля</string>
-    <string name="default_account">\@строка/обычные_субтитры</string>
     <string name="help">Помощь</string>
     <string name="profile_number">Профиль %d</string>
     <string name="automatic_plugin_download_mode_title">Выберите режим фильтера плагинов для загрузки</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -33,7 +33,6 @@
     <string name="search_hint">Hľadať…</string>
     <string name="title_downloads">Sťahovanie</string>
     <string name="no_data">Žiadne dáta</string>
-    <string name="sort_cancel">Zrušiť</string>
     <string name="sort_copy">Kopírovať</string>
     <string name="sort_close">Zavrieť</string>
     <string name="sort_save">Uložiť</string>
@@ -60,7 +59,6 @@
     <string name="download_canceled">Sťahovanie zrušené</string>
     <string name="app_dubbed_text">Dab</string>
     <string name="popup_delete_file">Zmazať súbor</string>
-    <string name="type_none">Žiadny</string>
     <string name="app_subbed_text">Tit</string>
     <string name="type_re_watching">Opätovné sledovanie</string>
     <string name="popup_play_file">Prehrať súbor</string>
@@ -265,7 +263,7 @@
     <string name="preferred_media_settings">Preferované médiá</string>
     <string name="nginx_url_pref">URL servera NGINX</string>
     <string name="episode_format" formatted="true">%d %s</string>
-    <string name="default_subtitles">Predvolené</string>
+    <string name="action_default">Predvolené</string>
     <string name="add_sync">Pridať sledovanie</string>
     <string name="no_season">Žiadna sezóna</string>
     <string name="episode">Epizóda</string>
@@ -293,6 +291,7 @@
     <string name="year">Rok</string>
     <string name="resize_fit">Prispôsobiť obrazovke</string>
     <string name="delete">Zmazať</string>
+    <string name="cancel">Zrušiť</string>
     <string name="used_storage">Využité</string>
     <string name="show_hd">Štítok kvality</string>
     <string name="android_tv_interface_off_seek_settings">Prehrávač skrytý - dĺžka pretočenia</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -10,6 +10,7 @@
     <string name="download_failed">Dejintii ma guulaysan</string>
     <string name="search">Raadi</string>
     <string name="delete">Tirtir</string>
+    <string name="cancel">Jooji</string>
     <string name="pause">Haki</string>
     <string name="queued">Horran</string>
     <string name="resize_fit">Le-ekaysii shaashadda</string>
@@ -46,7 +47,6 @@
     <string name="type_completed">Dhamaystirmay</string>
     <string name="type_dropped">Soo dhacay</string>
     <string name="type_plan_to_watch">Ku talo jira</string>
-    <string name="type_none">Midna</string>
     <string name="play_movie_button">Daaro filinka</string>
     <string name="play_trailer_button">Daar goos-gooska</string>
     <string name="subs_window_color">Midabka daaqadda</string>
@@ -56,7 +56,6 @@
     <string name="play_torrent_button">Daalaco toorentiga</string>
     <string name="pick_subtitle">Qrl-hoosaadka</string>
     <string name="popup_resume_download">Dib u bilow dejinta</string>
-    <string name="sort_cancel">Jooji</string>
     <string name="subs_background_color">Midabka dambeedka</string>
     <string name="pick_source">Xigashooyinka</string>
     <string name="reload_error">Dib u xidhiidhinaya…</string>
@@ -202,7 +201,7 @@
     <string name="duration">Muddada</string>
     <string name="used_storage">La isticmaalay</string>
     <string name="no_subtitles">Qrl-hoosaad ma leh</string>
-    <string name="default_subtitles">Sidiisaa</string>
+    <string name="action_default">Sidiisaa</string>
     <string name="free_storage">Bilaash</string>
     <string name="app_storage">Appka</string>
     <string name="cartoons_singular">Kartoob</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -26,7 +26,6 @@
     <string name="type_completed">Avslutad</string>
     <string name="type_dropped">Dropped</string>
     <string name="type_plan_to_watch">Plannerad</string>
-    <string name="type_none">Ingen</string>
     <string name="play_movie_button">Spela Upp</string>
     <string name="play_torrent_button">Strömma Torrent</string>
     <string name="pick_source">Källor</string>
@@ -53,7 +52,6 @@
     <string name="error_bookmarks_text">Bokmärken</string>
     <string name="action_remove_from_bookmarks">Ta bort</string>
     <string name="sort_apply">Tillämpa</string>
-    <string name="sort_cancel">Avbryt</string>
     <string name="player_speed">Spelarhastighet</string>
     <string name="subtitles_settings">Undertextinställningar</string>
     <string name="subs_text_color">Textfärg</string>
@@ -125,6 +123,7 @@
     <string name="episode_short">A</string>
     <string name="delete_file">Ta bort nerladdad fil</string>
     <string name="delete">Ta bort</string>
+    <string name="cancel">Avbryt</string>
     <string name="delete_message">%s kommer att raderas permanent
 \nÄr du helt säker\?</string>
     <string name="status_ongoing">Pågående</string>
@@ -137,7 +136,7 @@
     <string name="synopsis">Sammanfattning</string>
     <string name="queued">på kö</string>
     <string name="no_subtitles">Inga undertexter</string>
-    <string name="default_subtitles">Standard</string>
+    <string name="action_default">Standard</string>
     <string name="free_storage">Tillgängligt</string>
     <string name="used_storage">Använtt</string>
     <string name="app_storage">App</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -38,7 +38,6 @@
     <string name="home_more_info">மேலும் தகவல்கள்</string>
     <string name="home_expanded_hide">மறை</string>
     <string name="action_remove_from_bookmarks">நீக்கு</string>
-    <string name="sort_cancel">ரத்து செய்க</string>
     <string name="sort_clear">நீக்கு</string>
     <string name="sort_save">சேமிக்கவும்</string>
     <string name="subs_text_color">உரை வண்ணம்</string>
@@ -63,7 +62,6 @@
     <string name="cast_format" formatted="true">நடிகர்கள்: %s</string>
     <string name="go_back_img_des">பின் செல்</string>
     <string name="title_settings">அமைப்புகள்</string>
-    <string name="type_none">ஏதும் இல்லை</string>
     <string name="loading">ஏற்றுகிறது…</string>
     <string name="type_dropped">கைவிடப்பட்டது</string>
     <string name="download_done">பதிவிறக்கம் முடிந்தது</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -36,7 +36,6 @@
     <string name="type_completed">Tapos nang panoorin</string>
     <string name="type_dropped">Ayaw nang panoorin</string>
     <string name="type_plan_to_watch">Balak panoorin</string>
-    <string name="type_none">None</string>
     <string name="play_movie_button">I-play ang Movie</string>
     <string name="play_torrent_button">Stream Torrent</string>
     <string name="pick_source">Sources</string>
@@ -70,7 +69,6 @@
     <string name="error_bookmarks_text">Bookmark</string>
     <string name="action_remove_from_bookmarks">Tanggalin</string>
     <string name="sort_apply">Kumpirmahin</string>
-    <string name="sort_cancel">Kanselahin</string>
     <string name="player_speed">Bilis ng Playback</string>
     <string name="subtitles_settings">Subtitle Setting</string>
     <string name="subs_text_color">Kulay ng Teksto</string>
@@ -144,6 +142,7 @@
     <string name="episode_short">E</string>
     <string name="delete_file">Burahin ang file</string>
     <string name="delete">Tanggalin</string>
+    <string name="cancel">Kanselahin</string>
     <string name="pause">I-pause</string>
     <string name="resume">I-resume</string>
     <string name="delete_message">This will permanently delete %s
@@ -158,7 +157,7 @@
     <string name="synopsis">Sinopsis</string>
     <string name="queued">nakapila</string>
     <string name="no_subtitles">walang subtitles</string>
-    <string name="default_subtitles">Default</string>
+    <string name="action_default">Default</string>
     <string name="free_storage">Bakante</string>
     <string name="used_storage">Gamit</string>
     <string name="app_storage">App</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -57,7 +57,6 @@
     <string name="type_completed">Tamamlandı</string>
     <string name="type_dropped">Bırakıldı</string>
     <string name="type_plan_to_watch">Planlandı</string>
-    <string name="type_none">Hiçbiri</string>
     <string name="type_re_watching">Yeniden izleniyor</string>
     <string name="play_movie_button">Filmi oynat</string>
     <string name="play_livestream_button">Canlı yayını oynat</string>
@@ -96,7 +95,6 @@
     <string name="action_remove_from_bookmarks">Kaldır</string>
     <string name="action_add_to_bookmarks">İzleme durumunu ayarla</string>
     <string name="sort_apply">Uygula</string>
-    <string name="sort_cancel">İptal et</string>
     <string name="sort_copy">Kopyala</string>
     <string name="sort_close">Kapat</string>
     <string name="sort_clear">Temizle</string>
@@ -205,7 +203,7 @@
     <string name="no_episodes_found">Bölüm bulunamadı</string>
     <string name="delete_file">Dosyayı sil</string>
     <string name="delete">Sil</string>
-    <string name="cancel" translatable="false">@string/sort_cancel</string>
+    <string name="cancel">İptal et</string>
     <string name="pause">Durdur</string>
     <string name="resume">Sürdür</string>
     <string name="go_back_30">-30</string>
@@ -224,7 +222,7 @@
     <string name="synopsis">Özet</string>
     <string name="queued">Sıraya alındı</string>
     <string name="no_subtitles">Alt yazı yok</string>
-    <string name="default_subtitles">Varsayılan</string>
+    <string name="action_default">Varsayılan</string>
     <string name="free_storage">Boş</string>
     <string name="used_storage">Kullanılan</string>
     <string name="app_storage">Uygulama</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -112,9 +112,7 @@
     <string name="popup_play_file">Переглянути файл</string>
     <string name="home_more_info">Детальніше</string>
     <string name="filter_bookmarks">Фільтр закладок</string>
-    <string name="type_none">Нічого</string>
-    <string name="sort_cancel">Скасувати</string>
-    <string name="sort_clear">Очистити</string>
+        <string name="sort_clear">Очистити</string>
     <string name="subtitles_settings">Налаштування субтитрів</string>
     <string name="subs_background_color">Колір фону</string>
     <string name="subs_subtitle_elevation">Висота субтитрів</string>
@@ -174,6 +172,7 @@
     <string name="episode_short">Е</string>
     <string name="delete_file">Видалити файл</string>
     <string name="delete">Видалити</string>
+    <string name="cancel">Скасувати</string>
     <string name="resume">Відновити</string>
     <string name="go_back_30">-30</string>
     <string name="delete_message" formatted="true">Це назавжди видалить %s
@@ -186,7 +185,7 @@
     <string name="duration">Тривалість</string>
     <string name="queued">у черзі</string>
     <string name="no_subtitles">Без субтитрів</string>
-    <string name="default_subtitles">За замовчуванням</string>
+    <string name="action_default">За замовчуванням</string>
     <string name="free_storage">Вільно</string>
     <string name="used_storage">Зайнято</string>
     <string name="app_storage">Застосунок</string>
@@ -549,7 +548,6 @@
     <string name="unable_to_inflate">Не вдалося створити UI коректно, це ВАЖЛИВА ПОМИЛКА, про яку слід негайно повідомити %s</string>
     <string name="automatic_plugin_download_mode_title">Виберіть режим для фільтрації завантаження плагінів</string>
     <string name="disable">Вимкнути</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="no_repository_found_error">Репозиторій не знайдено, перевірте URL-адресу та спробуйте VPN</string>
     <string name="no_plugins_found_error">Не знайдено жодних плагінів у репозиторії</string>
     <string name="already_voted">Ви вже проголосували</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -34,7 +34,6 @@
     <string name="type_on_hold">معطل</string>
     <string name="type_dropped">چھوڑ دیا گیا</string>
     <string name="type_plan_to_watch">دیکھنے کا منصوبہ</string>
-    <string name="type_none">کوئی نہیں</string>
     <string name="type_re_watching">دوبارہ دیکھنا</string>
     <string name="play_movie_button">مووی لگائے</string>
     <string name="play_trailer_button">ٹریلر چلائیں</string>
@@ -67,7 +66,6 @@
     <string name="action_remove_from_bookmarks">ریمو</string>
     <string name="action_add_to_bookmarks">واچ اسٹیٹس کو سیٹ کریں</string>
     <string name="sort_apply">لاگو کریں</string>
-    <string name="sort_cancel">منسوخ کریں</string>
     <string name="sort_copy">کاپی</string>
     <string name="sort_close">بند کریں</string>
     <string name="sort_clear">صاف کریں</string>
@@ -193,6 +191,7 @@
     <string name="no_episodes_found">کوئی اقساط نہیں ملی</string>
     <string name="delete_file">فائل کو ڈیلیٹ کریں</string>
     <string name="delete">مٹا دیں</string>
+    <string name="cancel">منسوخ کریں</string>
     <string name="pause">توقف</string>
     <string name="resume">از سر نو شروع کریں</string>
     <string name="go_back_30">-30</string>
@@ -211,7 +210,7 @@
     <string name="synopsis">خلاصہ</string>
     <string name="queued">قطار میں</string>
     <string name="no_subtitles">کوئی سب ٹائٹلز نہیں</string>
-    <string name="default_subtitles">ڈیفالٹ</string>
+    <string name="action_default">ڈیفالٹ</string>
     <string name="free_storage">مفت</string>
     <string name="used_storage">استعمال شُدہ</string>
     <string name="cartoons">کارٹون</string>
@@ -535,7 +534,6 @@
     <string name="edit">ترتیب دیں</string>
     <string name="wifi">وائی فائی</string>
     <string name="profile_background_des">پروفائل پس منظر</string>
-    <string name="default_account">@string/default_subtitles</string>
     <string name="help">مدد</string>
     <string name="profile_number">پروفائل %d</string>
     <string name="automatic_plugin_download_mode_title">پلگ انز کو ڈاؤن لوڈ کرنے کے لئے موڈ منتخب کریں</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -45,7 +45,6 @@
     <string name="type_completed">Đã xem</string>
     <string name="type_dropped">Bỏ qua</string>
     <string name="type_plan_to_watch">Xem sau</string>
-    <string name="type_none">Mặc định</string>
     <string name="type_re_watching">Xem lại</string>
     <string name="play_movie_button">Xem Ngay</string>
     <string name="play_livestream_button">Phát trực tiếp</string>
@@ -83,7 +82,6 @@
     <string name="action_remove_from_bookmarks">Xóa</string>
     <string name="action_add_to_bookmarks">Đặt trạng thái xem</string>
     <string name="sort_apply">Áp dụng</string>
-    <string name="sort_cancel">Hủy bỏ</string>
     <string name="sort_copy">Sao lưu</string>
     <string name="sort_close">Đóng</string>
     <string name="sort_clear">Huỷ bỏ</string>
@@ -190,6 +188,7 @@
     <string name="no_episodes_found">Không có tập nào</string>
     <string name="delete_file">Xóa Tệp</string>
     <string name="delete">Xóa</string>
+    <string name="cancel">Hủy bỏ</string>
     <string name="pause">Tạm Dừng</string>
     <string name="resume">Tiếp Tục</string>
     <string name="go_back_30">-30</string>
@@ -208,7 +207,7 @@
     <string name="synopsis">Thông tin</string>
     <string name="queued">Hàng chờ</string>
     <string name="no_subtitles">Không có phụ đề</string>
-    <string name="default_subtitles">Mặc Định</string>
+    <string name="action_default">Mặc Định</string>
     <string name="free_storage">Còn trống</string>
     <string name="used_storage">Đã sử dụng</string>
     <string name="app_storage">App</string>
@@ -567,5 +566,4 @@
     <string name="no_plugins_found_error">Không tìm thấy plugin</string>
     <string name="unable_to_inflate">Không thể khởi tạo UI, đây là một LỖI LỚN và cần được báo cáo ngay lập tức tới %s</string>
     <string name="automatic_plugin_download_mode_title">Chọn chế độ để lọc plugin tải xuống</string>
-    <string name="default_account">@string/default_subtitles</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -57,7 +57,6 @@
     <string name="type_completed">觀看完畢</string>
     <string name="type_dropped">放棄觀看</string>
     <string name="type_plan_to_watch">計畫觀看</string>
-    <string name="type_none">無</string>
     <string name="type_re_watching">重新觀看</string>
     <string name="play_movie_button">播放電影</string>
     <string name="play_livestream_button">播放直播</string>
@@ -96,7 +95,6 @@
     <string name="action_remove_from_bookmarks">移除</string>
     <string name="action_add_to_bookmarks">設定觀看狀態</string>
     <string name="sort_apply">套用</string>
-    <string name="sort_cancel">取消</string>
     <string name="sort_copy">複製</string>
     <string name="sort_close">關閉</string>
     <string name="sort_clear">清除</string>
@@ -205,7 +203,7 @@
     <string name="no_episodes_found">未找到劇集</string>
     <string name="delete_file">刪除文件</string>
     <string name="delete">刪除</string>
-    <string name="cancel" translatable="false">@string/sort_cancel</string>
+    <string name="cancel">取消</string>
     <string name="pause">暫停</string>
     <string name="resume">繼續</string>
     <string name="go_back_30">-30</string>
@@ -224,7 +222,7 @@
     <string name="synopsis">簡介</string>
     <string name="queued">已加入佇列</string>
     <string name="no_subtitles">無字幕</string>
-    <string name="default_subtitles">預設</string>
+    <string name="action_default">預設</string>
     <string name="free_storage">空閒</string>
     <string name="used_storage">已使用</string>
     <string name="app_storage">應用程式</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -57,7 +57,6 @@
     <string name="type_completed">观看完毕</string>
     <string name="type_dropped">放弃观看</string>
     <string name="type_plan_to_watch">计划观看</string>
-    <string name="type_none">无</string>
     <string name="type_re_watching">重新观看</string>
     <string name="play_movie_button">播放电影</string>
     <string name="play_livestream_button">播放直播</string>
@@ -96,7 +95,6 @@
     <string name="action_remove_from_bookmarks">移除</string>
     <string name="action_add_to_bookmarks">设置观看状态</string>
     <string name="sort_apply">应用</string>
-    <string name="sort_cancel">取消</string>
     <string name="sort_copy">复制</string>
     <string name="sort_close">关闭</string>
     <string name="sort_clear">清除</string>
@@ -206,7 +204,7 @@
     <string name="no_episodes_found">未找到剧集</string>
     <string name="delete_file">删除文件</string>
     <string name="delete">删除</string>
-    <string name="cancel" translatable="false">@string/sort_cancel</string>
+    <string name="cancel">取消</string>
     <string name="pause">暂停</string>
     <string name="resume">继续</string>
     <string name="go_back_30">-30</string>
@@ -225,7 +223,7 @@
     <string name="synopsis">简介</string>
     <string name="queued">已加入队列</string>
     <string name="no_subtitles">无字幕</string>
-    <string name="default_subtitles">默认</string>
+    <string name="action_default">默认</string>
     <string name="free_storage">空闲</string>
     <string name="used_storage">已使用</string>
     <string name="app_storage">应用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,7 +123,7 @@
     <string name="type_completed">Completed</string>
     <string name="type_dropped">Dropped</string>
     <string name="type_plan_to_watch">Plan to Watch</string>
-    <string name="type_none">None</string>
+    <string name="type_none" translatable="false">@string/none</string>
     <string name="type_re_watching">Rewatching</string>
     <string name="play_movie_button">Play Movie</string>
     <string name="play_trailer_button">Play Trailer</string>
@@ -164,7 +164,7 @@
     <string name="action_remove_from_bookmarks">Remove</string>
     <string name="action_add_to_bookmarks">Set watch status</string>
     <string name="sort_apply">Apply</string>
-    <string name="sort_cancel">Cancel</string>
+    <string name="sort_cancel" translatable="false">@string/cancel</string>
     <string name="sort_copy">Copy</string>
     <string name="sort_close">Close</string>
     <string name="sort_clear">Clear</string>
@@ -287,7 +287,7 @@
     <string name="no_episodes_found">No Episodes found</string>
     <string name="delete_file">Delete File</string>
     <string name="delete">Delete</string>
-    <string name="cancel" translatable="false">@string/sort_cancel</string>
+    <string name="cancel">Cancel</string>
     <string name="pause">Pause</string>
     <string name="start">Start</string>
     <string name="test_failed">Failed</string>
@@ -307,8 +307,9 @@
     <string name="synopsis">Synopsis</string>
     <string name="queued">queued</string>
     <string name="no_subtitles">No Subtitles</string>
-    <string name="default_subtitles">Default</string>
-    <string name="default_account">@string/default_subtitles</string>
+    <string name="action_default">Default</string>
+    <string name="default_subtitles" translatable="false">@string/action_default</string>
+    <string name="default_account" translatable="false">@string/action_default</string>
     <string name="free_storage">Free</string>
     <string name="used_storage">Used</string>
     <string name="app_storage">App</string>
@@ -698,7 +699,7 @@
     <string name="duplicate_add">Add</string>
     <string name="duplicate_replace">Replace</string>
     <string name="duplicate_replace_all">Replace All</string>
-    <string name="duplicate_cancel" translatable="false">@string/sort_cancel</string>
+    <string name="duplicate_cancel" translatable="false">@string/cancel</string>
     <string name="duplicate_message_single">
         It appears that a potentially duplicate item already exists in your library: \'%1$s.\'
 


### PR DESCRIPTION
Note: this was done with some regex find and replacements and python scripts I made to do it, I did not go through and make sure every one was properly updated in every file, but it does seem like they should be as ones I checked were, and the others should not be that different. I did all the files here to try and avoid breaking translations or require them be retranslated, however if you do not wish to do this, feel free to close, and I apologize.

Only one that has an issue is cancel, which was removed if delete didn't exist in language because my script moved it by placing it after delete, since sort_cancel was removed and replaced with cancel for consistency, I can fix this for ones that didn't have delete and it was completely removed if necessary.

But the overall purpose of this was to just combine and reduce the overall amount of keys that need translated.