### PR TITLE
Use Season index to search Subs

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -265,9 +265,10 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         when (val newMeta = currentMeta) {
             is ResultEpisode -> {
+                Log.d("King", "TempMeta => $newMeta")
                 if (!newMeta.tvType.isMovieType()) {
                     meta.episode = newMeta.episode
-                    meta.season = newMeta.season
+                    meta.season = newMeta.seasonIndex
                 }
                 meta.name = newMeta.headerName
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -265,7 +265,6 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         when (val newMeta = currentMeta) {
             is ResultEpisode -> {
-                Log.d("King", "TempMeta => $newMeta")
                 if (!newMeta.tvType.isMovieType()) {
                     meta.episode = newMeta.episode
                     meta.season = newMeta.seasonIndex


### PR DESCRIPTION
If Extenstion is using the SeasonData and doesn't provide both (season & displaySeason) as displaySeason is nullable.

https://github.com/recloudstream/cloudstream/blob/ee4d1dedc5adb1be656a05d1ee0f41b11f9d0a84/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt#L2319
https://github.com/recloudstream/cloudstream/blob/ee4d1dedc5adb1be656a05d1ee0f41b11f9d0a84/app/src/main/java/com/lagradost/cloudstream3/metaproviders/TraktProvider.kt#L172
using seasonIndex assures subtitles search uses the right season number in all cases.