### PR TITLE
Fix fcast link selection

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -1728,7 +1728,7 @@ class ResultViewModel2 : ViewModel() {
                         txt(R.string.episode_action_cast_mirror)
                     ) { (result, index) ->
                         val host = device?.host ?: return@acquireSingleLink
-                        val link = result.links.firstOrNull() ?: return@acquireSingleLink
+                        val link = result.links.getOrNull(index) ?: return@acquireSingleLink
 
                         FcastSession(host).use { session ->
                             session.sendMessage(


### PR DESCRIPTION
This loads the selected link. A mistake caused the first link to always be loaded.

I tried to make subtitles load, but using m3u is a no-go as it does not support non-m3u videos.
I could not get dash to work consistently.