### PR TITLE
refactor (library search): sort and query current page only and delay search when typing

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
@@ -148,6 +148,11 @@ class LibraryFragment : Fragment() {
         activity?.theme?.resolveAttribute(android.R.attr.textColor, searchExitIconColor, true)
         searchExitIcon?.setColorFilter(searchExitIconColor.data)
 
+        val searchCallback = Runnable {
+            val newText = binding?.mainSearch?.query?.toString() ?: return@Runnable
+            libraryViewModel.sort(ListSorting.Query, newText)
+        }
+
         binding?.mainSearch?.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
                 libraryViewModel.sort(ListSorting.Query, query)
@@ -164,15 +169,11 @@ class LibraryFragment : Fragment() {
                     return true
                 }
 
-                val callback = Runnable {
-                    libraryViewModel.sort(ListSorting.Query, newText)
-                }
-
-                binding?.mainSearch?.removeCallbacks(callback)
+                binding?.mainSearch?.removeCallbacks(searchCallback)
 
                 // Delay the execution of the search operation by 1 second (adjust as needed)
                 // this prevents running search when the user is typing
-                binding?.mainSearch?.postDelayed(callback, 1000)
+                binding?.mainSearch?.postDelayed(searchCallback, 1000)
 
                 return true
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.lagradost.cloudstream3.APIHolder
 import com.lagradost.cloudstream3.APIHolder.allProviders
@@ -163,7 +164,16 @@ class LibraryFragment : Fragment() {
                     return true
                 }
 
-                libraryViewModel.sort(ListSorting.Query, newText)
+                val callback = Runnable {
+                    libraryViewModel.sort(ListSorting.Query, newText)
+                }
+
+                binding?.mainSearch?.removeCallbacks(callback)
+
+                // Delay the execution of the search operation by 0.5 second (adjust as needed)
+                // this prevents running search when the user is typing
+                binding?.mainSearch?.postDelayed(callback, 1000)
+
                 return true
             }
         })
@@ -450,6 +460,14 @@ class LibraryFragment : Fragment() {
                                 binding?.searchBar?.setExpanded(true)
                             }
                         }.attach()
+
+                        binding?.libraryTabLayout?.addOnTabSelectedListener(object: TabLayout.OnTabSelectedListener {
+                            override fun onTabSelected(tab: TabLayout.Tab?) {
+                                libraryViewModel.currentPage = binding?.libraryTabLayout?.selectedTabPosition ?:0
+                            }
+                            override fun onTabUnselected(tab: TabLayout.Tab?) {}
+                            override fun onTabReselected(tab: TabLayout.Tab?) {}
+                        })
 
                     }
                 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
@@ -170,7 +170,7 @@ class LibraryFragment : Fragment() {
 
                 binding?.mainSearch?.removeCallbacks(callback)
 
-                // Delay the execution of the search operation by 0.5 second (adjust as needed)
+                // Delay the execution of the search operation by 1 second (adjust as needed)
                 // this prevents running search when the user is typing
                 binding?.mainSearch?.postDelayed(callback, 1000)
 


### PR DESCRIPTION
Fix: In library, sort and query current page only and delay search for 500ms when user is typing.

Note: I have used snippets from codeium AI to add delay. So the approach maybe incorrect. Pls review.