### PR TITLE
Move setting downloadStorageAppbar visibility to downloadBytes

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
@@ -101,10 +101,10 @@ class DownloadFragment : Fragment() {
         }
         observe(downloadsViewModel.usedBytes) {
             updateStorageInfo(view.context, it, R.string.used_storage, binding?.downloadUsedTxt, binding?.downloadUsed)
-            binding?.downloadStorageAppbar?.isVisible = it > 0
         }
         observe(downloadsViewModel.downloadBytes) {
             updateStorageInfo(view.context, it, R.string.app_storage, binding?.downloadAppTxt, binding?.downloadApp)
+            binding?.downloadStorageAppbar?.isVisible = it > 0
         }
 
         val adapter = DownloadAdapter(


### PR DESCRIPTION
I think this was always intended. If not it should just be removed completely. If you have the app itself installed you are using storage on your device (which is what usedBytes is), I think the intended purpose was used bytes within the app (which is what downloadBytes is)