### PR TITLE
feat(UI): Use same Episode holder size

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/EpisodeAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/EpisodeAdapter.kt
@@ -57,8 +57,7 @@ const val ACTION_PLAY_EPISODE_IN_MPV = 17
 const val ACTION_MARK_AS_WATCHED = 18
 const val ACTION_FCAST = 19
 
-const val TV_EP_SIZE_LARGE = 400
-const val TV_EP_SIZE_SMALL = 300
+const val TV_EP_SIZE = 400
 data class EpisodeClickEvent(val action: Int, val data: ResultEpisode)
 
 class EpisodeAdapter(
@@ -181,7 +180,7 @@ class EpisodeAdapter(
         fun bind(card: ResultEpisode) {
             localCard = card
             val setWidth =
-                if (isLayout(TV or EMULATOR)) TV_EP_SIZE_LARGE.toPx else ViewGroup.LayoutParams.MATCH_PARENT
+                if (isLayout(TV or EMULATOR)) TV_EP_SIZE.toPx else ViewGroup.LayoutParams.MATCH_PARENT
 
             binding.episodeLinHolder.layoutParams.width = setWidth
             binding.episodeHolderLarge.layoutParams.width = setWidth
@@ -336,7 +335,7 @@ class EpisodeAdapter(
         fun bind(card: ResultEpisode) {
             binding.episodeHolder.layoutParams.apply {
                 width =
-                    if (isLayout(TV or EMULATOR)) TV_EP_SIZE_SMALL.toPx else ViewGroup.LayoutParams.MATCH_PARENT
+                    if (isLayout(TV or EMULATOR)) TV_EP_SIZE.toPx else ViewGroup.LayoutParams.MATCH_PARENT
             }
 
             binding.apply {

--- a/app/src/main/res/layout/result_episode.xml
+++ b/app/src/main/res/layout/result_episode.xml
@@ -90,14 +90,15 @@
 
             android:textColor="?attr/textColor"
             tools:text="Episode 1" />
-    </LinearLayout>
 
-    <com.lagradost.cloudstream3.ui.download.button.PieFetchButton
-        android:id="@+id/download_button"
-        android:layout_width="@dimen/download_size"
-        android:layout_height="@dimen/download_size"
-        android:layout_gravity="center_vertical|end"
-        android:layout_marginStart="-50dp"
-        android:background="?selectableItemBackgroundBorderless"
-        android:padding="10dp" />
+        <com.lagradost.cloudstream3.ui.download.button.PieFetchButton
+            android:id="@+id/download_button"
+            android:layout_width="@dimen/download_size"
+            android:layout_height="@dimen/download_size"
+            android:layout_gravity="center_vertical|end"
+            android:layout_marginStart="-60dp"
+            android:background="?selectableItemBackgroundBorderless"
+            android:padding="10dp" />
+
+    </LinearLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
When the season has episodes that mix use the large & small episode holders, margin & sizes will be different which make the UI inconsistent, so: 
- on TV: Use the same width size.
- on Mobile: Use same margin for download button.