### PR TITLE
Fix some deprecations and other warnings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET" /> <!-- unless you only use cs3 as a player for downloaded stuff, you need this -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" /> <!-- Downloads -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Downloads on low api devices -->
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" /> <!-- Plugin API -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" /> <!-- Plugin API -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" /> <!-- some dependency needs this -->
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" /> <!-- Used for player vertical slide -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" /> <!-- Used for app update -->
@@ -17,7 +17,11 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" /> <!-- Required for getting arbitrary Aniyomi packages  -->
+    <!-- Required for getting arbitrary Aniyomi packages  -->
+    <uses-permission
+        android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
+
     <!-- Fixes android tv fuckery -->
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -37,9 +41,11 @@
     <application
         android:name=".AcraApplication"
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="true"
         android:appCategory="video"
         android:banner="@mipmap/ic_banner"
         android:fullBackupContent="@xml/backup_descriptor"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
@@ -47,7 +53,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"
-        tools:targetApi="o">
+        tools:targetApi="tiramisu">
 
         <meta-data
             android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
@@ -182,8 +188,8 @@
         <receiver
             android:name=".receivers.VideoDownloadRestartReceiver"
             android:enabled="false"
-            android:exported="true">
-            <intent-filter android:exported="true">
+            android:exported="false">
+            <intent-filter android:exported="false">
                 <action android:name="restart_service" />
             </intent-filter>
         </receiver>

--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1576,6 +1576,23 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener {
 //                showToast(this, currentFocus.toString(), Toast.LENGTH_LONG)
 //            }
 //        }
+
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    window?.navigationBarColor = colorFromAttribute(R.attr.primaryGrayBackground)
+                    updateLocale()
+
+                    // If we don't disable we end up in a loop with default behavior calling
+                    // this callback as well, so we disable it, run default behavior,
+                    // then re-enable this callback so it can be used for next back press.
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                    isEnabled = true
+                }
+            }
+        )
     }
 
     private var backPressedCallback: OnBackPressedCallback? = null
@@ -1585,6 +1602,9 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener {
             backPressedCallback = object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
                     showConfirmExitDialog()
+                    window?.navigationBarColor =
+                        colorFromAttribute(R.attr.primaryGrayBackground)
+                    updateLocale()
                 }
             }
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1590,7 +1590,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener {
         }
 
         backPressedCallback?.isEnabled = true
-        onBackPressedDispatcher.addCallback(this, backPressedCallback!!)
+        onBackPressedDispatcher.addCallback(this, backPressedCallback ?: return)
     }
 
     private fun detachBackPressedCallback() {

--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -19,6 +19,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.IdRes
 import androidx.annotation.MainThread
@@ -132,7 +133,6 @@ import com.lagradost.cloudstream3.utils.DataStore.setKey
 import com.lagradost.cloudstream3.utils.DataStoreHelper
 import com.lagradost.cloudstream3.utils.DataStoreHelper.migrateResumeWatching
 import com.lagradost.cloudstream3.utils.Event
-import com.lagradost.cloudstream3.utils.IOnBackPressed
 import com.lagradost.cloudstream3.utils.InAppUpdater.Companion.runAutoUpdate
 import com.lagradost.cloudstream3.utils.SingleSelectionHelper.showBottomDialog
 import com.lagradost.cloudstream3.utils.UIHelper.changeStatusBarState
@@ -650,34 +650,6 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener {
         builder.show().setDefaultFocus()
     }
 
-    private fun backPressed() {
-        this.window?.navigationBarColor =
-            this.colorFromAttribute(R.attr.primaryGrayBackground)
-        this.updateLocale()
-        this.updateLocale()
-
-        val navHostFragment =
-            supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as? NavHostFragment
-        val navController = navHostFragment?.navController
-        val isAtHome =
-            navController?.currentDestination?.matchDestination(R.id.navigation_home) == true
-
-        if (isAtHome && isTvSettings()) {
-            showConfirmExitDialog()
-        } else {
-            super.onBackPressed()
-        }
-    }
-
-    override fun onBackPressed() {
-        ((supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as? NavHostFragment?)?.childFragmentManager?.primaryNavigationFragment as? IOnBackPressed)?.onBackPressed()
-            ?.let { runNormal ->
-                if (runNormal) backPressed()
-            } ?: run {
-            backPressed()
-        }
-    }
-
     override fun onDestroy() {
         val broadcastIntent = Intent()
         broadcastIntent.action = "restart_service"
@@ -1087,6 +1059,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener {
         } catch (_: Throwable) {
         }
     }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         app.initClient(this)
         val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
@@ -1384,6 +1357,12 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener {
                     this.putString(SearchFragment.SEARCH_QUERY, nextSearchQuery)
                 }
             }
