### PR TITLE
Don't check year when checking duplicates if year is empty

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -1099,13 +1099,14 @@ class ResultViewModel2 : ViewModel() {
 
         val duplicateEntries = data.filter { it: DataStoreHelper.LibrarySearchResponse ->
             val librarySyncData = it.syncData
+            val yearCheck = year == it.year || year == null || it.year == null
 
             val checks = listOf(
                 { imdbId != null && getImdbIdFromSyncData(librarySyncData) == imdbId },
                 { tmdbId != null && getTMDbIdFromSyncData(librarySyncData) == tmdbId },
                 { malId != null && librarySyncData?.get(AccountManager.malApi.idPrefix) == malId },
                 { aniListId != null && librarySyncData?.get(AccountManager.aniListApi.idPrefix) == aniListId },
-                { normalizedName == normalizeString(it.name) && year == it.year }
+                { normalizedName == normalizeString(it.name) && yearCheck }
             )
 
             checks.any { it() }


### PR DESCRIPTION
Some sources don't use year which makes this not match when it really should match