### PR TITLE
Fix nonTransferableKeys in BackupUtils

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
@@ -68,7 +68,7 @@ object BackupUtils {
 
         DOWNLOAD_EPISODE_CACHE,
 
-        "biometric_key" // can lock down users if backup is shared on a incompatible device
+        "biometric_key", // can lock down users if backup is shared on a incompatible device
         "nginx_user", // Nginx user key
     )
 

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
@@ -65,13 +65,16 @@ object BackupUtils {
         PLUGINS_KEY_LOCAL,
 
         OPEN_SUBTITLES_USER_KEY,
-        "nginx_user", // Nginx user key
+
+        DOWNLOAD_EPISODE_CACHE,
+
         "biometric_key" // can lock down users if backup is shared on a incompatible device
+        "nginx_user", // Nginx user key
     )
 
-    /** false if blacklisted key */
+    /** false if key should not be contained in backup */
     private fun String.isTransferable(): Boolean {
-        return !nonTransferableKeys.contains(this)
+        return !nonTransferableKeys.any { this.contains(it) }
     }
 
     private var restoreFileSelector: ActivityResultLauncher<Array<String>>? = null

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
@@ -69,7 +69,7 @@ object BackupUtils {
         DOWNLOAD_EPISODE_CACHE,
 
         "biometric_key", // can lock down users if backup is shared on a incompatible device
-        "nginx_user", // Nginx user key
+        "nginx_user" // Nginx user key
     )
 
     /** false if key should not be contained in backup */


### PR DESCRIPTION
This applies a change from #623 to fix this.

Per https://github.com/recloudstream/cloudstream/issues/969#issuecomment-1986977976

Fixes #744