### PR TITLE
refactor: use stable long term embedded jdk

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,17 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="delegatedBuild" value="true" />
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,7 @@ fun String.execute() = ByteArrayOutputStream().use { baot ->
 }
 
 android {
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }
@@ -131,13 +132,17 @@ android {
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {
         abortOnError = false
         checkReleaseBuilds = false
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     namespace = "com.lagradost.cloudstream3"
@@ -243,7 +248,7 @@ tasks.register("makeJar", Copy::class) {
 
 tasks.withType<KotlinCompile> {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
         freeCompilerArgs = listOf("-Xjvm-default=all-compatibility")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,5 @@ android.useAndroidX=true
 # android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
i am not sure if the gradle.xml file needs to be included in this or maybe it needs, anyways (draft)
after this android 14 support next