### PR TITLE
refactor: improve add new repository dialog & update gradle to 8.7

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/ExtensionsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/ExtensionsFragment.kt
@@ -33,7 +33,7 @@ import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setToolBarScrollFlags
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setUpToolbar
-import com.lagradost.cloudstream3.utils.AppUtils.downloadAllPluginsDialog
+import com.lagradost.cloudstream3.utils.AppUtils.addRepositoryDialog
 import com.lagradost.cloudstream3.utils.AppUtils.setDefaultFocus
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.Coroutines.main
@@ -273,10 +273,7 @@ class ExtensionsFragment : Fragment() {
                         if (plugins.isNullOrEmpty()) {
                             showToast(R.string.no_plugins_found_error, Toast.LENGTH_LONG)
                         } else {
-                            this@ExtensionsFragment.activity?.downloadAllPluginsDialog(
-                                url,
-                                fixedName
-                            )
+                            this@ExtensionsFragment.activity?.addRepositoryDialog(fixedName)
                         }
                     }
                 }

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/AppUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/AppUtils.kt
@@ -62,7 +62,6 @@ import com.lagradost.cloudstream3.syncproviders.providers.Kitsu
 import com.lagradost.cloudstream3.ui.WebviewFragment
 import com.lagradost.cloudstream3.ui.result.ResultFragment
 import com.lagradost.cloudstream3.ui.settings.Globals
-import com.lagradost.cloudstream3.ui.settings.extensions.PluginsViewModel.Companion.downloadAll
 import com.lagradost.cloudstream3.ui.settings.extensions.RepositoryData
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.Coroutines.main
@@ -386,7 +385,7 @@ object AppUtils {
                 )
             }
             afterRepositoryLoadedEvent.invoke(true)
-            downloadAllPluginsDialog(url, repo.name)
+            addRepositoryDialog(repo.name)
         }
     }
 
@@ -429,24 +428,17 @@ object AppUtils {
         }
     }
 
+    fun Activity.addRepositoryDialog(repositoryName: String) {
+        val message = String.format(resources.getString(
+            R.string.download_all_plugins_from_repo), repositoryName)
 
-    fun Activity.downloadAllPluginsDialog(repositoryUrl: String, repositoryName: String) {
         runOnUiThread {
-            val context = this
             val builder: AlertDialog.Builder = AlertDialog.Builder(this)
-            builder.setTitle(
-                repositoryName
-            )
-            builder.setMessage(
-                R.string.download_all_plugins_from_repo
-            )
-            builder.apply {
-                setPositiveButton(R.string.download) { _, _ ->
-                    downloadAll(context, repositoryUrl, null)
-                }
 
-                setNegativeButton(R.string.no) { _, _ -> }
-            }
+            builder.setTitle(repositoryName)
+            builder.setMessage(message)
+            builder.setPositiveButton(R.string.ok, null)
+            builder.setCancelable(false)
             builder.show().setDefaultFocus()
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,7 +606,8 @@
     <string name="view_public_repositories_button">View community repositories</string>
     <string name="view_public_repositories_button_short">Public list</string>
     <string name="uppercase_all_subtitles">Uppercase all subtitles</string>
-    <string name="download_all_plugins_from_repo">Download all plugins from this repository?</string>
+    <string name="download_all_plugins_from_repo">%1$s has been added. You can install you desired extensions from 𝗦𝗲𝘁𝘁𝗶𝗻𝗴𝘀 > 𝗘𝘅𝘁𝗲𝗻𝘀𝗶𝗼𝗻𝘀 > %1$s.
+        CloudStream 3 does not takes any responsibility for using third-party extensions neither provides support for them.</string>
     <string name="single_plugin_disabled" formatted="true">%s (Disabled)</string>
     <string name="tracks">Tracks</string>
     <string name="audio_tracks">Audio tracks</string>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 30 17:11:15 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
no one uses all extensions, plus only few of them work, but users always download all the extensions even disabled one, with current dialog, now we tell them that repo has been added and they can download extensions what they want along with a staturory warning the cs3 doesnt take responsibility of third party extensions as people have been using lots of 3rd party extensions.
tell me if message can be improved, i tried my best 🐯