### PR TITLE
[TV] Limit Homepage Header Description to 3 lines & 6 Tags

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
@@ -317,7 +317,7 @@ class HomeParentItemAdapterPreview(
                 homePreviewText.text = item.name
                 populateChips(
                     homePreviewTags,
-                    item.tags ?: emptyList(),
+                    item.tags?.take(6) ?: emptyList(),
                     R.style.ChipFilledSemiTransparent
                 )
 

--- a/app/src/main/res/layout/fragment_home_head_tv.xml
+++ b/app/src/main/res/layout/fragment_home_head_tv.xml
@@ -137,7 +137,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
-                android:maxLines="5"
+                android:maxLines="3"
                 android:paddingBottom="5dp"
                 android:textSize="15sp"
                 tools:text="very nice tv series" />


### PR DESCRIPTION
Make Homepage header cleaner, on result page you can check full description & tags.