### PR TITLE
feat: show the episodic range popup with current selection checked

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
@@ -247,6 +247,7 @@ open class ResultFragmentPhone : FullScreenPlayer() {
     }
 
     var selectSeason: String? = null
+    var selectEpisodeRange: String? = null
 
     private fun setUrl(url: String?) {
         if (url == null) {
@@ -1027,6 +1028,8 @@ open class ResultFragmentPhone : FullScreenPlayer() {
         observeNullable(viewModel.selectedRange) { range ->
             resultBinding?.apply {
                 resultEpisodeSelect.setText(range)
+
+                selectEpisodeRange = range?.asStringNull(resultEpisodeSelect.context)
                 // If Season button is invisible then the bookmark button next focus is episode select
                 if (resultEpisodeSelect.isVisible && !resultSeasonButton.isVisible && resultResumeParent.isVisible) {
                     setFocusUpAndDown(resultResumeSeriesButton, resultEpisodeSelect)
@@ -1060,9 +1063,12 @@ open class ResultFragmentPhone : FullScreenPlayer() {
                             r to (text?.asStringNull(ctx) ?: return@mapNotNull null)
                         }
 
-                    view.popupMenuNoIconsAndNoStringRes(names.mapIndexed { index, (_, name) ->
-                        index to name
-                    }) {
+                    activity?.showDialog(
+                        names.map { it.second },
+                        names.indexOfFirst { it.second == selectEpisodeRange },
+                        "",
+                        false,
+                        {}) { itemId ->
                         viewModel.changeRange(names[itemId].first)
                     }
                 }


### PR DESCRIPTION
before
![image](https://github.com/recloudstream/cloudstream/assets/118901131/f1a770b8-0508-48ee-9469-74c95bbb60a0)

now
![image](https://github.com/recloudstream/cloudstream/assets/118901131/1122b732-fba2-46a2-bbfb-bae1addb672c)
