### PR TITLE
refactor (search filter) : syncing main tytype chips and bottom dialog tytype chips

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
@@ -315,30 +315,27 @@ class SearchFragment : Fragment() {
                         arrayAdapter.notifyDataSetChanged()
                     }
 
-                    val selectedSearchTypesFromDialog = DataStoreHelper.searchPreferenceTags
+                    bindChips(
+                        selectMainpageBinding.tvtypesChipsScroll.tvtypesChips,
+                        selectedSearchTypes,
+                        validAPIs.flatMap { api -> api.supportedTypes }.distinct()
+                    ) { list ->
+                        updateList(list)
 
-                    context?.filterProviderByPreferredMedia()?.let { validAPIs ->
-                        bindChips(
-                            selectMainpageBinding.tvtypesChipsScroll.tvtypesChips,
-                            selectedSearchTypesFromDialog,
-                            validAPIs.flatMap { api -> api.supportedTypes }.distinct()
-                        ) { list ->
-                            updateList(list)
-
-                            // refresh selected chips in main chips
-                            if (selectedSearchTypes.toSet() != list.toSet()) {
-                                selectedSearchTypes.clear()
-                                selectedSearchTypes.addAll(list)
-                                bindChips(
-                                    binding?.tvtypesChipsScroll?.tvtypesChips,
-                                    selectedSearchTypes,
-                                    validAPIs.flatMap { api -> api.supportedTypes }.distinct()
-                                ) { // This already handled in another bindChips. Do nothing here! }
-                                }
-
+                        // refresh selected chips in main chips
+                        if (selectedSearchTypes.toSet() != list.toSet()) {
+                            selectedSearchTypes.clear()
+                            selectedSearchTypes.addAll(list)
+                            bindChips(
+                                binding?.tvtypesChipsScroll?.tvtypesChips,
+                                selectedSearchTypes,
+                                validAPIs.flatMap { api -> api.supportedTypes }.distinct()
+                            ) { // This already handled in another bindChips. Do nothing here! }
                             }
+
                         }
                     }
+
 
                     cancelBtt?.setOnClickListener {
                         dialog.dismissSafe()
@@ -362,7 +359,7 @@ class SearchFragment : Fragment() {
                         // run search when dialog is close
                         search(binding?.mainSearch?.query?.toString())
                     }
-                    updateList(selectedSearchTypesFromDialog.toList())
+                    updateList(selectedSearchTypes.toList())
                 }
             }
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
@@ -330,7 +330,8 @@ class SearchFragment : Fragment() {
                                 binding?.tvtypesChipsScroll?.tvtypesChips,
                                 selectedSearchTypes,
                                 validAPIs.flatMap { api -> api.supportedTypes }.distinct()
-                            ) { // This already handled in another bindChips. Do nothing here! }
+                            ) {
+                                // This already handled in another bindChips. Do nothing here!
                             }
 
                         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
@@ -326,13 +326,7 @@ class SearchFragment : Fragment() {
                         if (selectedSearchTypes.toSet() != list.toSet()) {
                             selectedSearchTypes.clear()
                             selectedSearchTypes.addAll(list)
-                            bindChips(
-                                binding?.tvtypesChipsScroll?.tvtypesChips,
-                                selectedSearchTypes,
-                                validAPIs.flatMap { api -> api.supportedTypes }.distinct()
-                            ) {
-                                // This already handled in another bindChips. Do nothing here!
-                            }
+                            updateChips(binding?.tvtypesChipsScroll?.tvtypesChips, selectedSearchTypes)
 
                         }
                     }


### PR DESCRIPTION
changes applicable to search page.

- and run search when bottom dialog for provider filter closes <- should this be on dialog close or selecting tytype chips in dialog?

![image](https://github.com/recloudstream/cloudstream/assets/118901131/4eb2933b-3a33-4002-8695-f198ec492f79)
