### PR TITLE
Fix debug exceptions in releases

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,6 @@ plugins {
 
 val tmpFilePath = System.getProperty("user.home") + "/work/_temp/keystore/"
 val prereleaseStoreFile: File? = File(tmpFilePath).listFiles()?.first()
-var isLibraryDebug = false
 
 fun String.execute() = ByteArrayOutputStream().use { baot ->
     if (project.exec {
@@ -105,7 +104,6 @@ android {
             )
         }
         debug {
-            isLibraryDebug = true
             isDebuggable = true
             applicationIdSuffix = ".debug"
             proguardFiles(
@@ -236,7 +234,14 @@ dependencies {
     implementation("com.github.Blatzar:NiceHttp:0.4.11") // HTTP Lib
 
     implementation(project(":library") {
-        this.extra.set("isDebug", isLibraryDebug)
+        // There does not seem to be a good way of getting the android flavor.
+        val isDebug = gradle.startParameter.taskRequests.any { task ->
+            task.args.any { arg ->
+                arg.contains("debug", true)
+            }
+        }
+
+        this.extra.set("isDebug", isDebug)
     })
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -38,6 +38,11 @@ buildkonfig {
 
     defaultConfigs {
         val isDebug = kotlin.runCatching { extra.get("isDebug") }.getOrNull() == true
+        if (isDebug) {
+            logger.quiet("Compiling library with debug flag")
+        } else {
+            logger.quiet("Compiling library with release flag")
+        }
         buildConfigField(FieldSpec.Type.BOOLEAN, "DEBUG", isDebug.toString())
     }
 }


### PR DESCRIPTION
Fixes https://github.com/recloudstream/cloudstream/issues/1167

Tested and works, although I would have liked a better build flavor detection.
`arg.contains("debug", true)` could be swapped with more precise checks, but that would be more likely to break if the flavor name changes.