### PR TITLE
feat(ui): Fix downloads focus on TV

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
@@ -15,6 +15,7 @@ import com.lagradost.cloudstream3.utils.Coroutines.main
 import com.lagradost.cloudstream3.utils.DataStore.getKey
 import com.lagradost.cloudstream3.utils.DataStore.getKeys
 import com.lagradost.cloudstream3.utils.UIHelper.fixPaddingStatusbar
+import com.lagradost.cloudstream3.utils.UIHelper.setAppBarNoScrollFlagsOnTV
 import com.lagradost.cloudstream3.utils.VideoDownloadHelper
 import com.lagradost.cloudstream3.utils.VideoDownloadManager
 import kotlinx.coroutines.Dispatchers
@@ -89,8 +90,8 @@ class DownloadChildFragment : Fragment() {
             setNavigationOnClickListener {
                 activity?.onBackPressedDispatcher?.onBackPressed()
             }
+            setAppBarNoScrollFlagsOnTV()
         }
-
 
         val adapter: RecyclerView.Adapter<RecyclerView.ViewHolder> =
             DownloadChildAdapter(

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
@@ -41,6 +41,7 @@ import com.lagradost.cloudstream3.utils.UIHelper.dismissSafe
 import com.lagradost.cloudstream3.utils.UIHelper.fixPaddingStatusbar
 import com.lagradost.cloudstream3.utils.UIHelper.hideKeyboard
 import com.lagradost.cloudstream3.utils.UIHelper.navigate
+import com.lagradost.cloudstream3.utils.UIHelper.setAppBarNoScrollFlagsOnTV
 import com.lagradost.cloudstream3.utils.VideoDownloadHelper
 import com.lagradost.cloudstream3.utils.VideoDownloadManager
 import java.net.URI
@@ -96,6 +97,8 @@ class DownloadFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         hideKeyboard()
+
+        binding?.downloadStorageAppbar?.setAppBarNoScrollFlagsOnTV()
 
         observe(downloadsViewModel.noDownloadsText) {
             binding?.textNoDownloads?.text = it

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
@@ -45,6 +45,7 @@ import androidx.core.view.marginBottom
 import androidx.core.view.marginLeft
 import androidx.core.view.marginRight
 import androidx.core.view.marginTop
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.fragment.NavHostFragment
@@ -58,6 +59,7 @@ import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.RequestOptions.bitmapTransform
 import com.bumptech.glide.request.target.Target
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipDrawable
 import com.google.android.material.chip.ChipGroup
@@ -205,6 +207,14 @@ object UIHelper {
         activity?.window?.decorView?.clearFocus()
         view?.let {
             hideKeyboard(it)
+        }
+    }
+
+    fun View?.setAppBarNoScrollFlagsOnTV() {
+        if (isLayout(Globals.TV or EMULATOR)) {
+            this?.updateLayoutParams<AppBarLayout.LayoutParams> {
+                scrollFlags = AppBarLayout.LayoutParams.SCROLL_FLAG_NO_SCROLL
+            }
         }
     }
 

--- a/app/src/main/res/layout/download_child_episode.xml
+++ b/app/src/main/res/layout/download_child_episode.xml
@@ -9,6 +9,7 @@
     android:layout_height="50dp"
     android:layout_marginBottom="5dp"
     android:foreground="@drawable/outline_drawable"
+    android:focusable="true"
     android:nextFocusLeft="@id/nav_rail_view"
     android:nextFocusRight="@id/download_button"
     app:cardBackgroundColor="@color/transparent"
@@ -84,7 +85,9 @@
             android:layout_height="@dimen/download_size"
             android:layout_gravity="center_vertical|end"
             android:layout_marginStart="-50dp"
-            android:background="?selectableItemBackgroundBorderless"
+            android:foreground="@drawable/outline_drawable"
+            android:focusable="true"
+            android:nextFocusLeft="@id/download_child_episode_holder"
             android:padding="10dp" />
     </GridLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/download_header_episode.xml
+++ b/app/src/main/res/layout/download_header_episode.xml
@@ -9,6 +9,8 @@
     android:layout_marginTop="10dp"
     android:layout_marginEnd="10dp"
     android:foreground="@drawable/outline_drawable"
+    android:focusable="true"
+    android:nextFocusRight="@id/download_button"
     app:cardBackgroundColor="?attr/boxItemBackground"
     app:cardCornerRadius="@dimen/rounded_image_radius">
 
@@ -71,7 +73,9 @@
             android:layout_height="@dimen/download_size"
             android:layout_gravity="center_vertical|end"
             android:layout_marginStart="-50dp"
-            android:background="?selectableItemBackgroundBorderless"
+            android:foreground="@drawable/outline_drawable"
+            android:focusable="true"
+            android:nextFocusLeft="@id/episode_holder"
             android:padding="10dp" />
     </LinearLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
- Top toolbar is always visible on TV.
- Downloads items (for Movie & Episodes) focus fix.

closes #1059 