### PR TITLE
Make Rating non-focusable (Old TV API)

### DIFF
--- a/app/src/main/res/layout/fragment_result_tv.xml
+++ b/app/src/main/res/layout/fragment_result_tv.xml
@@ -399,6 +399,7 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
                             android:id="@+id/result_meta_content_rating"
                             android:layout_gravity="center_vertical"
                             style="@style/SmallWhiteButton"
+                            android:focusable="false"
                             tools:text="PG-13" />
 
                         <TextView


### PR DESCRIPTION
On old TV API versions, Rating is focusable which is not needed.