### PR TITLE
fix: upgrade gradle and kgp upgrade

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import com.android.build.gradle.internal.tasks.factory.dependsOn
 import org.jetbrains.dokka.gradle.DokkaTask
 import java.io.ByteArrayOutputStream
 import java.net.URL
@@ -283,8 +284,10 @@ tasks.register("makeJar", Copy::class) {
     from("build/intermediates/compile_app_classes_jar/prereleaseDebug")
     into("build")
     include("classes.jar")
-    dependsOn("build")
 }
+
+tasks.named("makeJar").dependsOn("build")
+tasks.named("makeJar").dependsOn("assemblePrerelease")
 
 tasks.withType<DokkaTask>().configureEach {
     moduleName.set("Cloudstream")


### PR DESCRIPTION
let the build workflow fail after merging #726 to get latest log, then merge this one , i think this work as the make jar classes workflow will now run after the prerelease and build push.