### PR TITLE
feat(Extensions): Trakt season names remove

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/metaproviders/TraktProvider.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/metaproviders/TraktProvider.kt
@@ -166,17 +166,9 @@ open class TraktProvider : MainAPI() {
             val resSeasons = getApi("$traktApiUrl/shows/${mediaDetails?.ids?.trakt.toString()}/seasons?extended=cloud9,full,episodes")
             val episodes = mutableListOf<Episode>()
             val seasons = parseJson<List<Seasons>>(resSeasons)
-            val seasonsNames = mutableListOf<SeasonData>()
             var nextAir:  NextAiring? = null
 
             seasons.forEach { season ->
-
-                seasonsNames.add(
-                    SeasonData(
-                        season.number!!,
-                        season.title
-                    )
-                )
 
                 season.episodes?.map { episode ->
 
@@ -250,7 +242,6 @@ open class TraktProvider : MainAPI() {
                 this.comingSoon = isUpcoming(mediaDetails.released)
                 //posterHeaders
                 this.nextAiring = nextAir
-                this.seasonNames = seasonsNames
                 this.backgroundPosterUrl = getOriginalWidthImageUrl(backDropUrl)
                 this.contentRating = mediaDetails.certification
                 addTrailer(mediaDetails.trailer)


### PR DESCRIPTION
if DisplaySeason is null, it conflicts with subs provider so I have removed it from trakt as most seasons doesn't have names, only the special season has a name
as the option now is to add DisplaySeason in trakt and that leads to display seasons to be duplicated as trakt uses the below as seasons names:
Specials
Season 1
Season 2