### PR TITLE
Major performance and bug fixes to downloads

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/DownloaderTestImpl.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/DownloaderTestImpl.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3
 
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.downloader.Downloader
 import org.schabi.newpipe.extractor.downloader.Request
 import org.schabi.newpipe.extractor.downloader.Response
@@ -18,7 +19,7 @@ class DownloaderTestImpl private constructor(builder: OkHttpClient.Builder) : Do
         val dataToSend: ByteArray? = request.dataToSend()
         var requestBody: RequestBody? = null
         if (dataToSend != null) {
-            requestBody = RequestBody.create(null, dataToSend)
+            requestBody = dataToSend.toRequestBody(null, 0, dataToSend.size)
         }
         val requestBuilder: okhttp3.Request.Builder = okhttp3.Request.Builder()
             .method(httpMethod, requestBody).url(url)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
@@ -15,8 +15,8 @@ import com.lagradost.cloudstream3.databinding.DownloadHeaderEpisodeBinding
 import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.ui.download.button.DownloadStatusTell
 import com.lagradost.cloudstream3.utils.AppUtils.getNameFull
-import com.lagradost.cloudstream3.utils.DataStoreHelper
 import com.lagradost.cloudstream3.utils.DataStoreHelper.fixVisual
+import com.lagradost.cloudstream3.utils.DataStoreHelper.getViewPos
 import com.lagradost.cloudstream3.utils.UIHelper.setImage
 import com.lagradost.cloudstream3.utils.VideoDownloadHelper
 
@@ -116,7 +116,7 @@ class DownloadAdapter(
                 }
 
                 downloadHeaderTitle.text = d.name
