### PR TITLE
feat (library tabs): save and restore tab selection

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
@@ -7,7 +7,6 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -16,7 +15,6 @@ import android.view.ViewGroup.FOCUS_AFTER_DESCENDANTS
 import android.view.ViewGroup.FOCUS_BLOCK_DESCENDANTS
 import android.view.animation.AlphaAnimation
 import android.widget.ImageView
-import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.StringRes
@@ -25,9 +23,8 @@ import androidx.core.view.allViews
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.viewpager2.widget.ViewPager2
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.appbar.AppBarLayout
+import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.lagradost.cloudstream3.APIHolder
@@ -452,6 +449,20 @@ class LibraryFragment : Fragment() {
                                 binding?.searchBar?.setExpanded(true)
                             }
                         }.attach()
+
+                        binding?.libraryTabLayout?.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+                            override fun onTabSelected(tab: TabLayout.Tab?) {
+                                val position = tab?.position ?: 0
+                                libraryViewModel.setTabPosition(position)
+                            }
+                            override fun onTabUnselected(tab: TabLayout.Tab?) = Unit
+                            override fun onTabReselected(tab: TabLayout.Tab?) = Unit
+                        })
+
+                        libraryViewModel.getTabPosition().observe(viewLifecycleOwner) { position ->
+                            binding?.libraryTabLayout?.getTabAt(position)?.select()
+                        }
+
                     }
                 }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryViewModel.kt
@@ -28,6 +28,16 @@ enum class ListSorting(@StringRes val stringRes: Int) {
 const val LAST_SYNC_API_KEY = "last_sync_api"
 
 class LibraryViewModel : ViewModel() {
+    private val tabPositionLiveData = MutableLiveData<Int>()
+
+    fun setTabPosition(position: Int) {
+        tabPositionLiveData.value = position
+    }
+
+    fun getTabPosition(): LiveData<Int> {
+        return tabPositionLiveData
+    }
+    
     private val _pages: MutableLiveData<Resource<List<SyncAPI.Page>>> = MutableLiveData(null)
     val pages: LiveData<Resource<List<SyncAPI.Page>>> = _pages
 


### PR DESCRIPTION
Issue:
savedInstanceState is not restoring the tab selection when you open any movie and return to library section. Also, scroll position is not restored (I was not able to add changes to remember scroll position. Someone, pls give it a try).

Steps to reproduce:
1. (Optional if you have liked movies in library) Go to any movie and like it from top bar
2. Go to library, scroll and select favorite from bottom tab selector
3. Click on any movie
4. Go back, it will take you to watching instead of favorite

Affects:
This fix will affect tab functionality of the library section.

Fix:
libraryviewmodel will save the tab position and will be used to restore the tab position.