### PR TITLE
PluginManager: uncomment setReadOnly for Android 14

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
@@ -477,13 +477,13 @@ object PluginManager {
         Log.i(TAG, "Loading plugin: $data")
 
         return try {
-            /* in case of android 14 then
+            // in case of android 14 then
             try {
                 File(filePath).setReadOnly()
-            } catch (t : Throwable) {
+            } catch (t: Throwable) {
                 Log.e(TAG, "Failed to set dex as readonly")
                 logError(t)
-            }*/
+            }
 
             val loader = PathClassLoader(filePath, context.classLoader)
             var manifest: Plugin.Manifest


### PR DESCRIPTION
Should allow us to eventually set targetSdk to version 34 to support DCL, but I'm not sure if we need to bump that just yet, but eventually probably should, especially since Android 14 has been the most recent stable release for a little while now.