### PR TITLE
Revert the repo change to get keys

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/Vidplay.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/Vidplay.kt
@@ -10,8 +10,8 @@ import com.lagradost.cloudstream3.utils.M3u8Helper
 import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
 
-// Code found in https://github.com/blacksourcellc/vid_keys
-// special credits to @blacksourcellc for providing key
+// Code found in https://github.com/Claudemirovsky/worstsource-keys
+// special credits to @Claudemirovsky for providing key
 
 class MyCloud : Vidplay() {
     override val name = "MyCloud"
@@ -27,7 +27,7 @@ open class Vidplay : ExtractorApi() {
     override val mainUrl = "https://vidplay.site"
     override val requiresReferer = true
     open val key =
-        "https://raw.githubusercontent.com/blacksourcellc/vid_keys/keys/keys.json"
+        "https://raw.githubusercontent.com/Claudemirovsky/worstsource-keys/keys/keys.json"
 
     override suspend fun getUrl(
         url: String,


### PR DESCRIPTION
The repo isn't updated, and old repo has started the key build again so now the old key works again. Vidplay doesn't work with new key currently,  and I haven't updated the app to the new key so I can use the old key. Reason I know old key broke is from the debug app. Here is some screenshots, the debug I'm using was from the PR that changed the key repo and was previously working earlier. The beta is before the new key repo merge

![Screenshot_20240110_154112_CloudStream Debug](https://github.com/recloudstream/cloudstream/assets/87155550/10d0d74d-e00d-465d-85b3-ca4a2ad008d9)
![Screenshot_20240110_154116_One UI Home](https://github.com/recloudstream/cloudstream/assets/87155550/bf1c700a-a8f5-4d56-bf30-fd6db2887340)
![Screenshot_20240110_154221_CloudStream Beta](https://github.com/recloudstream/cloudstream/assets/87155550/298e5e26-1c18-482c-8d71-d8feab342db8)
![Screenshot_20240110_154227_One UI Home](https://github.com/recloudstream/cloudstream/assets/87155550/6b31459c-1245-4065-9a0a-bf4b7d2a31fa)