-                val mbString = formatShortFileSize(itemView.context, card.totalBytes)
+                val formattedSizeString = formatShortFileSize(itemView.context, card.totalBytes)
 
                 if (card.child != null) {
                     downloadHeaderGotoChild.isVisible = false
@@ -131,7 +131,7 @@ class DownloadAdapter(
                         downloadButton.applyMetaData(card.child.id, card.currentBytes, card.totalBytes)
                         // We will let the view model handle this
                         downloadButton.doSetProgress = false
-                        downloadHeaderInfo.text = formatShortFileSize(downloadHeaderInfo.context, card.totalBytes)
+                        downloadHeaderInfo.text = formattedSizeString
                     } else downloadButton.doSetProgress = true
 
                     downloadButton.setDefaultClickListener(card.child, downloadHeaderInfo, mediaClickCallback)
@@ -152,7 +152,7 @@ class DownloadAdapter(
                                     R.plurals.episodes,
                                     card.totalDownloads
                                 ),
-                                mbString
+                                formattedSizeString
                             )
                     } catch (e: Exception) {
                         // You probably formatted incorrectly
@@ -173,7 +173,7 @@ class DownloadAdapter(
             val d = card.data
 
             binding.apply {
-                val posDur = DataStoreHelper.getViewPos(d.id)
+                val posDur = getViewPos(d.id)
                 downloadChildEpisodeProgress.apply {
                     isVisible = posDur != null
                     posDur?.let {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
@@ -130,9 +130,9 @@ class DownloadAdapter(
                         downloadButton.setProgress(card.currentBytes, card.totalBytes)
                         downloadButton.applyMetaData(card.child.id, card.currentBytes, card.totalBytes)
                         // We will let the view model handle this
-                        downloadButton.setProgressText = false
+                        downloadButton.doSetProgress = false
                         downloadHeaderInfo.text = formatShortFileSize(downloadHeaderInfo.context, card.totalBytes)
-                    } else downloadButton.setProgressText = true
+                    } else downloadButton.doSetProgress = true
 
                     downloadButton.setDefaultClickListener(card.child, downloadHeaderInfo, mediaClickCallback)
                     downloadButton.isVisible = true
@@ -192,9 +192,9 @@ class DownloadAdapter(
                     downloadButton.setProgress(card.currentBytes, card.totalBytes)
                     downloadButton.applyMetaData(d.id, card.currentBytes, card.totalBytes)
                     // We will let the view model handle this
-                    downloadButton.setProgressText = false
+                    downloadButton.doSetProgress = false
                     downloadChildEpisodeTextExtra.text = formatShortFileSize(downloadChildEpisodeTextExtra.context, card.totalBytes)
-                } else downloadButton.setProgressText = true
+                } else downloadButton.doSetProgress = true
 
                 downloadButton.setDefaultClickListener(d, downloadChildEpisodeTextExtra, mediaClickCallback)
                 downloadButton.isVisible = true

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
@@ -27,6 +27,9 @@ const val DOWNLOAD_ACTION_PAUSE_DOWNLOAD = 3
 const val DOWNLOAD_ACTION_DOWNLOAD = 4
 const val DOWNLOAD_ACTION_LONG_CLICK = 5
 
+const val DOWNLOAD_ACTION_GO_TO_CHILD = 0
+const val DOWNLOAD_ACTION_LOAD_RESULT = 1
+
 abstract class VisualDownloadCached(
     open val currentBytes: Long,
     open val totalBytes: Long,
@@ -111,7 +114,7 @@ class DownloadAdapter(
                 downloadHeaderPoster.apply {
                     setImage(d.poster)
                     setOnClickListener {
-                        clickCallback.invoke(DownloadHeaderClickEvent(1, d))
+                        clickCallback.invoke(DownloadHeaderClickEvent(DOWNLOAD_ACTION_LOAD_RESULT, d))
                     }
                 }
 
@@ -161,7 +164,7 @@ class DownloadAdapter(
                     }
 
                     episodeHolder.setOnClickListener {
-                        clickCallback.invoke(DownloadHeaderClickEvent(DOWNLOAD_ACTION_PLAY_FILE, d))
+                        clickCallback.invoke(DownloadHeaderClickEvent(DOWNLOAD_ACTION_GO_TO_CHILD, d))
                     }
                 }
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
@@ -161,7 +161,7 @@ class DownloadAdapter(
                     }
 
                     episodeHolder.setOnClickListener {
-                        clickCallback.invoke(DownloadHeaderClickEvent(0, d))
+                        clickCallback.invoke(DownloadHeaderClickEvent(DOWNLOAD_ACTION_PLAY_FILE, d))
                     }
                 }
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
@@ -13,6 +13,7 @@ import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.databinding.DownloadChildEpisodeBinding
 import com.lagradost.cloudstream3.databinding.DownloadHeaderEpisodeBinding
 import com.lagradost.cloudstream3.mvvm.logError
+import com.lagradost.cloudstream3.ui.download.button.DownloadStatusTell
 import com.lagradost.cloudstream3.utils.AppUtils.getNameFull
 import com.lagradost.cloudstream3.utils.DataStoreHelper
 import com.lagradost.cloudstream3.utils.DataStoreHelper.fixVisual
@@ -93,112 +94,128 @@ class DownloadAdapter(
         private val mediaClickCallback: (DownloadClickEvent) -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        @SuppressLint("SetTextI18n")
         fun bind(card: VisualDownloadCached?) {
             when (binding) {
-                is DownloadHeaderEpisodeBinding -> binding.apply {
-                    if (card == null || card !is VisualDownloadHeaderCached) return@apply
-                    val d = card.data
+                is DownloadHeaderEpisodeBinding -> bindHeader(card as? VisualDownloadHeaderCached)
+                is DownloadChildEpisodeBinding -> bindChild(card as? VisualDownloadChildCached)
+            }
+        }
 
-                    downloadHeaderPoster.apply {
-                        setImage(d.poster)
-                        setOnClickListener {
-                            clickCallback.invoke(DownloadHeaderClickEvent(1, d))
-                        }
-                    }
+        @SuppressLint("SetTextI18n")
+        private fun bindHeader(card: VisualDownloadHeaderCached?) {
+            if (binding !is DownloadHeaderEpisodeBinding) return
+            card ?: return
+            val d = card.data
 
-                    downloadHeaderTitle.text = d.name
-                    val mbString = formatShortFileSize(itemView.context, card.totalBytes)
-
-                    if (card.child != null) {
-                        downloadHeaderGotoChild.isVisible = false
-
-                        downloadButton.setDefaultClickListener(card.child, downloadHeaderInfo, mediaClickCallback)
-                        downloadButton.setProgress(card.currentBytes, card.totalBytes)
-                        downloadButton.isVisible = true
-
-                        episodeHolder.setOnClickListener {
-                            mediaClickCallback.invoke(
-                                DownloadClickEvent(
-                                    DOWNLOAD_ACTION_PLAY_FILE,
-                                    card.child
-                                )
-                            )
-                        }
-                    } else {
-                        downloadButton.isVisible = false
-                        downloadHeaderGotoChild.isVisible = true
-
-                        try {
-                            downloadHeaderInfo.text =
-                                downloadHeaderInfo.context.getString(R.string.extra_info_format)
-                                    .format(
-                                        card.totalDownloads,
-                                        if (card.totalDownloads == 1) downloadHeaderInfo.context.getString(
-                                            R.string.episode
-                                        ) else downloadHeaderInfo.context.getString(
-                                            R.string.episodes
-                                        ),
-                                        mbString
-                                    )
-                        } catch (t: Throwable) {
-                            // You probably formatted incorrectly
-                            downloadHeaderInfo.text = "Error"
-                            logError(t)
-                        }
-
-                        episodeHolder.setOnClickListener {
-                            clickCallback.invoke(DownloadHeaderClickEvent(0, d))
-                        }
+            binding.apply {
+                downloadHeaderPoster.apply {
+                    setImage(d.poster)
+                    setOnClickListener {
+                        clickCallback.invoke(DownloadHeaderClickEvent(1, d))
                     }
                 }
 
-                is DownloadChildEpisodeBinding -> binding.apply {
-                    if (card == null || card !is VisualDownloadChildCached) return@apply
-                    val d = card.data
+                downloadHeaderTitle.text = d.name
+                val mbString = formatShortFileSize(itemView.context, card.totalBytes)
 
-                    val posDur = DataStoreHelper.getViewPos(d.id)
-                    downloadChildEpisodeProgress.apply {
-                        if (posDur != null) {
-                            val visualPos = posDur.fixVisual()
-                            max = (visualPos.duration / 1000).toInt()
-                            progress = (visualPos.position / 1000).toInt()
-                            isVisible = true
-                        } else isVisible = false
+                if (card.child != null) {
+                    downloadHeaderGotoChild.isVisible = false
+
+                    val status = downloadButton.getStatus(card.child.id, card.currentBytes, card.totalBytes)
+                    if (status == DownloadStatusTell.IsDone) {
+                        // We do this here instead if we are finished downloading
+                        // so that we can use the value from the view model
+                        // rather than extra unneeded disk operations and to prevent a
+                        // delay in updating download icon state.
+                        downloadButton.setProgress(card.currentBytes, card.totalBytes)
+                        downloadButton.applyMetaData(card.child.id, card.currentBytes, card.totalBytes)
+                        // We will let the view model handle this
+                        downloadButton.setProgressText = false
+                        downloadHeaderInfo.text = formatShortFileSize(downloadHeaderInfo.context, card.totalBytes)
+                    } else downloadButton.setProgressText = true
+
+                    downloadButton.setDefaultClickListener(card.child, downloadHeaderInfo, mediaClickCallback)
+                    downloadButton.isVisible = true
+
+                    episodeHolder.setOnClickListener {
+                        mediaClickCallback.invoke(DownloadClickEvent(DOWNLOAD_ACTION_PLAY_FILE, card.child))
+                    }
+                } else {
+                    downloadButton.isVisible = false
+                    downloadHeaderGotoChild.isVisible = true
+
+                    try {
+                        downloadHeaderInfo.text = downloadHeaderInfo.context.getString(R.string.extra_info_format)
+                            .format(
+                                card.totalDownloads,
+                                downloadHeaderInfo.context.resources.getQuantityString(
+                                    R.plurals.episodes,
+                                    card.totalDownloads
+                                ),
+                                mbString
+                            )
+                    } catch (e: Exception) {
+                        // You probably formatted incorrectly
+                        downloadHeaderInfo.text = "Error"
+                        logError(e)
                     }
 
-                    downloadButton.setDefaultClickListener(card.data, downloadChildEpisodeTextExtra, mediaClickCallback)
+                    episodeHolder.setOnClickListener {
+                        clickCallback.invoke(DownloadHeaderClickEvent(0, d))
+                    }
+                }
+            }
+        }
+
+        private fun bindChild(card: VisualDownloadChildCached?) {
+            if (binding !is DownloadChildEpisodeBinding) return
+            card ?: return
+            val d = card.data
+
+            binding.apply {
+                val posDur = DataStoreHelper.getViewPos(d.id)
+                downloadChildEpisodeProgress.apply {
+                    isVisible = posDur != null
+                    posDur?.let {
+                        val visualPos = it.fixVisual()
+                        max = (visualPos.duration / 1000).toInt()
+                        progress = (visualPos.position / 1000).toInt()
+                    }
+                }
+
+                val status = downloadButton.getStatus(d.id, card.currentBytes, card.totalBytes)
+                if (status == DownloadStatusTell.IsDone) {
+                    // We do this here instead if we are finished downloading
+                    // so that we can use the value from the view model
+                    // rather than extra unneeded disk operations and to prevent a
+                    // delay in updating download icon state.
                     downloadButton.setProgress(card.currentBytes, card.totalBytes)
+                    downloadButton.applyMetaData(d.id, card.currentBytes, card.totalBytes)
+                    // We will let the view model handle this
+                    downloadButton.setProgressText = false
+                    downloadChildEpisodeTextExtra.text = formatShortFileSize(downloadChildEpisodeTextExtra.context, card.totalBytes)
+                } else downloadButton.setProgressText = true
 
-                    downloadChildEpisodeText.apply {
-                        text = context.getNameFull(d.name, d.episode, d.season)
-                        isSelected = true // Needed for text repeating
-                    }
+                downloadButton.setDefaultClickListener(d, downloadChildEpisodeTextExtra, mediaClickCallback)
+                downloadButton.isVisible = true
 
-                    downloadChildEpisodeHolder.setOnClickListener {
-                        mediaClickCallback.invoke(DownloadClickEvent(DOWNLOAD_ACTION_PLAY_FILE, d))
-                    }
+                downloadChildEpisodeText.apply {
+                    text = context.getNameFull(d.name, d.episode, d.season)
+                    isSelected = true // Needed for text repeating
+                }
+
+                downloadChildEpisodeHolder.setOnClickListener {
+                    mediaClickCallback.invoke(DownloadClickEvent(DOWNLOAD_ACTION_PLAY_FILE, d))
                 }
             }
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DownloadViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
         val binding = when (viewType) {
-            VIEW_TYPE_HEADER -> {
-                DownloadHeaderEpisodeBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
-                )
-            }
-            VIEW_TYPE_CHILD -> {
-                DownloadChildEpisodeBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
-                )
-            }
+            VIEW_TYPE_HEADER -> DownloadHeaderEpisodeBinding.inflate(inflater, parent, false)
+            VIEW_TYPE_CHILD -> DownloadChildEpisodeBinding.inflate(inflater, parent, false)
             else -> throw IllegalArgumentException("Invalid view type")
         }
         return DownloadViewHolder(binding, clickCallback, mediaClickCallback)
@@ -209,8 +226,11 @@ class DownloadAdapter(
     }
 
     override fun getItemViewType(position: Int): Int {
-        val card = getItem(position)
-        return if (card is VisualDownloadChildCached) VIEW_TYPE_CHILD else VIEW_TYPE_HEADER
+        return when (getItem(position)) {
+            is VisualDownloadChildCached -> VIEW_TYPE_CHILD
+            is VisualDownloadHeaderCached -> VIEW_TYPE_HEADER
+            else -> throw IllegalArgumentException("Invalid data type at position $position")
+        }
     }
 
     class DiffCallback : DiffUtil.ItemCallback<VisualDownloadCached>() {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadAdapter.kt
@@ -114,6 +114,7 @@ class DownloadAdapter(
                         downloadHeaderGotoChild.isVisible = false
 
                         downloadButton.setDefaultClickListener(card.child, downloadHeaderInfo, mediaClickCallback)
+                        downloadButton.setProgress(card.currentBytes, card.totalBytes)
                         downloadButton.isVisible = true
 
                         episodeHolder.setOnClickListener {
@@ -167,6 +168,7 @@ class DownloadAdapter(
                     }
 
                     downloadButton.setDefaultClickListener(card.data, downloadChildEpisodeTextExtra, mediaClickCallback)
+                    downloadButton.setProgress(card.currentBytes, card.totalBytes)
 
                     downloadChildEpisodeText.apply {
                         text = context.getNameFull(d.name, d.episode, d.season)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
@@ -35,6 +35,7 @@ class DownloadChildFragment : Fragment() {
 
     override fun onDestroyView() {
         downloadDeleteEventListener?.let { VideoDownloadManager.downloadDeleteEvent -= it }
+        downloadDeleteEventListener = null
         binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
@@ -142,7 +142,7 @@ class DownloadFragment : Fragment() {
 
     private fun handleItemClick(click: DownloadHeaderClickEvent) {
         when (click.action) {
-            0 -> {
+            DOWNLOAD_ACTION_PLAY_FILE -> {
                 if (!click.data.type.isMovieType()) {
                     val folder = DataStore.getFolderName(DOWNLOAD_EPISODE_CACHE, click.data.id.toString())
                     activity?.navigate(
@@ -151,7 +151,7 @@ class DownloadFragment : Fragment() {
                     )
                 }
             }
-            1 -> {
+            DOWNLOAD_ACTION_DELETE_FILE -> {
                 (activity as AppCompatActivity?)?.loadResult(click.data.url, click.data.apiName)
             }
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
@@ -142,7 +142,7 @@ class DownloadFragment : Fragment() {
 
     private fun handleItemClick(click: DownloadHeaderClickEvent) {
         when (click.action) {
-            0 -> {
+            DOWNLOAD_ACTION_GO_TO_CHILD -> {
                 if (!click.data.type.isMovieType()) {
                     val folder = DataStore.getFolderName(DOWNLOAD_EPISODE_CACHE, click.data.id.toString())
                     activity?.navigate(
@@ -151,7 +151,7 @@ class DownloadFragment : Fragment() {
                     )
                 }
             }
-            1 -> {
+            DOWNLOAD_ACTION_LOAD_RESULT -> {
                 (activity as AppCompatActivity?)?.loadResult(click.data.url, click.data.apiName)
             }
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
@@ -35,7 +35,6 @@ import com.lagradost.cloudstream3.ui.result.setLinearListLayout
 import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.utils.AppUtils.loadResult
-import com.lagradost.cloudstream3.utils.Coroutines.main
 import com.lagradost.cloudstream3.utils.DOWNLOAD_EPISODE_CACHE
 import com.lagradost.cloudstream3.utils.DataStore
 import com.lagradost.cloudstream3.utils.UIHelper.dismissSafe
@@ -60,16 +59,8 @@ class DownloadFragment : Fragment() {
         this.layoutParams = param
     }
 
-    private fun setList(list: List<VisualDownloadHeaderCached>) {
-        main {
-            (binding?.downloadList?.adapter as? DownloadAdapter)?.submitList(list)
-        }
-    }
-
     override fun onDestroyView() {
-        downloadDeleteEventListener?.let {
-            VideoDownloadManager.downloadDeleteEvent -= it
-        }
+        downloadDeleteEventListener?.let { VideoDownloadManager.downloadDeleteEvent -= it }
         downloadDeleteEventListener = null
         binding = null
         super.onDestroyView()
@@ -95,12 +86,10 @@ class DownloadFragment : Fragment() {
         hideKeyboard()
         binding?.downloadStorageAppbar?.setAppBarNoScrollFlagsOnTV()
 
-        observe(downloadsViewModel.noDownloadsText) {
-            binding?.textNoDownloads?.text = it
-        }
         observe(downloadsViewModel.headerCards) {
-            setList(it)
+            (binding?.downloadList?.adapter as? DownloadAdapter)?.submitList(it)
             binding?.downloadLoading?.isVisible = false
+            binding?.textNoDownloads?.isVisible = it.isEmpty()
         }
         observe(downloadsViewModel.availableBytes) {
             updateStorageInfo(view.context, it, R.string.free_storage, binding?.downloadFreeTxt, binding?.downloadFree)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
@@ -142,7 +142,7 @@ class DownloadFragment : Fragment() {
 
     private fun handleItemClick(click: DownloadHeaderClickEvent) {
         when (click.action) {
-            DOWNLOAD_ACTION_PLAY_FILE -> {
+            0 -> {
                 if (!click.data.type.isMovieType()) {
                     val folder = DataStore.getFolderName(DOWNLOAD_EPISODE_CACHE, click.data.id.toString())
                     activity?.navigate(
@@ -151,7 +151,7 @@ class DownloadFragment : Fragment() {
                     )
                 }
             }
-            DOWNLOAD_ACTION_DELETE_FILE -> {
+            1 -> {
                 (activity as AppCompatActivity?)?.loadResult(click.data.url, click.data.apiName)
             }
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
@@ -21,11 +21,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class DownloadViewModel : ViewModel() {
-    private val _noDownloadsText = MutableLiveData<String>().apply {
-        value = ""
-    }
-    val noDownloadsText: LiveData<String> = _noDownloadsText
-
     private val _headerCards =
         MutableLiveData<List<VisualDownloadHeaderCached>>().apply { listOf<VisualDownloadHeaderCached>() }
     val headerCards: LiveData<List<VisualDownloadHeaderCached>> = _headerCards

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
@@ -18,7 +18,6 @@ import com.lagradost.cloudstream3.utils.DataStore.getKeys
 import com.lagradost.cloudstream3.utils.VideoDownloadHelper
 import com.lagradost.cloudstream3.utils.VideoDownloadManager
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class DownloadViewModel : ViewModel() {
@@ -43,8 +42,8 @@ class DownloadViewModel : ViewModel() {
 
     fun updateList(context: Context) = viewModelScope.launchSafe {
         val children = withContext(Dispatchers.IO) {
-            val headers = context.getKeys(DOWNLOAD_EPISODE_CACHE)
-            headers.mapNotNull { context.getKey<VideoDownloadHelper.DownloadEpisodeCached>(it) }
+            context.getKeys(DOWNLOAD_EPISODE_CACHE)
+                .mapNotNull { context.getKey<VideoDownloadHelper.DownloadEpisodeCached>(it) }
                 .distinctBy { it.id } // Remove duplicates
         }
 
@@ -57,10 +56,10 @@ class DownloadViewModel : ViewModel() {
 
         // Gets all children downloads
         withContext(Dispatchers.IO) {
-            for (c in children) {
-                val childFile = VideoDownloadManager.getDownloadFileInfoAndUpdateSettings(context, c.id) ?: continue
+            children.forEach { c ->
+                val childFile = VideoDownloadManager.getDownloadFileInfoAndUpdateSettings(context, c.id) ?: return@forEach
 
-                if (childFile.fileLength <= 1) continue
+                if (childFile.fileLength <= 1) return@forEach
                 val len = childFile.totalBytes
                 val flen = childFile.fileLength
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
@@ -16,7 +16,7 @@ import com.lagradost.cloudstream3.utils.DataStore.getFolderName
 import com.lagradost.cloudstream3.utils.DataStore.getKey
 import com.lagradost.cloudstream3.utils.DataStore.getKeys
 import com.lagradost.cloudstream3.utils.VideoDownloadHelper
-import com.lagradost.cloudstream3.utils.VideoDownloadManager
+import com.lagradost.cloudstream3.utils.VideoDownloadManager.getDownloadFileInfoAndUpdateSettings
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -57,7 +57,7 @@ class DownloadViewModel : ViewModel() {
         // Gets all children downloads
         withContext(Dispatchers.IO) {
             children.forEach { c ->
-                val childFile = VideoDownloadManager.getDownloadFileInfoAndUpdateSettings(context, c.id) ?: return@forEach
+                val childFile = getDownloadFileInfoAndUpdateSettings(context, c.id) ?: return@forEach
 
                 if (childFile.fileLength <= 1) return@forEach
                 val len = childFile.totalBytes

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
@@ -64,42 +64,18 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
     var currentMetaData: DownloadMetadata =
         DownloadMetadata(0, 0, 0, null)
 
-    fun setPersistentId(id: Int) {
-        persistentId = id
-        currentMetaData.id = id
-
-        VideoDownloadManager.getDownloadFileInfoAndUpdateSettings(context, id)?.let { savedData ->
-            val downloadedBytes = savedData.fileLength
-            val totalBytes = savedData.totalBytes
-
-            /*lastRequest = savedData.uriRequest
-            files = savedData.files
-
-            var totalBytes: Long = 0
-            var downloadedBytes: Long = 0
-            for (file in savedData.files) {
-                downloadedBytes += file.completedLength
-                totalBytes += file.length
-            }*/
-            setProgress(downloadedBytes, totalBytes)
-            // some extra padding for just in case
-            val status = VideoDownloadManager.downloadStatus[id]
-                ?: if (downloadedBytes > 1024L && downloadedBytes + 1024L >= totalBytes) DownloadStatusTell.IsDone else DownloadStatusTell.IsPaused
-            currentMetaData.apply {
-                this.id = id
-                this.downloadedLength = downloadedBytes
-                this.totalLength = totalBytes
-                this.status = status
-            }
-            setStatus(status)
-        } ?: run {
-            resetView()
-        }
-    }
-
     abstract fun setStatus(status: VideoDownloadManager.DownloadType?)
 
     open fun setProgress(downloadedBytes: Long, totalBytes: Long) {
+        val status = VideoDownloadManager.downloadStatus[id]
+            ?: if (downloadedBytes > 1024L && downloadedBytes + 1024L >= totalBytes) DownloadStatusTell.IsDone else DownloadStatusTell.IsPaused
+        currentMetaData.apply {
+            this.id = id
+            this.downloadedLength = downloadedBytes
+            this.totalLength = totalBytes
+            this.status = status
+        }
+        setStatus(status)
         isZeroBytes = downloadedBytes == 0L
         progressBar.post {
             val steps = 10000L
@@ -174,7 +150,7 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
         val pid = persistentId
         if (pid != null) {
             // refresh in case of onDetachedFromWindow -> onAttachedToWindow while still being ???????
-            setPersistentId(pid)
+            currentMetaData.id = pid
         }
 
         super.onAttachedToWindow()
@@ -198,5 +174,4 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
      * Get a clean slate again, might be useful in recyclerview?
      * */
     abstract fun resetView()
-
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
@@ -57,23 +57,23 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
         resetViewData()
     }
 
+    var doSetProgress = true
+
     open fun resetViewData() {
         // lastRequest = null
         isZeroBytes = true
+        doSetProgress = true
         persistentId = null
     }
 
     var currentMetaData: DownloadMetadata =
         DownloadMetadata(0, 0, 0, null)
 
-    private var progressSet = false
-    var setProgressText = true
-
     fun setPersistentId(id: Int) {
         persistentId = id
         currentMetaData.id = id
 
-        if (progressSet) return
+        if (!doSetProgress) return
 
         ioSafe {
             val savedData = VideoDownloadManager.getDownloadFileInfoAndUpdateSettings(context, id)
@@ -112,7 +112,6 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
     }
 
     open fun setProgress(downloadedBytes: Long, totalBytes: Long) {
-        progressSet = true
         isZeroBytes = downloadedBytes == 0L
         progressBar.post {
             val steps = 10000L
@@ -137,7 +136,7 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
             if (isZeroBytes) {
                 progressText?.isVisible = false
             } else {
-                if (setProgressText) {
+                if (doSetProgress) {
                     progressText?.apply {
                         val currentMbString =
                             Formatter.formatShortFileSize(context, downloadedBytes)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
@@ -1,7 +1,7 @@
 package com.lagradost.cloudstream3.ui.download.button
 
 import android.content.Context
-import android.text.format.Formatter
+import android.text.format.Formatter.formatShortFileSize
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import android.widget.TextView
@@ -36,7 +36,7 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
     lateinit var progressBar: ContentLoadingProgressBar
     var progressText: TextView? = null
 
-    /*val gid: String? get() = sessionIdToGid[persistentId]
+    /* val gid: String? get() = sessionIdToGid[persistentId]
 
     // used for resuming data
     var _lastRequestOverride: UriRequest? = null
@@ -46,7 +46,7 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
             _lastRequestOverride = value
         }
 
-    var files: List<AbstractClient.JsonFile> = emptyList()*/
+    var files: List<AbstractClient.JsonFile> = emptyList() */
     protected var isZeroBytes: Boolean = true
 
     fun inflate(@LayoutRes layout: Int) {
@@ -93,6 +93,7 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
     abstract fun setStatus(status: VideoDownloadManager.DownloadType?)
 
     fun getStatus(id:Int, downloadedBytes: Long, totalBytes: Long): DownloadStatusTell {
+        // some extra padding for just in case
         return VideoDownloadManager.downloadStatus[id]
             ?: if (downloadedBytes > 1024L && downloadedBytes + 1024L >= totalBytes) {
                 DownloadStatusTell.IsDone
@@ -138,13 +139,12 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
             } else {
                 if (doSetProgress) {
                     progressText?.apply {
-                        val currentMbString =
-                            Formatter.formatShortFileSize(context, downloadedBytes)
-                        val totalMbString = Formatter.formatShortFileSize(context, totalBytes)
+                        val currentFormattedSizeString = formatShortFileSize(context, downloadedBytes)
+                        val totalFormattedSizeString = formatShortFileSize(context, totalBytes)
                         text =
-                                //if (isTextPercentage) "%d%%".format(setCurrentBytes * 100L / setTotalBytes) else
+                                // if (isTextPercentage) "%d%%".format(setCurrentBytes * 100L / setTotalBytes) else
                             context?.getString(R.string.download_size_format)
-                                ?.format(currentMbString, totalMbString)
+                                ?.format(currentFormattedSizeString, totalFormattedSizeString)
                     }
                 }
             }
@@ -182,8 +182,8 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
 
     override fun onAttachedToWindow() {
         VideoDownloadManager.downloadStatusEvent += ::downloadStatusEvent
-        //VideoDownloadManager.downloadDeleteEvent += ::downloadDeleteEvent
-        //VideoDownloadManager.downloadEvent += ::downloadEvent
+        // VideoDownloadManager.downloadDeleteEvent += ::downloadDeleteEvent
+        // VideoDownloadManager.downloadEvent += ::downloadEvent
         VideoDownloadManager.downloadProgressEvent += ::downloadProgressEvent
 
         val pid = persistentId
@@ -197,8 +197,8 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
 
     override fun onDetachedFromWindow() {
         VideoDownloadManager.downloadStatusEvent -= ::downloadStatusEvent
-        //VideoDownloadManager.downloadDeleteEvent -= ::downloadDeleteEvent
-        //VideoDownloadManager.downloadEvent -= ::downloadEvent
+        // VideoDownloadManager.downloadDeleteEvent -= ::downloadDeleteEvent
+        // VideoDownloadManager.downloadEvent -= ::downloadEvent
         VideoDownloadManager.downloadProgressEvent -= ::downloadProgressEvent
 
         super.onDetachedFromWindow()

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/PieFetchButton.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/PieFetchButton.kt
@@ -301,6 +301,7 @@ open class PieFetchButton(context: Context, attributeSet: AttributeSet) :
         setStatus(null)
         currentMetaData = DownloadMetadata(0, 0, 0, null)
         isZeroBytes = true
+        doSetProgress = true
         progressBar.progress = 0
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/PieFetchButton.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/PieFetchButton.kt
@@ -167,7 +167,6 @@ open class PieFetchButton(context: Context, attributeSet: AttributeSet) :
         callback: (DownloadClickEvent) -> Unit
     ) {
         this.progressText = textView
-        this.setPersistentId(card.id)
         view.setOnClickListener {
             if (isZeroBytes) {
                 removeKey(KEY_RESUME_PACKAGES, card.id.toString())

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/PieFetchButton.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/PieFetchButton.kt
@@ -13,7 +13,6 @@ import androidx.annotation.MainThread
 import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
-import com.lagradost.cloudstream3.AcraApplication.Companion.getKey
 import com.lagradost.cloudstream3.AcraApplication.Companion.removeKey
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.mvvm.logError
@@ -28,7 +27,6 @@ import com.lagradost.cloudstream3.utils.UIHelper.popupMenuNoIcons
 import com.lagradost.cloudstream3.utils.VideoDownloadHelper
 import com.lagradost.cloudstream3.utils.VideoDownloadManager
 import com.lagradost.cloudstream3.utils.VideoDownloadManager.KEY_RESUME_PACKAGES
-
 
 open class PieFetchButton(context: Context, attributeSet: AttributeSet) :
     BaseFetchButton(context, attributeSet) {
@@ -167,6 +165,7 @@ open class PieFetchButton(context: Context, attributeSet: AttributeSet) :
         callback: (DownloadClickEvent) -> Unit
     ) {
         this.progressText = textView
+        this.setPersistentId(card.id)
         view.setOnClickListener {
             if (isZeroBytes) {
                 removeKey(KEY_RESUME_PACKAGES, card.id.toString())

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadManager.kt
@@ -17,6 +17,7 @@ import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
+import com.bumptech.glide.Glide
 import com.bumptech.glide.load.model.GlideUrl
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.APIHolder.getApiFromNameNull
@@ -28,7 +29,6 @@ import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.TvType
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.mvvm.logError
-import com.lagradost.cloudstream3.mvvm.normalSafeApiCall
 import com.lagradost.cloudstream3.services.VideoDownloadService
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.Coroutines.main
@@ -234,10 +234,10 @@ object VideoDownloadManager {
                 return cachedBitmaps[url]
             }
 
-            val bitmap = com.bumptech.glide.Glide.with(this)
+            val bitmap = Glide.with(this)
                 .asBitmap()
                 .load(GlideUrl(url) { headers ?: emptyMap() })
-                .into(720, 720)
+                .submit(720, 720)
                 .get()
 
             if (bitmap != null) {

--- a/app/src/main/res/layout/fragment_downloads.xml
+++ b/app/src/main/res/layout/fragment_downloads.xml
@@ -143,17 +143,15 @@
 
     <TextView
         android:id="@+id/text_no_downloads"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_gravity="center"
+        android:layout_margin="30dp"
+        android:text="@string/downloads_empty"
+        android:textSize="15sp"
+        android:gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <!--
     <ProgressBar

--- a/app/src/main/res/layout/fragment_downloads.xml
+++ b/app/src/main/res/layout/fragment_downloads.xml
@@ -148,7 +148,6 @@
         android:layout_gravity="center"
         android:layout_margin="30dp"
         android:text="@string/downloads_empty"
-        android:textSize="15sp"
         android:gravity="center"
         android:visibility="gone"
         tools:visibility="visible" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="download_canceled">Download Canceled</string>
     <string name="download_done">Download Done</string>
     <string name="download_format" translatable="false">%s - %s</string>
-    <string name="downloads_empty">You currently don\'t have any downloads.</string>
+    <string name="downloads_empty">There are currently no downloads.</string>
     <string name="update_started">Update Started</string>
     <string name="stream">Network stream</string>
     <string name="error_loading_links_toast">Error Loading Links</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,9 +339,9 @@
     <string name="livestreams">Livestreams</string>
     <string name="nsfw">NSFW</string>
     <string name="others">Others</string>
-    <plurals name="episodes">
-        <item quantity="one">Episode</item>
-        <item quantity="other">Episodes</item>
+    <plurals name="episodes" translatable="false">
+        <item quantity="one">@string/episode</item>
+        <item quantity="other">@string/episodes</item>
     </plurals>
     <!--singular-->
     <string name="movies_singular">Movie</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,6 +339,10 @@
     <string name="livestreams">Livestreams</string>
     <string name="nsfw">NSFW</string>
     <string name="others">Others</string>
+    <plurals name="episodes">
+        <item quantity="one">Episode</item>
+        <item quantity="other">Episodes</item>
+    </plurals>
     <!--singular-->
     <string name="movies_singular">Movie</string>
     <string name="tv_series_singular">Series</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <string name="download_canceled">Download Canceled</string>
     <string name="download_done">Download Done</string>
     <string name="download_format" translatable="false">%s - %s</string>
+    <string name="downloads_empty">You currently don\'t have any downloads.</string>
     <string name="update_started">Update Started</string>
     <string name="stream">Network stream</string>
     <string name="error_loading_links_toast">Error Loading Links</string>


### PR DESCRIPTION
I tracked down underlying issues to setPersistentId. So I instead improved this using IO context, and this makes it use the view model more when in the downloads view, because otherwise when running savedData in an IO context it causes it to wait before updating progress which causes visible UI delays. This prevents that with downloads with the IsDone status.

This also has a UI change: If a download is complete, it no longer shows bytes / bytes, it only shows bytes once. This is both a UI and performance improvement to have to do less. Finally, this does some cleanup to DownloadAdapter and DownloadViewModel as well and fixes the display of the no downloads messages which previously seemed to have intended implementation but did nothing.

This also fixes the underlying cause of many bugs like the byte mismatch, while my previous fix for that was just a patch-job, this should fix the underlying cause of them as well.

Overall when testing this makes downloads load with almost no lag at all now.