### PR TITLE
fix (library): reverted unnecessary changes and updated currentPage logic

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
@@ -25,7 +25,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
-import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.lagradost.cloudstream3.APIHolder
 import com.lagradost.cloudstream3.APIHolder.allProviders
@@ -398,7 +397,7 @@ class LibraryFragment : Fragment() {
                             0,
                             viewpager.adapter?.itemCount ?: 0
                         )
-                        binding?.viewpager?.setCurrentItem(libraryViewModel.getTabPosition().value ?: 0, false)
+                        binding?.viewpager?.setCurrentItem(libraryViewModel.currentPage, false)
 
                         // Only stop loading after 300ms to hide the fade effect the viewpager produces when updating
                         // Without this there would be a flashing effect:
@@ -439,6 +438,8 @@ class LibraryFragment : Fragment() {
                             tab.view.nextFocusDownId = R.id.search_result_root
 
                             tab.view.setOnClickListener {
+                                libraryViewModel.currentPage = position // updating selected library tab position
+
                                 val currentItem =
                                     binding?.viewpager?.currentItem ?: return@setOnClickListener
                                 val distance = abs(position - currentItem)
@@ -449,19 +450,6 @@ class LibraryFragment : Fragment() {
                                 binding?.searchBar?.setExpanded(true)
                             }
                         }.attach()
-
-                        binding?.libraryTabLayout?.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
-                            override fun onTabSelected(tab: TabLayout.Tab?) {
-                                val position = tab?.position ?: 0
-                                libraryViewModel.setTabPosition(position)
-                            }
-                            override fun onTabUnselected(tab: TabLayout.Tab?) = Unit
-                            override fun onTabReselected(tab: TabLayout.Tab?) = Unit
-                        })
-
-                        libraryViewModel.getTabPosition().observe(viewLifecycleOwner) { position ->
-                            binding?.libraryTabLayout?.getTabAt(position)?.select()
-                        }
 
                     }
                 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryViewModel.kt
@@ -28,15 +28,7 @@ enum class ListSorting(@StringRes val stringRes: Int) {
 const val LAST_SYNC_API_KEY = "last_sync_api"
 
 class LibraryViewModel : ViewModel() {
-    private val tabPositionLiveData = MutableLiveData<Int>()
-
-    fun setTabPosition(position: Int) {
-        tabPositionLiveData.value = position
-    }
-
-    fun getTabPosition(): LiveData<Int> {
-        return tabPositionLiveData
-    }
+    var currentPage: Int = 0
     
     private val _pages: MutableLiveData<Resource<List<SyncAPI.Page>>> = MutableLiveData(null)
     val pages: LiveData<Resource<List<SyncAPI.Page>>> = _pages


### PR DESCRIPTION
fixes:
updating currentPage in tab.view.setOnClickListener will save the current page
binding?.libraryTabLayout?.addOnTabSelectedListener and MutableLiveData<Int>() is not required

refs:
https://github.com/recloudstream/cloudstream/pull/801
https://github.com/recloudstream/cloudstream/pull/798