+
+            if (isTvSettings()) {
+                if (navDestination.matchDestination(R.id.navigation_home)) {
+                    attachBackPressedCallback()
+                } else detachBackPressedCallback()
+            }
         }
 
         //val navController = findNavController(R.id.nav_host_fragment)
@@ -1597,7 +1576,25 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener {
 //                showToast(this, currentFocus.toString(), Toast.LENGTH_LONG)
 //            }
 //        }
+    }
 
+    private var backPressedCallback: OnBackPressedCallback? = null
+
+    private fun attachBackPressedCallback() {
+        if (backPressedCallback == null) {
+            backPressedCallback = object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    showConfirmExitDialog()
+                }
+            }
+        }
+
+        backPressedCallback?.isEnabled = true
+        onBackPressedDispatcher.addCallback(this, backPressedCallback!!)
+    }
+
+    private fun detachBackPressedCallback() {
+        backPressedCallback?.isEnabled = false
     }
 
     suspend fun checkGithubConnectivity(): Boolean {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
@@ -60,7 +60,7 @@ class DownloadChildFragment : Fragment() {
                 }
             }.sortedBy { it.data.episode + (it.data.season ?: 0) * 100000 }
             if (eps.isEmpty()) {
-                activity?.onBackPressed()
+                activity?.onBackPressedDispatcher?.onBackPressed()
                 return@main
             }
 
@@ -78,7 +78,7 @@ class DownloadChildFragment : Fragment() {
         val folder = arguments?.getString("folder")
         val name = arguments?.getString("name")
         if (folder == null) {
-            activity?.onBackPressed() // TODO FIX
+            activity?.onBackPressedDispatcher?.onBackPressed() // TODO FIX
             return
         }
         fixPaddingStatusbar(binding?.downloadChildRoot)
@@ -87,7 +87,7 @@ class DownloadChildFragment : Fragment() {
             title = name
             setNavigationIcon(R.drawable.ic_baseline_arrow_back_24)
             setNavigationOnClickListener {
-                activity?.onBackPressed()
+                activity?.onBackPressedDispatcher?.onBackPressed()
             }
         }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.KeyEvent
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import com.lagradost.cloudstream3.CommonActivity
 import com.lagradost.cloudstream3.R
@@ -32,10 +33,6 @@ class DownloadedPlayerActivity : AppCompatActivity() {
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
         CommonActivity.onUserLeaveHint(this)
-    }
-
-    override fun onBackPressed() {
-        finish()
     }
 
     private fun playLink(url: String) {
@@ -109,6 +106,15 @@ class DownloadedPlayerActivity : AppCompatActivity() {
             finish()
             return
         }
+
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    finish()
+                }
+            }
+        )
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.lagradost.cloudstream3.CommonActivity.screenHeight
@@ -15,10 +16,8 @@ import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.ui.player.CSPlayerEvent
 import com.lagradost.cloudstream3.ui.player.PlayerEventSource
 import com.lagradost.cloudstream3.ui.player.SubtitleData
-import com.lagradost.cloudstream3.utils.IOnBackPressed
 
