### PR TITLE
fix: extension activity interruption

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
@@ -429,7 +429,6 @@ object PluginManager {
      **/
     fun loadAllLocalPlugins(context: Context, forceReload: Boolean) {
         val dir = File(LOCAL_PLUGINS_PATH)
-        removeKey(PLUGINS_KEY_LOCAL)
 
         if (!dir.exists()) {
             val res = dir.mkdirs()


### PR DESCRIPTION
![Screenshot_2024-03-20-13-50-16-453_com lagradost cloudstream3 prerelease debug_1](https://github.com/recloudstream/cloudstream/assets/164035730/5d3a4f6a-4381-424f-af48-1721156fb773)

Show this activity if only local extension loaded
