### PR TITLE
Fix crash on plugin reload

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/Event.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/Event.kt
@@ -1,9 +1,13 @@
 package com.lagradost.cloudstream3.utils
 
+import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
 class Event<T> {
     private val observers = mutableSetOf<(T) -> Unit>()
 
-    val size : Int get() = observers.size
+    val size: Int get() = observers.size
 
     operator fun plusAssign(observer: (T) -> Unit) {
         observers.add(observer)
@@ -13,8 +17,14 @@ class Event<T> {
         observers.remove(observer)
     }
 
+    private val invokeMutex = Mutex()
+
     operator fun invoke(value: T) {
-        for (observer in observers)
-            observer(value)
+        ioSafe {
+            invokeMutex.withLock { // Can crash otherwise
+                for (observer in observers)
+                    observer(value)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/Event.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/Event.kt
@@ -1,30 +1,26 @@
 package com.lagradost.cloudstream3.utils
 
-import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-
 class Event<T> {
     private val observers = mutableSetOf<(T) -> Unit>()
 
     val size: Int get() = observers.size
 
     operator fun plusAssign(observer: (T) -> Unit) {
-        observers.add(observer)
+        synchronized(observers) {
+            observers.add(observer)
+        }
     }
 
     operator fun minusAssign(observer: (T) -> Unit) {
-        observers.remove(observer)
+        synchronized(observers) {
+            observers.remove(observer)
+        }
     }
 
-    private val invokeMutex = Mutex()
-
     operator fun invoke(value: T) {
-        ioSafe {
-            invokeMutex.withLock { // Can crash otherwise
-                for (observer in observers)
-                    observer(value)
-            }
+        synchronized(observers) {
+            for (observer in observers)
+                observer(value)
         }
     }
 }


### PR DESCRIPTION
The patch fixes this error:
```java
Process: com.lagradost.cloudstream3.prerelease.debug, PID: 13521
java.util.ConcurrentModificationException
at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:760)
at java.util.LinkedHashMap$LinkedKeyIterator.next(LinkedHashMap.java:782)
at com.lagradost.cloudstream3.utils.Event.invoke(Event.kt:25)
at com.lagradost.cloudstream3.plugins.PluginManager.loadAllLocalPlugins(PluginManager.kt:452)
at com.lagradost.cloudstream3.plugins.PluginManager.hotReloadAllLocalPlugins(PluginManager.kt:423)
at com.lagradost.cloudstream3.MainActivity$Companion.handleAppIntentUrl(MainActivity.kt:377)
at com.lagradost.cloudstream3.MainActivity.handleAppIntent(MainActivity.kt:696)
at com.lagradost.cloudstream3.MainActivity.onNewIntent(MainActivity.kt:688)
at android.app.Activity.performNewIntent(Activity.java:8321)
at android.app.Instrumentation.callActivityOnNewIntent(Instrumentation.java:1517)
at android.app.Instrumentation.callActivityOnNewIntent(Instrumentation.java:1530)
at android.app.ActivityThread.deliverNewIntents(ActivityThread.java:3822)
at android.app.ActivityThread.handleNewIntent(ActivityThread.java:3829)
at android.app.servertransaction.NewIntentItem.execute(NewIntentItem.java:56)
at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2307)
at android.os.Handler.dispatchMessage(Handler.java:106)
at android.os.Looper.loopOnce(Looper.java:201)
at android.os.Looper.loop(Looper.java:288)
at android.app.ActivityThread.main(ActivityThread.java:7872)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```
Caused by modifying observers when iterating over them. This happens often when using deployWithAdb, which reloads all plugins.