### PR TITLE
feat(UI): Hide Platform's not related settings

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsAccount.kt
@@ -36,6 +36,7 @@ import com.lagradost.cloudstream3.ui.settings.Globals.PHONE
 import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.getPref
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.hideOn
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setPaddingBottom
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setToolBarScrollFlags
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setUpToolbar
@@ -298,10 +299,7 @@ class SettingsAccount : PreferenceFragmentCompat(), BiometricAuthenticator.Biome
         hideKeyboard()
         setPreferencesFromResource(R.xml.settings_account, rootKey)
 
-        // hide preference on tvs and emulators
-        getPref(R.string.biometric_key)?.isEnabled = isLayout(PHONE)
-
-        getPref(R.string.biometric_key)?.setOnPreferenceClickListener {
+        getPref(R.string.biometric_key)?.hideOn(TV or EMULATOR)?.setOnPreferenceClickListener {
             val ctx = context ?: return@setOnPreferenceClickListener false
 
             if (deviceHasPasswordPinLock(ctx)) {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -26,6 +26,7 @@ import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
 import com.lagradost.cloudstream3.ui.settings.Globals.PHONE
 import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.getPref
 import com.lagradost.cloudstream3.utils.DataStoreHelper
 import com.lagradost.cloudstream3.utils.UIHelper
 import com.lagradost.cloudstream3.utils.UIHelper.clipboardHelper
@@ -51,6 +52,30 @@ class SettingsFragment : Fragment() {
                 logError(e)
                 null
             }
+        }
+
+        /**
+         * Hide many Preferences on selected layouts.
+         **/
+        fun PreferenceFragmentCompat?.hidePrefs(ids: List<Int>, layoutFlags: Int) {
+            if (this == null) return
+
+            try {
+                ids.forEach {
+                    getPref(it)?.isVisible = !isLayout(layoutFlags)
+                }
+            } catch (e: Exception) {
+                logError(e)
+            }
+        }
+
+        /**
+         * Hide the Preference on selected layouts.
+         **/
+        fun Preference?.hideOn(layoutFlags: Int): Preference? {
+            if (this == null) return null
+            this.isVisible = !isLayout(layoutFlags)
+            return this
         }
 
         /**

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
@@ -27,10 +27,13 @@ import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.mvvm.normalSafeApiCall
 import com.lagradost.cloudstream3.network.initClient
 import com.lagradost.cloudstream3.ui.EasterEggMonke
+import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
 import com.lagradost.cloudstream3.ui.settings.Globals.PHONE
+import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.beneneCount
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.getPref
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.hideOn
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setPaddingBottom
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setToolBarScrollFlags
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setUpToolbar
@@ -208,9 +211,7 @@ class SettingsGeneral : PreferenceFragmentCompat() {
             return@setOnPreferenceClickListener true
         }
 
-        // disable preference on tvs and emulators
-        getPref(R.string.battery_optimisation_key)?.isEnabled = isLayout(PHONE)
-        getPref(R.string.battery_optimisation_key)?.setOnPreferenceClickListener {
+        getPref(R.string.battery_optimisation_key)?.hideOn(TV or EMULATOR)?.setOnPreferenceClickListener {
             val ctx = context ?: return@setOnPreferenceClickListener false
 
             if (isAppRestricted(ctx)) {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
@@ -7,8 +7,14 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.mvvm.logError
+import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
+import com.lagradost.cloudstream3.ui.settings.Globals.PHONE
+import com.lagradost.cloudstream3.ui.settings.Globals.TV
+import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.getFolderSize
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.getPref
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.hideOn
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.hidePrefs
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setPaddingBottom
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setToolBarScrollFlags
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setUpToolbar
@@ -30,6 +36,18 @@ class SettingsPlayer : PreferenceFragmentCompat() {
         hideKeyboard()
         setPreferencesFromResource(R.xml.settings_player, rootKey)
         val settingsManager = PreferenceManager.getDefaultSharedPreferences(requireContext())
+
+        //Hide specific prefs on TV/EMULATOR
+        hidePrefs(
+            listOf(
+                R.string.pref_category_gestures_key,
+                R.string.rotate_video_key,
+                R.string.auto_rotate_video_key
+            ),
+            TV or EMULATOR
+        )
+
+        getPref(R.string.pref_category_android_tv_key)?.hideOn(PHONE)
 
         getPref(R.string.video_buffer_length_key)?.setOnPreferenceClickListener {
             val prefNames = resources.getStringArray(R.array.video_buffer_length_names)
@@ -227,6 +245,5 @@ class SettingsPlayer : PreferenceFragmentCompat() {
                 return@setOnPreferenceClickListener true
             }
         }
-
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,7 +438,9 @@
     <string name="pref_category_actions">Actions</string>
     <string name="pref_category_cache">Cache</string>
     <string name="pref_category_android_tv">Android TV</string>
+    <string name="pref_category_android_tv_key" translatable="false" >pref_category_android_tv_key</string>
     <string name="pref_category_gestures">Gestures</string>
+    <string name="pref_category_gestures_key" translatable="false">pref_category_gestures_key</string>
     <string name="pref_category_player_features">Player features</string>
     <string name="pref_category_subtitles">Subtitles</string>
     <string name="pref_category_player_layout">Layout</string>

--- a/app/src/main/res/xml/settings_player.xml
+++ b/app/src/main/res/xml/settings_player.xml
@@ -101,7 +101,8 @@
     </PreferenceCategory>
     
     <PreferenceCategory
-        android:title="@string/pref_category_gestures">
+        android:title="@string/pref_category_gestures"
+        app:key="@string/pref_category_gestures_key">
         <SwitchPreference
             android:icon="@drawable/ic_baseline_ondemand_video_24"
             android:summary="@string/swipe_to_seek_settings_des"
@@ -166,7 +167,8 @@
             android:title="@string/video_buffer_clear_settings" />
     </PreferenceCategory>
     <PreferenceCategory
-        android:title="@string/pref_category_android_tv">
+        android:title="@string/pref_category_android_tv"
+        android:key="@string/pref_category_android_tv_key" >
         <SeekBarPreference
             android:defaultValue="10"
             android:max="60"


### PR DESCRIPTION
Hide the below settings

**On Phone**:
- Player -> Android TV.

**On TV**:
- General -> Disable Battery optimization.
- Player -> all "Gesture" section.
- "Accounts and Security" -> "Lock with Biometrics"