-
-open class ResultTrailerPlayer : ResultFragmentPhone(), IOnBackPressed {
+open class ResultTrailerPlayer : ResultFragmentPhone() {
 
     override var lockRotation = false
     override var isFullScreenPlayer = false
@@ -28,7 +27,7 @@ open class ResultTrailerPlayer : ResultFragmentPhone(), IOnBackPressed {
         const val TAG = "RESULT_TRAILER"
     }
 
-    var playerWidthHeight: Pair<Int, Int>? = null
+    private var playerWidthHeight: Pair<Int, Int>? = null
 
     override fun nextEpisode() {}
 
@@ -154,6 +153,10 @@ open class ResultTrailerPlayer : ResultFragmentPhone(), IOnBackPressed {
         }
         fixPlayerSize()
         uiReset()
+
+        if (isFullScreenPlayer) {
+            attachBackPressedCallback()
+        } else detachBackPressedCallback()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -172,12 +175,22 @@ open class ResultTrailerPlayer : ResultFragmentPhone(), IOnBackPressed {
         }
     }
 
-    override fun onBackPressed(): Boolean {
-        return if (isFullScreenPlayer) {
-            updateFullscreen(false)
-            false
-        } else {
-            true
+    private var backPressedCallback: OnBackPressedCallback? = null
+
+    private fun attachBackPressedCallback() {
+        if (backPressedCallback == null) {
+            backPressedCallback = object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    updateFullscreen(false)
+                }
+            }
         }
+
+        backPressedCallback?.isEnabled = true
+        requireActivity().onBackPressedDispatcher.addCallback(requireActivity(), backPressedCallback!!)
+    }
+
+    private fun detachBackPressedCallback() {
+        backPressedCallback?.isEnabled = false
     }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
@@ -187,7 +187,11 @@ open class ResultTrailerPlayer : ResultFragmentPhone() {
         }
 
         backPressedCallback?.isEnabled = true
-        requireActivity().onBackPressedDispatcher.addCallback(requireActivity(), backPressedCallback!!)
+
+        activity?.onBackPressedDispatcher?.addCallback(
+            activity ?: return,
+            backPressedCallback ?: return
+        )
     }
 
     private fun detachBackPressedCallback() {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -63,7 +63,7 @@ class SettingsFragment : Fragment() {
                 setTitle(title)
                 setNavigationIcon(R.drawable.ic_baseline_arrow_back_24)
                 setNavigationOnClickListener {
-                    activity?.onBackPressed()
+                    activity?.onBackPressedDispatcher?.onBackPressed()
                 }
             }
             fixPaddingStatusbar(settingsToolbar)
@@ -78,7 +78,7 @@ class SettingsFragment : Fragment() {
                 setNavigationIcon(R.drawable.ic_baseline_arrow_back_24)
                 children.firstOrNull { it is ImageView }?.tag = getString(R.string.tv_no_focus_tag)
                 setNavigationOnClickListener {
-                    activity?.onBackPressed()
+                    activity?.onBackPressedDispatcher?.onBackPressed()
                 }
             }
             fixPaddingStatusbar(settingsToolbar)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginsFragment.kt
@@ -69,7 +69,7 @@ class PluginsFragment : Fragment() {
         val isLocal = arguments?.getBoolean(PLUGINS_BUNDLE_LOCAL) == true
 
         if (url == null || name == null) {
-            activity?.onBackPressed()
+            activity?.onBackPressedDispatcher?.onBackPressed()
             return
         }
 
@@ -117,7 +117,7 @@ class PluginsFragment : Fragment() {
                 if (searchView?.isIconified == false) {
                     searchView.isIconified = true
                 } else {
-                    activity?.onBackPressed()
+                    activity?.onBackPressedDispatcher?.onBackPressed()
                 }
             }
             searchView?.setOnQueryTextFocusChangeListener { _, hasFocus ->

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/IOnBackPressed.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/IOnBackPressed.kt
@@ -1,5 +1,0 @@
-package com.lagradost.cloudstream3.utils
-
-interface IOnBackPressed {
-    fun onBackPressed(): Boolean
-}

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
@@ -418,7 +418,7 @@ object UIHelper {
     }
 
     fun FragmentActivity.popCurrentPage() {
-        this.onBackPressed()
+        this.onBackPressedDispatcher.onBackPressed()
         /*val currentFragment = supportFragmentManager.fragments.lastOrNull {
             it.isVisible
         } ?: return
@@ -438,7 +438,7 @@ object UIHelper {
         val currentFragment = supportFragmentManager.fragments.lastOrNull {
             it.isVisible
         }
-            ?: //this.onBackPressed()
+            ?: //this.onBackPressedDispatcher.onBackPressed()
             return
 
 /*

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+</data-extraction-rules>


### PR DESCRIPTION
* Replace deprecated onBackPressed()
* Fixes some AndroidManifest warnings
  * Use android:dataExtractionRules for Android 12+
  * Add tools:ignore for ScopedStorage and QueryAllPackagesPermission
  * Make VideoDownloadRestartReceiver not exported (fixes "
Exported receiver does not require permission") - if this was incorrect I can revert this part
  * Bump tools:targetApi
* Enable android:enableOnBackInvokedCallback for predictive back gestures on Android 13 (if enabled in developer options) and Android 14 (also fixes "OnBackInvokedCallback is not enabled for the application." which is commonly seen in logcat)
