### PR TITLE
feat(ui): authenticate first when enabling security settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,7 +154,7 @@ repositories {
 dependencies {
     // Testing
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.json:json:20231013")
+    testImplementation("org.json:json:20240303")
     androidTestImplementation("androidx.test:core")
     implementation("androidx.test.ext:junit-ktx:1.1.5")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
@@ -163,10 +163,10 @@ dependencies {
     // Android Core & Lifecycle
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.navigation:navigation-ui-ktx:2.7.6")
+    implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.7.6")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
 
     // Design & UI
     implementation("jp.wasabeef:glide-transformations:4.3.0")

--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3
 
 import android.animation.ValueAnimator
+import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -62,9 +63,11 @@ import com.lagradost.cloudstream3.APIHolder.apis
 import com.lagradost.cloudstream3.APIHolder.getApiDubstatusSettings
 import com.lagradost.cloudstream3.APIHolder.initAll
 import com.lagradost.cloudstream3.APIHolder.updateHasTrailers
+import com.lagradost.cloudstream3.AcraApplication.Companion.context
 import com.lagradost.cloudstream3.AcraApplication.Companion.getKey
 import com.lagradost.cloudstream3.AcraApplication.Companion.removeKey
 import com.lagradost.cloudstream3.AcraApplication.Companion.setKey
+import com.lagradost.cloudstream3.CommonActivity.activity
 import com.lagradost.cloudstream3.CommonActivity.loadThemes
 import com.lagradost.cloudstream3.CommonActivity.onColorSelectedEvent
 import com.lagradost.cloudstream3.CommonActivity.onDialogDismissedEvent
@@ -135,6 +138,7 @@ import com.lagradost.cloudstream3.utils.BackupUtils.backup
 import com.lagradost.cloudstream3.utils.BackupUtils.setUpBackup
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.deviceHasPasswordPinLock
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.isAuthEnabled
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.startBiometricAuthentication
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.Coroutines.main
@@ -1226,10 +1230,9 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricAu
         changeStatusBarState(isEmulatorSettings())
 
         /** Biometric stuff for users without accounts **/
-        val authEnabled = settingsManager.getBoolean(getString(R.string.biometric_key), false)
         val noAccounts = settingsManager.getBoolean(getString(R.string.skip_startup_account_select_key), false) || accounts.count() <= 1
 
-        if (isTruePhone() && authEnabled && noAccounts) {
+        if (isTruePhone() && isAuthEnabled(this) && noAccounts) {
             if (deviceHasPasswordPinLock(this)) {
                 startBiometricAuthentication(this, R.string.biometric_authentication_title, false)
 
@@ -1787,6 +1790,14 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricAu
         binding?.navHostFragment?.isInvisible = false
     }
 
+    override fun onAuthenticationError() {
+        try {
+            finish()
+        }
+        catch (e:Exception) {
+            print(e)
+        }
+    }
     private var backPressedCallback: OnBackPressedCallback? = null
 
     private fun attachBackPressedCallback() {

--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.lagradost.cloudstream3
 
 import android.animation.ValueAnimator
-import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -63,11 +62,9 @@ import com.lagradost.cloudstream3.APIHolder.apis
 import com.lagradost.cloudstream3.APIHolder.getApiDubstatusSettings
 import com.lagradost.cloudstream3.APIHolder.initAll
 import com.lagradost.cloudstream3.APIHolder.updateHasTrailers
-import com.lagradost.cloudstream3.AcraApplication.Companion.context
 import com.lagradost.cloudstream3.AcraApplication.Companion.getKey
 import com.lagradost.cloudstream3.AcraApplication.Companion.removeKey
 import com.lagradost.cloudstream3.AcraApplication.Companion.setKey
-import com.lagradost.cloudstream3.CommonActivity.activity
 import com.lagradost.cloudstream3.CommonActivity.loadThemes
 import com.lagradost.cloudstream3.CommonActivity.onColorSelectedEvent
 import com.lagradost.cloudstream3.CommonActivity.onDialogDismissedEvent
@@ -137,8 +134,10 @@ import com.lagradost.cloudstream3.utils.AppUtils.setDefaultFocus
 import com.lagradost.cloudstream3.utils.BackupUtils.backup
 import com.lagradost.cloudstream3.utils.BackupUtils.setUpBackup
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.biometricPrompt
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.deviceHasPasswordPinLock
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.isAuthEnabled
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.promptInfo
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.startBiometricAuthentication
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.Coroutines.main
@@ -1236,8 +1235,8 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricAu
             if (deviceHasPasswordPinLock(this)) {
                 startBiometricAuthentication(this, R.string.biometric_authentication_title, false)
 
-                BiometricAuthenticator.promptInfo?.let {
-                    BiometricAuthenticator.biometricPrompt?.authenticate(it)
+                promptInfo?.let {
+                    biometricPrompt?.authenticate(it)
                 }
 
                 // hide background while authenticating, Sorry moms & dads 🙏
@@ -1791,13 +1790,9 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricAu
     }
 
     override fun onAuthenticationError() {
-        try {
             finish()
-        }
-        catch (e:Exception) {
-            print(e)
-        }
     }
+
     private var backPressedCallback: OnBackPressedCallback? = null
 
     private fun attachBackPressedCallback() {

--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1234,8 +1234,6 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener,
         changeStatusBarState(isLayout(EMULATOR))
 
         /** Biometric stuff for users without accounts **/
-        val noAccounts = settingsManager.getBoolean(getString(R.string.skip_startup_account_select_key), false) || accounts.count() <= 1
-        val authEnabled = settingsManager.getBoolean(getString(R.string.biometric_key), false)
         val noAccounts = settingsManager.getBoolean(
             getString(R.string.skip_startup_account_select_key),
             false
@@ -1245,8 +1243,8 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener,
             if (deviceHasPasswordPinLock(this)) {
                 startBiometricAuthentication(this, R.string.biometric_authentication_title, false)
 
-                BiometricAuthenticator.promptInfo?.let { promt ->
-                    BiometricAuthenticator.biometricPrompt?.authenticate(promt)
+                promptInfo?.let { prompt ->
+                    biometricPrompt?.authenticate(prompt)
                 }
 
                 // hide background while authenticating, Sorry moms & dads 🙏

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountSelectActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountSelectActivity.kt
@@ -23,8 +23,10 @@ import com.lagradost.cloudstream3.ui.settings.Globals.PHONE
 import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.biometricPrompt
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.deviceHasPasswordPinLock
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.isAuthEnabled
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.promptInfo
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.startBiometricAuthentication
 import com.lagradost.cloudstream3.utils.DataStoreHelper.accounts
 import com.lagradost.cloudstream3.utils.DataStoreHelper.selectedKeyIndex
@@ -64,8 +66,8 @@ class AccountSelectActivity : AppCompatActivity(), BiometricAuthenticator.Biomet
                         false
                     )
 
-                    BiometricAuthenticator.promptInfo?.let { prompt ->
-                        BiometricAuthenticator.biometricPrompt?.authenticate(prompt)
+                    promptInfo?.let { prompt ->
+                        biometricPrompt?.authenticate(prompt)
                     }
                 }
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountSelectActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountSelectActivity.kt
@@ -22,6 +22,7 @@ import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.isTrueP
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.isTvSettings
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.deviceHasPasswordPinLock
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.isAuthEnabled
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.startBiometricAuthentication
 import com.lagradost.cloudstream3.utils.DataStoreHelper.accounts
 import com.lagradost.cloudstream3.utils.DataStoreHelper.selectedKeyIndex
@@ -46,7 +47,6 @@ class AccountSelectActivity : AppCompatActivity(), BiometricAuthenticator.Biomet
         )
 
         val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
-        val authEnabled = settingsManager.getBoolean(getString(R.string.biometric_key), false)
         val skipStartup = settingsManager.getBoolean(getString(R.string.skip_startup_account_select_key), false
         ) || accounts.count() <= 1
 
@@ -54,7 +54,7 @@ class AccountSelectActivity : AppCompatActivity(), BiometricAuthenticator.Biomet
 
         fun askBiometricAuth() {
 
-            if (isTruePhone() && authEnabled) {
+            if (isTruePhone() && isAuthEnabled(this)) {
                 if (deviceHasPasswordPinLock(this)) {
                     startBiometricAuthentication(
                         this,
@@ -186,5 +186,9 @@ class AccountSelectActivity : AppCompatActivity(), BiometricAuthenticator.Biomet
 
     override fun onAuthenticationSuccess() {
        Log.i(BiometricAuthenticator.TAG,"Authentication successful in AccountSelectActivity")
+    }
+
+    override fun onAuthenticationError() {
+        finish()
     }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountSelectActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountSelectActivity.kt
@@ -64,8 +64,8 @@ class AccountSelectActivity : AppCompatActivity(), BiometricAuthenticator.Biomet
                         false
                     )
 
-                    BiometricAuthenticator.promptInfo?.let { promt ->
-                        BiometricAuthenticator.biometricPrompt?.authenticate(promt)
+                    BiometricAuthenticator.promptInfo?.let { prompt ->
+                        BiometricAuthenticator.biometricPrompt?.authenticate(prompt)
                     }
                 }
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
@@ -39,14 +39,19 @@ import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setUpTo
 import com.lagradost.cloudstream3.utils.AppUtils.html
 import com.lagradost.cloudstream3.utils.BackupUtils
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.authCallback
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.biometricPrompt
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.deviceHasPasswordPinLock
 import com.lagradost.cloudstream3.utils.BiometricAuthenticator.isAuthEnabled
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.promptInfo
+import com.lagradost.cloudstream3.utils.BiometricAuthenticator.startBiometricAuthentication
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.SingleSelectionHelper.showBottomDialogText
 import com.lagradost.cloudstream3.utils.UIHelper.dismissSafe
 import com.lagradost.cloudstream3.utils.UIHelper.hideKeyboard
 import com.lagradost.cloudstream3.utils.UIHelper.setImage
 
-class SettingsAccount : PreferenceFragmentCompat(),BiometricAuthenticator.BiometricAuthCallback {
+class SettingsAccount : PreferenceFragmentCompat(), BiometricAuthenticator.BiometricAuthCallback {
     companion object {
         /** Used by nginx plugin too */
         fun showLoginInfo(
@@ -297,15 +302,15 @@ class SettingsAccount : PreferenceFragmentCompat(),BiometricAuthenticator.Biomet
         getPref(R.string.biometric_key)?.setOnPreferenceClickListener {
             val ctx = context ?: return@setOnPreferenceClickListener false
 
-            if (BiometricAuthenticator.deviceHasPasswordPinLock(ctx)) {
-                BiometricAuthenticator.startBiometricAuthentication(
-                        activity?: requireActivity(),
-                        R.string.biometric_authentication_title,
+            if (deviceHasPasswordPinLock(ctx)) {
+                startBiometricAuthentication(
+                    activity?: requireActivity(),
+                    R.string.biometric_authentication_title,
                         false
                     )
-                BiometricAuthenticator.promptInfo?.let {
-                    BiometricAuthenticator.authCallback = this
-                    BiometricAuthenticator.biometricPrompt?.authenticate(it)
+                promptInfo?.let {
+                    authCallback = this
+                    biometricPrompt?.authenticate(it)
                 }
             }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
@@ -31,6 +31,7 @@ import com.lagradost.cloudstream3.syncproviders.AuthAPI
 import com.lagradost.cloudstream3.syncproviders.InAppAuthAPI
 import com.lagradost.cloudstream3.syncproviders.OAuth2API
 import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
+import com.lagradost.cloudstream3.ui.settings.Globals.PHONE
 import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.getPref
@@ -296,7 +297,7 @@ class SettingsAccount : PreferenceFragmentCompat(), BiometricAuthenticator.Biome
         hideKeyboard()
         setPreferencesFromResource(R.xml.settings_account, rootKey)
         // hide preference on tvs and emulators
-        if (!isTruePhone()) {
+        if (!isLayout(PHONE)) {
             getPref(R.string.biometric_key)?.isVisible = false
         }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
@@ -298,7 +298,7 @@ class SettingsAccount : PreferenceFragmentCompat(), BiometricAuthenticator.Biome
         setPreferencesFromResource(R.xml.settings_account, rootKey)
         // hide preference on tvs and emulators
         if (!isLayout(PHONE)) {
-            getPref(R.string.biometric_key)?.isVisible = false
+            getPref(R.string.biometric_key)?.isEnabled = false
         }
 
         getPref(R.string.biometric_key)?.setOnPreferenceClickListener {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
@@ -264,13 +264,13 @@ class SettingsAccount : PreferenceFragmentCompat(), BiometricAuthenticator.Biome
     private fun updateAuthPreference(enabled: Boolean) {
         val biometricKey = getString(R.string.biometric_key)
 
-        PreferenceManager.getDefaultSharedPreferences(context ?: requireContext()).edit()
+        PreferenceManager.getDefaultSharedPreferences(context ?: return).edit()
             .putBoolean(biometricKey, enabled).apply()
         findPreference<SwitchPreferenceCompat>(biometricKey)?.isChecked = enabled
     }
 
     override fun onAuthenticationError() {
-        updateAuthPreference(!isAuthEnabled(context ?: requireContext()))
+        updateAuthPreference(!isAuthEnabled(context ?: return))
     }
 
     override fun onAuthenticationSuccess() {
@@ -296,19 +296,18 @@ class SettingsAccount : PreferenceFragmentCompat(), BiometricAuthenticator.Biome
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         hideKeyboard()
         setPreferencesFromResource(R.xml.settings_account, rootKey)
+
         // hide preference on tvs and emulators
-        if (!isLayout(PHONE)) {
-            getPref(R.string.biometric_key)?.isEnabled = false
-        }
+        getPref(R.string.biometric_key)?.isEnabled = isLayout(PHONE)
 
         getPref(R.string.biometric_key)?.setOnPreferenceClickListener {
             val ctx = context ?: return@setOnPreferenceClickListener false
 
             if (deviceHasPasswordPinLock(ctx)) {
                 startBiometricAuthentication(
-                    activity?: requireActivity(),
+                    activity?: return@setOnPreferenceClickListener false,
                     R.string.biometric_authentication_title,
-                        false
+                    false
                     )
                 promptInfo?.let {
                     authCallback = this

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/BiometricAuthenticator.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/BiometricAuthenticator.kt
@@ -20,13 +20,12 @@ import com.lagradost.cloudstream3.R
 
 object BiometricAuthenticator {
 
+    const val TAG = "cs3Auth"
     private const val MAX_FAILED_ATTEMPTS = 3
     private var failedAttempts = 0
-    const val TAG = "cs3Auth"
     private var biometricManager: BiometricManager? = null
     var biometricPrompt: BiometricPrompt? = null
     var promptInfo: BiometricPrompt.PromptInfo? = null
-
     var authCallback: BiometricAuthCallback? = null // listen to authentication success
 
     private fun initializeBiometrics(activity: Activity) {

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/BiometricAuthenticator.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/BiometricAuthenticator.kt
@@ -37,7 +37,6 @@ object BiometricAuthenticator {
             activity as FragmentActivity,
             executor,
             object : BiometricPrompt.AuthenticationCallback() {
-
                 override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
                     super.onAuthenticationError(errorCode, errString)
                     showToast("$errString")
@@ -82,7 +81,6 @@ object BiometricAuthenticator {
                     .setDescription(description)
                     .setAllowedAuthenticators(authFlag)
                     .build()
-
             } else {
                 // for apis < 30
                 promptInfo = BiometricPrompt.PromptInfo.Builder()
@@ -91,7 +89,6 @@ object BiometricAuthenticator {
                     .setDeviceCredentialAllowed(true)
                     .build()
             }
-
         } else {
             // fallback for A12+ when both fingerprint & Face unlock is absent but PIN is set
             promptInfo = BiometricPrompt.PromptInfo.Builder()
@@ -107,7 +104,6 @@ object BiometricAuthenticator {
         var result = false
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-
             when (biometricManager?.canAuthenticate(
                 DEVICE_CREDENTIAL or BIOMETRIC_STRONG or BIOMETRIC_WEAK
             )) {
@@ -119,7 +115,6 @@ object BiometricAuthenticator {
                 BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED -> result = true
                 BiometricManager.BIOMETRIC_STATUS_UNKNOWN -> result = false
             }
-
         } else {
             @Suppress("DEPRECATION")
             when (biometricManager?.canAuthenticate()) {
@@ -151,7 +146,6 @@ object BiometricAuthenticator {
             authCallback = activity as? BiometricAuthCallback
             authenticationDialog(activity, title, setDeviceCred)
             promptInfo?.let { biometricPrompt?.authenticate(it) }
-
         } else {
             if (deviceHasPasswordPinLock(activity)) {
                 authCallback = activity as? BiometricAuthCallback

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,7 +249,7 @@
     <string name="search">Search</string>
     <string name="library">Library</string>
     <string name="category_account">Accounts and Security</string>
-    <string name="category_updates">Updates and backup</string>
+    <string name="category_updates">Updates and Backup</string>
     <string name="settings_info">Info</string>
     <string name="advanced_search">Advanced Search</string>
     <string name="advanced_search_des">Gives you the search results separated by provider</string>
@@ -611,7 +611,7 @@
     <string name="tracks">Tracks</string>
     <string name="audio_tracks">Audio tracks</string>
     <string name="video_tracks">Video tracks</string>
-    <string name="apply_on_restart">Apply on Restart</string>
+    <string name="apply_on_restart">Restart the app to see changes.</string>
     <string name="restart">Restart</string>
     <string name="stop">Stop</string>
     <string name="safe_mode_title">Safe mode on</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
         google()
@@ -6,12 +5,9 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.2.1")
+        classpath("com.android.tools.build:gradle:8.2.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle.kts files
     }
 }
 
@@ -23,7 +19,7 @@ allprojects {
 }
 
 plugins {
-    id("com.google.devtools.ksp") version "1.9.22-1.0.16" apply false
+    id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
 }
 
 tasks.register<Delete>("clean") {


### PR DESCRIPTION
hide the preference in tvs
authenticate when disabling the settings for more secure reasons
authenticate when enabling to test if device is capable or not (turn on when succceded).