### PR TITLE
[TV] More space around description on Result page

### DIFF
--- a/app/src/main/res/layout/fragment_result_tv.xml
+++ b/app/src/main/res/layout/fragment_result_tv.xml
@@ -387,6 +387,7 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
                     <com.lagradost.cloudstream3.widget.FlowLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginBottom="5dp"
                         app:itemSpacing="10dp">
 
                         <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
![ResultDescritopn](https://github.com/recloudstream/cloudstream/assets/17493070/97cba7d6-961e-4f06-80fa-942bc836514f)
