### PR TITLE
feat (resume): based on resume episode, restore details in UI (season, range and dubbed status)

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1022,6 +1022,7 @@ class GeneratorPlayer : FullScreenPlayer() {
                         resumeMeta.id,
                         resumeMeta.episode,
                         resumeMeta.season,
+                        resumeMeta.dubStatus,
                         isFromDownload = false
                     )
                 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragment.kt
@@ -50,6 +50,7 @@ data class ResultEpisode(
     val videoWatchState: VideoWatchState,
     /** Sum of all previous season episode counts + episode */
     val totalEpisodeIndex: Int? = null,
+    val dubStatus: DubStatus? = null
 )
 
 fun ResultEpisode.getRealPosition(): Long {
@@ -85,6 +86,7 @@ fun buildResultEpisode(
     tvType: TvType,
     parentId: Int,
     totalEpisodeIndex: Int? = null,
+    dubStatus: DubStatus? = null,
 ): ResultEpisode {
     val posDur = getViewPos(id)
     val videoWatchState = getVideoWatchState(id) ?: VideoWatchState.None
@@ -107,7 +109,8 @@ fun buildResultEpisode(
         tvType,
         parentId,
         videoWatchState,
-        totalEpisodeIndex
+        totalEpisodeIndex,
+        dubStatus
     )
 }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -2477,7 +2477,7 @@ class ResultViewModel2 : ViewModel() {
 
         // restore range based on resume details
         currentRanges[currentIndex]?.first {
-            it.endEpisode >= (resume.episode ?: 0)
+            it.endEpisode >= resume.episode ?: 0
         }?.apply {
             changeRange(this)
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -2241,7 +2241,8 @@ class ResultViewModel2 : ViewModel() {
                                     fillers.getOrDefault(episode, false),
                                     loadResponse.type,
                                     mainId,
-                                    totalIndex
+                                    totalIndex,
+                                    ep.key
                                 )
 
                             val season = eps.seasonIndex ?: 0
@@ -2290,7 +2291,8 @@ class ResultViewModel2 : ViewModel() {
                                 null,
                                 loadResponse.type,
                                 mainId,
-                                totalIndex
+                                totalIndex,
+                                null
                             )
 
                         val season = ep.seasonIndex ?: 0
@@ -2322,6 +2324,7 @@ class ResultViewModel2 : ViewModel() {
                         null,
                         loadResponse.type,
                         mainId,
+                        null,
                         null
                     )
                 )
@@ -2345,6 +2348,7 @@ class ResultViewModel2 : ViewModel() {
                         null,
                         loadResponse.type,
                         mainId,
+                        null,
                         null
                     )
                 )
@@ -2368,6 +2372,7 @@ class ResultViewModel2 : ViewModel() {
                         null,
                         loadResponse.type,
                         mainId,
+                        null,
                         null
                     )
                 )
@@ -2454,7 +2459,28 @@ class ResultViewModel2 : ViewModel() {
             )
         }
 
+        restoreSeasonAndRange(resume)
+
         return ResumeWatchingStatus(progress = progress, isMovie = isMovie, result = episode)
+    }
+
+    private fun restoreSeasonAndRange(resume: VideoDownloadHelper.ResumeWatching) {
+        // restore season based on resume details
+        resume.season?.apply {
+            changeSeason(this)
+        }
+
+        // restore dubStatus based on resume details
+        resume.dubStatus?.apply {
+            changeDubStatus(this)
+        }
+
+        // restore range based on resume details
+        currentRanges[currentIndex]?.first {
+            it.endEpisode >= (resume.episode ?: 0)
+        }?.apply {
+            changeRange(this)
+        }
     }
 
     private fun loadTrailers(loadResponse: LoadResponse) = ioSafe {

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/DataStoreHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/DataStoreHelper.kt
@@ -360,6 +360,7 @@ object DataStoreHelper {
                     null,
                     it.episode,
                     it.season,
+                    it.dubStatus,
                     it.isFromDownload,
                     it.updateTime
                 )
@@ -374,6 +375,7 @@ object DataStoreHelper {
         episodeId: Int?,
         episode: Int?,
         season: Int?,
+        dubStatus: DubStatus? = null,
         isFromDownload: Boolean = false,
         updateTime: Long? = null,
     ) {
@@ -386,6 +388,7 @@ object DataStoreHelper {
                 episodeId,
                 episode,
                 season,
+                dubStatus,
                 updateTime ?: System.currentTimeMillis(),
                 isFromDownload
             )

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadHelper.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3.utils
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.lagradost.cloudstream3.DubStatus
 import com.lagradost.cloudstream3.TvType
 object VideoDownloadHelper {
     data class DownloadEpisodeCached(
@@ -30,6 +31,7 @@ object VideoDownloadHelper {
         @JsonProperty("episodeId") val episodeId: Int?,
         @JsonProperty("episode") val episode: Int?,
         @JsonProperty("season") val season: Int?,
+        @JsonProperty("dubStatus") val dubStatus: DubStatus?,
         @JsonProperty("updateTime") val updateTime: Long,
         @JsonProperty("isFromDownload") val isFromDownload: Boolean,
     )


### PR DESCRIPTION
fix: changes basically shows the correct season, range and dub status based on the resume details

pls do review.

when resumeMeta will be ExtractorUri?
```
is ExtractorUri -> {
                    DataStoreHelper.setLastWatched(
```
**app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt**

**Movie**
![image](https://github.com/recloudstream/cloudstream/assets/153119899/bac43c8f-41d1-41f8-b923-cd1d8732bafc)
**Anime**
![image](https://github.com/recloudstream/cloudstream/assets/153119899/3ac4e9bc-1a5f-42ae-862a-307b48011f0f)
**TV**
![image](https://github.com/recloudstream/cloudstream/assets/153119899/4b210246-7493-4e48-915c-c13df6499c27)

