### PR TITLE
feat(TV UI): Player's Top controls redesign

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -912,7 +912,11 @@ class CS3IPlayer : IPlayer {
                     }
 
                     CSPlayerEvent.SeekForward -> seekTime(seekActionTime, source)
+
                     CSPlayerEvent.SeekBack -> seekTime(-seekActionTime, source)
+
+                    CSPlayerEvent.Restart -> seekTo(0, source)
+
                     CSPlayerEvent.NextEpisode -> event(
                         EpisodeSeekEvent(
                             offset = 1,

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -704,6 +704,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
             //player_media_route_button?.isClickable = !isGone
             playerGoBackHolder.isGone = isGone
             playerSourcesBtt.isGone = isGone
+            playerSkipEpisode.isClickable = !isGone
         }
     }
 
@@ -1222,6 +1223,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
 
         // if nothing has loaded these buttons should not be visible
         playerBinding?.apply {
+            playerSkipEpisode.isVisible = false
             playerGoForward.isVisible = false
             playerTracksBtt.isVisible = false
             playerSkipOp.isVisible = false
@@ -1457,6 +1459,11 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
             playerSkipOp.setOnClickListener {
                 autoHide()
                 skipOp()
+            }
+
+            playerSkipEpisode.setOnClickListener {
+                autoHide()
+                player.handleEvent(CSPlayerEvent.NextEpisode)
             }
 
             playerGoForward.setOnClickListener {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -46,6 +46,7 @@ import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
 import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.utils.AppContextUtils.isUsingMobileData
+import com.lagradost.cloudstream3.utils.AppContextUtils.setDefaultFocus
 import com.lagradost.cloudstream3.utils.DataStoreHelper
 import com.lagradost.cloudstream3.utils.SingleSelectionHelper.showDialog
 import com.lagradost.cloudstream3.utils.UIHelper.colorFromAttribute
@@ -59,6 +60,7 @@ import com.lagradost.cloudstream3.utils.UIHelper.toPx
 import com.lagradost.cloudstream3.utils.UserPreferenceDelegate
 import com.lagradost.cloudstream3.utils.Vector2
 import kotlin.math.*
+import kotlin.system.exitProcess
 
 const val MINIMUM_SEEK_TIME = 7000L         // when swipe seeking
 const val MINIMUM_VERTICAL_SWIPE = 2.0f     // in percentage
@@ -492,9 +494,17 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
                 player.seekTime(1L)
             }
             resetBtt.setOnClickListener {
-                subtitleDelay = 0
-                dialog.dismissSafe(activity)
-                player.seekTime(1L)
+                val resetSubsBuilder: AlertDialog.Builder = AlertDialog.Builder(ctx)
+                resetSubsBuilder.setTitle(R.string.confirm_reset_subs_dialog)
+                resetSubsBuilder.apply {
+                    setNegativeButton(R.string.no) { _, _ -> }
+                    setPositiveButton(R.string.yes) { _, _ ->
+                        subtitleDelay = 0
+                        dialog.dismissSafe(activity)
+                        player.seekTime(1L)
+                    }
+                }
+                resetSubsBuilder.show().setDefaultFocus()
             }
             cancelBtt.setOnClickListener {
                 subtitleDelay = beforeOffset

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -243,7 +243,6 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
 
         val playerSourceMove = if (isShowing) 0f else -50.toPx.toFloat()
 
-
         playerBinding?.apply {
             playerOpenSource.let {
                 ObjectAnimator.ofFloat(it, "translationY", playerSourceMove).apply {
@@ -705,7 +704,6 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
             //player_media_route_button?.isClickable = !isGone
             playerGoBackHolder.isGone = isGone
             playerSourcesBtt.isGone = isGone
-            playerSkipEpisode.isClickable = !isGone
         }
     }
 
@@ -1224,7 +1222,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
 
         // if nothing has loaded these buttons should not be visible
         playerBinding?.apply {
-            playerSkipEpisode.isVisible = false
+            playerGoForward.isVisible = false
             playerTracksBtt.isVisible = false
             playerSkipOp.isVisible = false
             shadowOverlay.isVisible = false
@@ -1296,6 +1294,10 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
 
                 PlayerEventType.SeekBack -> {
                     player.handleEvent(CSPlayerEvent.SeekBack)
+                }
+
+                PlayerEventType.Restart -> {
+                    player.handleEvent(CSPlayerEvent.Restart)
                 }
 
                 PlayerEventType.ToggleMute -> {
@@ -1457,9 +1459,14 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
                 skipOp()
             }
 
-            playerSkipEpisode.setOnClickListener {
+            playerGoForward.setOnClickListener {
                 autoHide()
                 player.handleEvent(CSPlayerEvent.NextEpisode)
+            }
+
+            playerRestart.setOnClickListener {
+                autoHide()
+                player.handleEvent(CSPlayerEvent.Restart)
             }
 
             playerLock.setOnClickListener {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -14,7 +14,13 @@ import android.os.Bundle
 import android.provider.Settings
 import android.text.Editable
 import android.text.format.DateUtils
-import android.view.*
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.Surface
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
 import android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
 import android.view.animation.AlphaAnimation
 import android.view.animation.Animation
@@ -46,7 +52,6 @@ import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
 import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.utils.AppContextUtils.isUsingMobileData
-import com.lagradost.cloudstream3.utils.AppContextUtils.setDefaultFocus
 import com.lagradost.cloudstream3.utils.DataStoreHelper
 import com.lagradost.cloudstream3.utils.SingleSelectionHelper.showDialog
 import com.lagradost.cloudstream3.utils.UIHelper.colorFromAttribute
@@ -59,8 +64,11 @@ import com.lagradost.cloudstream3.utils.UIHelper.showSystemUI
 import com.lagradost.cloudstream3.utils.UIHelper.toPx
 import com.lagradost.cloudstream3.utils.UserPreferenceDelegate
 import com.lagradost.cloudstream3.utils.Vector2
-import kotlin.math.*
-import kotlin.system.exitProcess
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.round
 
 const val MINIMUM_SEEK_TIME = 7000L         // when swipe seeking
 const val MINIMUM_VERTICAL_SWIPE = 2.0f     // in percentage
@@ -494,17 +502,9 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
                 player.seekTime(1L)
             }
             resetBtt.setOnClickListener {
-                val resetSubsBuilder: AlertDialog.Builder = AlertDialog.Builder(ctx)
-                resetSubsBuilder.setTitle(R.string.confirm_reset_subs_dialog)
-                resetSubsBuilder.apply {
-                    setNegativeButton(R.string.no) { _, _ -> }
-                    setPositiveButton(R.string.yes) { _, _ ->
-                        subtitleDelay = 0
-                        dialog.dismissSafe(activity)
-                        player.seekTime(1L)
-                    }
-                }
-                resetSubsBuilder.show().setDefaultFocus()
+                subtitleDelay = 0
+                dialog.dismissSafe(activity)
+                player.seekTime(1L)
             }
             cancelBtt.setOnClickListener {
                 subtitleDelay = beforeOffset

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -77,7 +77,8 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
     protected open var isFullScreenPlayer = true
     protected var playerBinding: PlayerCustomLayoutBinding? = null
 
-    private var durationMode : Boolean by UserPreferenceDelegate("duration_mode", false)
+    private var durationMode: Boolean by UserPreferenceDelegate("duration_mode", false)
+
     // state of player UI
     protected var isShowing = false
     protected var isLocked = false
@@ -283,7 +284,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
             player.getCurrentPreferredSubtitle() == null
     }
 
-    private fun restoreOrientationWithSensor(activity: Activity){
+    private fun restoreOrientationWithSensor(activity: Activity) {
         val currentOrientation = activity.resources.configuration.orientation
         var orientation = 0
         when (currentOrientation) {
@@ -299,7 +300,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
         activity.requestedOrientation = orientation
     }
 
-    private fun toggleOrientationWithSensor(activity: Activity){
+    private fun toggleOrientationWithSensor(activity: Activity) {
         val currentOrientation = activity.resources.configuration.orientation
         var orientation = 0
         when (currentOrientation) {
@@ -344,12 +345,11 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
 
     private fun updateOrientation(ignoreDynamicOrientation: Boolean = false) {
         activity?.apply {
-            if(lockRotation) {
-                if(isLocked) {
+            if (lockRotation) {
+                if (isLocked) {
                     lockOrientation(this)
-                }
-                else {
-                    if(ignoreDynamicOrientation){
+                } else {
+                    if (ignoreDynamicOrientation) {
                         // restore when lock is disabled
                         restoreOrientationWithSensor(this)
                     } else {
@@ -948,7 +948,10 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
                                         }
 
                                         else -> {
-                                            player.handleEvent(CSPlayerEvent.PlayPauseToggle, PlayerEventSource.UI)
+                                            player.handleEvent(
+                                                CSPlayerEvent.PlayPauseToggle,
+                                                PlayerEventSource.UI
+                                            )
                                         }
                                     }
                                 } else if (doubleTapEnabled && isFullScreenPlayer) {
@@ -1423,6 +1426,25 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
         }
 
         playerBinding?.apply {
+
+            if (isLayout(TV or EMULATOR)) {
+                mapOf(
+                    playerGoBack to playerGoBackText,
+                    playerRestart to playerRestartText,
+                    playerGoForward to playerGoForwardText
+                ).forEach { (button, text) ->
+                    button.setOnFocusChangeListener { _, hasFocus ->
+                        if (!hasFocus) {
+                            text.isSelected = false
+                            text.isVisible = false
+                            return@setOnFocusChangeListener
+                        }
+                        text.isSelected = true
+                        text.isVisible = true
+                    }
+                }
+            }
+
             playerPausePlay.setOnClickListener {
                 autoHide()
                 player.handleEvent(CSPlayerEvent.PlayPauseToggle)
@@ -1569,7 +1591,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
 
     private fun setRemainingTimeCounter(showRemaining: Boolean) {
         durationMode = showRemaining
-        playerBinding?.exoDuration?.isInvisible= showRemaining
+        playerBinding?.exoDuration?.isInvisible = showRemaining
         playerBinding?.timeLeft?.isVisible = showRemaining
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1096,7 +1096,8 @@ class GeneratorPlayer : FullScreenPlayer() {
         }
 
         playerBinding?.playerSkipOp?.isVisible = isOpVisible
-        playerBinding?.playerSkipEpisode?.isVisible =
+
+        playerBinding?.playerGoForward?.isVisible =
             !isOpVisible && viewModel.hasNextEpisode() == true
 
         if (percentage >= PRELOAD_NEXT_EPISODE_PERCENTAGE) {
@@ -1253,7 +1254,7 @@ class GeneratorPlayer : FullScreenPlayer() {
     fun setPlayerDimen(widthHeight: Pair<Int, Int>?) {
         val extra = if (widthHeight != null) {
             val (width, height) = widthHeight
-            "${width}x${height}"
+            "- ${width}x${height}"
         } else {
             ""
         }
@@ -1264,7 +1265,7 @@ class GeneratorPlayer : FullScreenPlayer() {
             0 -> ""
             1 -> extra
             2 -> source
-            3 -> "$source - $extra"
+            3 -> "$source $extra"
             else -> ""
         }
         playerBinding?.playerVideoTitleRez?.apply {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1100,7 +1100,7 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         when {
             isLayout(PHONE) ->
-                playerBinding?.playerGoForward?.isVisible =
+                playerBinding?.playerSkipEpisode?.isVisible =
                     !isOpVisible && viewModel.hasNextEpisode() == true
 
             else ->

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -44,6 +44,7 @@ import com.lagradost.cloudstream3.ui.player.source_priority.QualityDataHelper
 import com.lagradost.cloudstream3.ui.player.source_priority.QualityProfileDialog
 import com.lagradost.cloudstream3.ui.result.*
 import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
+import com.lagradost.cloudstream3.ui.settings.Globals.PHONE
 import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.ui.subtitles.SUBTITLE_AUTO_SELECT_KEY
@@ -1097,8 +1098,14 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         playerBinding?.playerSkipOp?.isVisible = isOpVisible
 
-        playerBinding?.playerGoForward?.isVisible =
-            !isOpVisible && viewModel.hasNextEpisode() == true
+        when {
+            isLayout(PHONE) ->
+                playerBinding?.playerGoForward?.isVisible =
+                    !isOpVisible && viewModel.hasNextEpisode() == true
+
+            else ->
+                playerBinding?.playerGoForward?.isVisible = viewModel.hasNextEpisode() == true
+        }
 
         if (percentage >= PRELOAD_NEXT_EPISODE_PERCENTAGE) {
             viewModel.preLoadNextLinks()
@@ -1290,7 +1297,8 @@ class GeneratorPlayer : FullScreenPlayer() {
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
         // this is used instead of layout-television to follow the settings and some TV devices are not classified as TV for some reason
-        layout = if (isLayout(TV or EMULATOR)) R.layout.fragment_player_tv else R.layout.fragment_player
+        layout =
+            if (isLayout(TV or EMULATOR)) R.layout.fragment_player_tv else R.layout.fragment_player
 
         viewModel = ViewModelProvider(this)[PlayerGeneratorViewModel::class.java]
         sync = ViewModelProvider(this)[SyncViewModel::class.java]

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
@@ -26,6 +26,7 @@ enum class PlayerEventType(val value: Int) {
     Resize(13),
     SearchSubtitlesOnline(14),
     SkipOp(15),
+    Restart(16),
 }
 
 enum class CSPlayerEvent(val value: Int) {
@@ -39,6 +40,7 @@ enum class CSPlayerEvent(val value: Int) {
     PrevEpisode(6),
     PlayPauseToggle(7),
     ToggleMute(8),
+    Restart(9),
 }
 
 enum class CSPlayerLoading {

--- a/app/src/main/res/drawable/ic_baseline_equalizer_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_equalizer_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M160,800v-320h160v320L160,800ZM400,800v-640h160v640L400,800ZM640,800v-440h160v440L640,800Z"
+      android:fillColor="#5f6368"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_replay_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_replay_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,5V2.21c0,-0.45 -0.54,-0.67 -0.85,-0.35l-3.8,3.79c-0.2,0.2 -0.2,0.51 0,0.71l3.79,3.79c0.32,0.31 0.86,0.09 0.86,-0.36V7c3.73,0 6.68,3.42 5.86,7.29 -0.47,2.27 -2.31,4.1 -4.57,4.57 -3.57,0.75 -6.75,-1.7 -7.23,-5.01 -0.07,-0.48 -0.49,-0.85 -0.98,-0.85 -0.6,0 -1.08,0.53 -1,1.13 0.62,4.39 4.8,7.64 9.53,6.72 3.12,-0.61 5.63,-3.12 6.24,-6.24C20.84,9.48 16.94,5 12,5z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_restart_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_restart_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M440,838q-121,-15 -200.5,-105.5T160,520q0,-66 26,-126.5T260,288l57,57q-38,34 -57.5,79T240,520q0,88 56,155.5T440,758v80ZM520,838v-80q87,-16 143.5,-83T720,520q0,-100 -70,-170t-170,-70h-3l44,44 -56,56 -140,-140 140,-140 56,56 -44,44h3q134,0 227,93t93,227q0,121 -79.5,211.5T520,838Z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_skip_next_24_big.xml
+++ b/app/src/main/res/drawable/ic_baseline_skip_next_24_big.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M2.775,21.225 L15.844,12 2.775,2.775ZM18.15,2.775v18.45h3.075V2.775Z"
+      android:strokeWidth="1.5375"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_skip_next_rounded_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_skip_next_rounded_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M7.58,16.89l5.77,-4.07c0.56,-0.4 0.56,-1.24 0,-1.63L7.58,7.11C6.91,6.65 6,7.12 6,7.93v8.14c0,0.81 0.91,1.28 1.58,0.82zM16,7v10c0,0.55 0.45,1 1,1s1,-0.45 1,-1V7c0,-0.55 -0.45,-1 -1,-1s-1,0.45 -1,1z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/app/src/main/res/layout/fragment_player_tv.xml
+++ b/app/src/main/res/layout/fragment_player_tv.xml
@@ -68,7 +68,9 @@
             android:layout_height="wrap_content"
             android:layout_margin="5dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            android:visibility="gone"
+            tools:visibility="visible">
 
             <ImageView
                 android:layout_width="30dp"
@@ -82,12 +84,11 @@
                 android:id="@+id/player_loading_go_back"
                 android:layout_width="70dp"
                 android:layout_height="70dp"
-
                 android:layout_gravity="center"
                 android:background="@drawable/video_tap_button_always_white"
-                android:clickable="true"
-                android:focusable="true"
-                android:focusableInTouchMode="true"
+                android:clickable="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
                 android:nextFocusRight="@id/overlay_loading_skip_button"
                 android:nextFocusDown="@id/overlay_loading_skip_button" />
         </FrameLayout>

--- a/app/src/main/res/layout/player_custom_layout.xml
+++ b/app/src/main/res/layout/player_custom_layout.xml
@@ -176,47 +176,104 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent">
 
-                    <ImageView
-                        android:id="@+id/player_go_back"
-                        android:layout_width="30dp"
-                        android:layout_height="30dp"
-                        android:src="@drawable/ic_baseline_arrow_back_24"
-                        app:tint="@android:color/white"
-                        android:background="@drawable/video_tap_button_always_white"
-                        android:clickable="true"
-                        android:contentDescription="@string/go_back_img_des"
-                        android:focusable="true"
-                        android:tag="@string/tv_no_focus_tag" />
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="10dp"
+                        android:id="@+id/player_go_back_root"
+                        android:orientation="vertical">
 
-                    <ImageView
-                        android:id="@+id/player_restart"
-                        android:layout_width="30dp"
-                        android:layout_height="30dp"
+                        <ImageView
+                            android:id="@+id/player_go_back"
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_baseline_arrow_back_24"
+                            app:tint="@android:color/white"
+                            android:background="@drawable/video_tap_button_always_white"
+                            android:clickable="true"
+                            android:contentDescription="@string/go_back_img_des"
+                            android:focusable="true"
+                            android:nextFocusRight="@id/player_restart"
+                            android:nextFocusLeft="@id/player_go_back"
+                            android:nextFocusDown="@id/player_pause_play"
+                            android:nextFocusUp="@id/player_go_back"
+                            android:tag="@string/tv_no_focus_tag" />
+
+                        <TextView
+                            android:id="@+id/player_go_back_text"
+                            style="@style/ResultMarqueeButtonText"
+                            android:text="@string/go_back_img_des"
+                            android:visibility="gone"/>
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
                         android:layout_marginStart="40dp"
-                        android:src="@drawable/ic_baseline_replay_24"
-                        app:tint="@android:color/white"
-                        android:background="@drawable/video_tap_button_always_white"
-                        android:clickable="true"
-                        android:contentDescription="@string/go_back_img_des"
-                        android:focusable="true"
-                        android:visibility="gone"
-                        tools:visibility="visible"
-                        android:tag="@string/tv_no_focus_tag" />
+                        android:layout_marginEnd="10dp"
+                        android:id="@+id/player_restart_root"
+                        android:orientation="vertical">
 
-                    <ImageView
-                        android:id="@+id/player_go_forward"
-                        android:layout_width="30dp"
-                        android:layout_height="30dp"
+                        <ImageView
+                            android:id="@+id/player_restart"
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_baseline_replay_24"
+                            app:tint="@android:color/white"
+                            android:background="@drawable/video_tap_button_always_white"
+                            android:clickable="true"
+                            android:contentDescription="@string/restart"
+                            android:focusable="true"
+                            android:nextFocusRight="@id/player_go_forward"
+                            android:nextFocusLeft="@id/player_go_back"
+                            android:nextFocusDown="@id/player_pause_play"
+                            android:nextFocusUp="@id/player_restart"
+                            android:tag="@string/tv_no_focus_tag" />
+
+                        <TextView
+                            android:id="@+id/player_restart_text"
+                            style="@style/ResultMarqueeButtonText"
+                            android:text="@string/restart"
+                            android:visibility="gone"/>
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
                         android:layout_marginStart="80dp"
-                        android:src="@drawable/ic_baseline_skip_next_rounded_24"
-                        app:tint="@android:color/white"
-                        android:background="@drawable/video_tap_button_always_white"
-                        android:clickable="true"
-                        android:contentDescription="@string/go_back_img_des"
-                        android:focusable="true"
-                        android:visibility="gone"
-                        tools:visibility="visible"
-                        android:tag="@string/tv_no_focus_tag" />
+                        android:layout_marginEnd="10dp"
+                        android:id="@+id/player_go_forward_root"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:id="@+id/player_go_forward"
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_baseline_skip_next_rounded_24"
+                            app:tint="@android:color/white"
+                            android:background="@drawable/video_tap_button_always_white"
+                            android:clickable="true"
+                            android:nextFocusRight="@id/player_go_forward"
+                            android:nextFocusLeft="@id/player_restart"
+                            android:nextFocusDown="@id/player_pause_play"
+                            android:nextFocusUp="@id/player_go_forward"
+                            android:contentDescription="@string/next_episode"
+                            android:focusable="true"
+                            android:tag="@string/tv_no_focus_tag" />
+
+                        <TextView
+                            android:id="@+id/player_go_forward_text"
+                            style="@style/ResultMarqueeButtonText"
+                            android:text="@string/next_episode"
+                            android:visibility="gone"/>
+
+                    </LinearLayout>
+
                 </FrameLayout>
 
 

--- a/app/src/main/res/layout/player_custom_layout.xml
+++ b/app/src/main/res/layout/player_custom_layout.xml
@@ -214,7 +214,8 @@
                         android:layout_marginStart="40dp"
                         android:layout_marginEnd="10dp"
                         android:id="@+id/player_restart_root"
-                        android:orientation="vertical">
+                        android:orientation="vertical"
+                        android:visibility="gone">
 
                         <ImageView
                             android:id="@+id/player_restart"
@@ -236,8 +237,7 @@
                         <TextView
                             android:id="@+id/player_restart_text"
                             style="@style/ResultMarqueeButtonText"
-                            android:text="@string/restart"
-                            android:visibility="gone"/>
+                            android:text="@string/restart" />
 
                     </LinearLayout>
 
@@ -247,7 +247,8 @@
                         android:layout_marginStart="80dp"
                         android:layout_marginEnd="10dp"
                         android:id="@+id/player_go_forward_root"
-                        android:orientation="vertical">
+                        android:orientation="vertical"
+                        android:visibility="gone">
 
                         <ImageView
                             android:id="@+id/player_go_forward"
@@ -269,8 +270,7 @@
                         <TextView
                             android:id="@+id/player_go_forward_text"
                             style="@style/ResultMarqueeButtonText"
-                            android:text="@string/next_episode"
-                            android:visibility="gone"/>
+                            android:text="@string/next_episode" />
 
                     </LinearLayout>
 

--- a/app/src/main/res/layout/player_custom_layout.xml
+++ b/app/src/main/res/layout/player_custom_layout.xml
@@ -193,7 +193,7 @@
                         android:layout_width="30dp"
                         android:layout_height="30dp"
                         android:layout_marginStart="40dp"
-                        android:src="@drawable/ic_baseline_restart_24"
+                        android:src="@drawable/ic_baseline_replay_24"
                         app:tint="@android:color/white"
                         android:background="@drawable/video_tap_button_always_white"
                         android:clickable="true"
@@ -208,7 +208,7 @@
                         android:layout_width="30dp"
                         android:layout_height="30dp"
                         android:layout_marginStart="80dp"
-                        android:src="@drawable/ic_baseline_arrow_forward_24"
+                        android:src="@drawable/ic_baseline_skip_next_rounded_24"
                         app:tint="@android:color/white"
                         android:background="@drawable/video_tap_button_always_white"
                         android:clickable="true"
@@ -660,6 +660,14 @@
                                 android:nextFocusRight="@id/player_skip_episode"
                                 android:text="@string/video_skip_op"
                                 app:icon="@drawable/ic_baseline_fast_forward_24" />
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/player_skip_episode"
+                                style="@style/VideoButton"
+                                android:nextFocusLeft="@id/player_skip_op"
+                                android:nextFocusRight="@id/player_lock"
+                                android:text="@string/next_episode"
+                                app:icon="@drawable/ic_baseline_skip_next_24" />
 
                         </LinearLayout>
                     </LinearLayout>

--- a/app/src/main/res/layout/player_custom_layout.xml
+++ b/app/src/main/res/layout/player_custom_layout.xml
@@ -172,27 +172,51 @@
                     android:id="@+id/player_go_back_holder"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_margin="5dp"
+                    android:layout_margin="20dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent">
 
                     <ImageView
+                        android:id="@+id/player_go_back"
                         android:layout_width="30dp"
                         android:layout_height="30dp"
-                        android:layout_gravity="center"
-                        android:contentDescription="@string/go_back_img_des"
                         android:src="@drawable/ic_baseline_arrow_back_24"
-                        app:tint="@android:color/white" />
-
-                    <ImageView
-                        android:id="@+id/player_go_back"
-                        android:layout_width="70dp"
-                        android:layout_height="70dp"
-                        android:layout_gravity="center"
+                        app:tint="@android:color/white"
                         android:background="@drawable/video_tap_button_always_white"
                         android:clickable="true"
                         android:contentDescription="@string/go_back_img_des"
-                        android:focusable="true" />
+                        android:focusable="true"
+                        android:tag="@string/tv_no_focus_tag" />
+
+                    <ImageView
+                        android:id="@+id/player_restart"
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:layout_marginStart="40dp"
+                        android:src="@drawable/ic_baseline_restart_24"
+                        app:tint="@android:color/white"
+                        android:background="@drawable/video_tap_button_always_white"
+                        android:clickable="true"
+                        android:contentDescription="@string/go_back_img_des"
+                        android:focusable="true"
+                        android:visibility="gone"
+                        tools:visibility="visible"
+                        android:tag="@string/tv_no_focus_tag" />
+
+                    <ImageView
+                        android:id="@+id/player_go_forward"
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:layout_marginStart="80dp"
+                        android:src="@drawable/ic_baseline_arrow_forward_24"
+                        app:tint="@android:color/white"
+                        android:background="@drawable/video_tap_button_always_white"
+                        android:clickable="true"
+                        android:contentDescription="@string/go_back_img_des"
+                        android:focusable="true"
+                        android:visibility="gone"
+                        tools:visibility="visible"
+                        android:tag="@string/tv_no_focus_tag" />
                 </FrameLayout>
 
 
@@ -637,14 +661,6 @@
                                 android:text="@string/video_skip_op"
                                 app:icon="@drawable/ic_baseline_fast_forward_24" />
 
-                            <com.google.android.material.button.MaterialButton
-                                android:id="@+id/player_skip_episode"
-                                style="@style/VideoButton"
-                                android:nextFocusLeft="@id/player_skip_op"
-
-                                android:nextFocusRight="@id/player_lock"
-                                android:text="@string/next_episode"
-                                app:icon="@drawable/ic_baseline_skip_next_24" />
                         </LinearLayout>
                     </LinearLayout>
                 </HorizontalScrollView>

--- a/app/src/main/res/layout/player_custom_layout.xml
+++ b/app/src/main/res/layout/player_custom_layout.xml
@@ -650,7 +650,7 @@
                                 android:nextFocusLeft="@id/player_sources_btt"
                                 android:nextFocusRight="@id/player_skip_op"
                                 android:text="@string/tracks"
-                                app:icon="@drawable/ic_baseline_playlist_play_24" />
+                                app:icon="@drawable/ic_baseline_equalizer_24" />
 
                             <com.google.android.material.button.MaterialButton
                                 android:id="@+id/player_skip_op"

--- a/app/src/main/res/layout/player_custom_layout_tv.xml
+++ b/app/src/main/res/layout/player_custom_layout_tv.xml
@@ -314,7 +314,7 @@
                         android:layout_width="30dp"
                         android:layout_height="30dp"
                         android:layout_marginStart="40dp"
-                        android:src="@drawable/ic_baseline_restart_24"
+                        android:src="@drawable/ic_baseline_replay_24"
                         app:tint="@android:color/white"
                         android:background="@drawable/video_tap_button_always_white"
                         android:clickable="true"
@@ -331,7 +331,7 @@
                         android:layout_width="30dp"
                         android:layout_height="30dp"
                         android:layout_marginStart="80dp"
-                        android:src="@drawable/ic_baseline_arrow_forward_24"
+                        android:src="@drawable/ic_baseline_skip_next_rounded_24"
                         app:tint="@android:color/white"
                         android:background="@drawable/video_tap_button_always_white"
                         android:clickable="true"
@@ -703,6 +703,18 @@
                             android:nextFocusDown="@id/player_skip_episode"
                             android:text="@string/video_skip_op"
                             app:icon="@drawable/ic_baseline_fast_forward_24" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/player_skip_episode"
+                            style="@style/VideoButtonTV"
+                            android:nextFocusLeft="@id/player_skip_op"
+                            android:nextFocusRight="@id/player_resize_btt"
+                            android:nextFocusUp="@id/player_pause_play"
+                            android:nextFocusDown="@id/player_resize_btt"
+                            android:text="@string/next_episode"
+                            app:icon="@drawable/ic_baseline_skip_next_24"
+                            android:visibility="gone"
+                            tools:visibility="visible"/>
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/player_resize_btt"

--- a/app/src/main/res/layout/player_custom_layout_tv.xml
+++ b/app/src/main/res/layout/player_custom_layout_tv.xml
@@ -287,61 +287,115 @@
                     android:id="@+id/player_go_back_holder"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="32dp"
+                    android:layout_marginStart="17dp"
                     android:layout_marginTop="20dp"
-                    android:layout_marginEnd="32dp"
+                    android:layout_marginEnd="17dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent">
 
-                    <ImageView
-                        android:id="@+id/player_go_back"
-                        android:layout_width="30dp"
-                        android:layout_height="30dp"
-                        android:src="@drawable/ic_baseline_arrow_back_24"
-                        app:tint="@android:color/white"
-                        android:background="@drawable/video_tap_button_always_white"
-                        android:clickable="true"
-                        android:contentDescription="@string/go_back_img_des"
-                        android:focusable="true"
-                        android:nextFocusRight="@id/player_restart"
-                        android:nextFocusLeft="@id/player_go_back"
-                        android:nextFocusDown="@id/player_pause_play"
-                        android:nextFocusUp="@id/player_go_back"
-                        android:tag="@string/tv_no_focus_tag" />
+                    <LinearLayout
+                        android:layout_width="60dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="10dp"
+                        android:id="@+id/player_go_back_root"
+                        android:orientation="vertical">
 
-                    <ImageView
-                        android:id="@+id/player_restart"
-                        android:layout_width="30dp"
-                        android:layout_height="30dp"
-                        android:layout_marginStart="40dp"
-                        android:src="@drawable/ic_baseline_replay_24"
-                        app:tint="@android:color/white"
-                        android:background="@drawable/video_tap_button_always_white"
-                        android:clickable="true"
-                        android:contentDescription="@string/go_back_img_des"
-                        android:focusable="true"
-                        android:nextFocusRight="@id/player_go_forward"
-                        android:nextFocusLeft="@id/player_go_back"
-                        android:nextFocusDown="@id/player_pause_play"
-                        android:nextFocusUp="@id/player_restart"
-                        android:tag="@string/tv_no_focus_tag" />
+                        <ImageView
+                            android:id="@+id/player_go_back"
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_baseline_arrow_back_24"
+                            app:tint="@android:color/white"
+                            android:background="@drawable/video_tap_button_always_white"
+                            android:clickable="true"
+                            android:contentDescription="@string/go_back_img_des"
+                            android:focusable="true"
+                            android:nextFocusRight="@id/player_restart"
+                            android:nextFocusLeft="@id/player_go_back"
+                            android:nextFocusDown="@id/player_pause_play"
+                            android:nextFocusUp="@id/player_go_back"
+                            android:tag="@string/tv_no_focus_tag" />
 
-                    <ImageView
-                        android:id="@+id/player_go_forward"
-                        android:layout_width="30dp"
-                        android:layout_height="30dp"
-                        android:layout_marginStart="80dp"
-                        android:src="@drawable/ic_baseline_skip_next_rounded_24"
-                        app:tint="@android:color/white"
-                        android:background="@drawable/video_tap_button_always_white"
-                        android:clickable="true"
-                        android:nextFocusRight="@id/player_go_forward"
-                        android:nextFocusLeft="@id/player_restart"
-                        android:nextFocusDown="@id/player_pause_play"
-                        android:nextFocusUp="@id/player_go_forward"
-                        android:contentDescription="@string/go_back_img_des"
-                        android:focusable="true"
-                        android:tag="@string/tv_no_focus_tag" />
+                        <TextView
+                            android:id="@+id/player_go_back_text"
+                            android:layout_marginTop="5dp"
+                            style="@style/ResultMarqueeButtonText"
+                            android:text="@string/go_back_img_des"
+                            android:visibility="invisible"
+                            tools:visibility="visible"/>
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="60dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="50dp"
+                        android:layout_marginEnd="10dp"
+                        android:id="@+id/player_restart_root"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:id="@+id/player_restart"
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_baseline_replay_24"
+                            app:tint="@android:color/white"
+                            android:background="@drawable/video_tap_button_always_white"
+                            android:clickable="true"
+                            android:contentDescription="@string/restart"
+                            android:focusable="true"
+                            android:nextFocusRight="@id/player_go_forward"
+                            android:nextFocusLeft="@id/player_go_back"
+                            android:nextFocusDown="@id/player_pause_play"
+                            android:nextFocusUp="@id/player_restart"
+                            android:tag="@string/tv_no_focus_tag" />
+
+                        <TextView
+                            android:id="@+id/player_restart_text"
+                            android:layout_marginTop="5dp"
+                            style="@style/ResultMarqueeButtonText"
+                            android:text="@string/restart"
+                            android:visibility="invisible"
+                            tools:visibility="visible"/>
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="60dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="100dp"
+                        android:layout_marginEnd="10dp"
+                        android:id="@+id/player_go_forward_root"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:id="@+id/player_go_forward"
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_baseline_skip_next_rounded_24"
+                            app:tint="@android:color/white"
+                            android:background="@drawable/video_tap_button_always_white"
+                            android:clickable="true"
+                            android:nextFocusRight="@id/player_go_forward"
+                            android:nextFocusLeft="@id/player_restart"
+                            android:nextFocusDown="@id/player_pause_play"
+                            android:nextFocusUp="@id/player_go_forward"
+                            android:contentDescription="@string/next_episode"
+                            android:focusable="true"
+                            android:tag="@string/tv_no_focus_tag" />
+
+                        <TextView
+                            android:id="@+id/player_go_forward_text"
+                            android:layout_marginTop="5dp"
+                            style="@style/ResultMarqueeButtonText"
+                            android:text="@string/next_episode"
+                            android:visibility="invisible"
+                            tools:visibility="visible"/>
+
+                    </LinearLayout>
 
                 </FrameLayout>
             </FrameLayout>
@@ -545,6 +599,7 @@
                     android:layout_height="wrap_content"
                     android:layoutDirection="ltr"
                     android:orientation="horizontal">
+
                     <ImageView
                         android:id="@+id/player_pause_play"
 
@@ -560,10 +615,10 @@
                         android:src="@drawable/netflix_pause"
 
                         android:tag="@string/tv_no_focus_tag"
-                        app:tint="@color/player_button_tv"
-                        tools:ignore="ContentDescription"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintStart_toStartOf="parent" />
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:tint="@color/player_button_tv"
+                        tools:ignore="ContentDescription" />
 
                     <TextView
                         android:id="@id/exo_position"
@@ -654,10 +709,10 @@
                         android:textColor="@android:color/white"
                         android:textSize="14sp"
                         android:textStyle="normal"
+                        android:visibility="gone"
                         app:layout_constraintBaseline_toBaselineOf="@id/exo_position"
                         app:layout_constraintEnd_toEndOf="parent"
-                        tools:text="-23:20"
-                        android:visibility="gone"/>
+                        tools:text="-23:20" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/app/src/main/res/layout/player_custom_layout_tv.xml
+++ b/app/src/main/res/layout/player_custom_layout_tv.xml
@@ -231,7 +231,7 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="80dp"
+                    android:layout_marginStart="32dp"
                     android:layout_marginTop="20dp"
                     android:layout_marginEnd="32dp"
                     android:orientation="vertical">
@@ -240,6 +240,7 @@
                         android:id="@+id/player_video_title"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:textAlignment="viewEnd"
                         android:gravity="end"
                         android:textColor="@color/white"
                         android:textSize="16sp"
@@ -250,6 +251,7 @@
                         android:id="@+id/player_video_title_rez"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:textAlignment="viewEnd"
                         android:gravity="end"
                         android:textColor="@color/white"
                         android:textSize="16sp"
@@ -285,28 +287,62 @@
                     android:id="@+id/player_go_back_holder"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_margin="5dp"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginEnd="32dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent">
 
                     <ImageView
+                        android:id="@+id/player_go_back"
                         android:layout_width="30dp"
                         android:layout_height="30dp"
-                        android:layout_gravity="center"
-                        android:contentDescription="@string/go_back_img_des"
                         android:src="@drawable/ic_baseline_arrow_back_24"
-                        app:tint="@android:color/white" />
-
-                    <ImageView
-                        android:id="@+id/player_go_back"
-                        android:layout_width="70dp"
-                        android:layout_height="70dp"
-                        android:layout_gravity="center"
+                        app:tint="@android:color/white"
                         android:background="@drawable/video_tap_button_always_white"
                         android:clickable="true"
                         android:contentDescription="@string/go_back_img_des"
                         android:focusable="true"
+                        android:nextFocusRight="@id/player_restart"
+                        android:nextFocusLeft="@id/player_go_back"
+                        android:nextFocusDown="@id/player_pause_play"
+                        android:nextFocusUp="@id/player_go_back"
                         android:tag="@string/tv_no_focus_tag" />
+
+                    <ImageView
+                        android:id="@+id/player_restart"
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:layout_marginStart="40dp"
+                        android:src="@drawable/ic_baseline_restart_24"
+                        app:tint="@android:color/white"
+                        android:background="@drawable/video_tap_button_always_white"
+                        android:clickable="true"
+                        android:contentDescription="@string/go_back_img_des"
+                        android:focusable="true"
+                        android:nextFocusRight="@id/player_go_forward"
+                        android:nextFocusLeft="@id/player_go_back"
+                        android:nextFocusDown="@id/player_pause_play"
+                        android:nextFocusUp="@id/player_restart"
+                        android:tag="@string/tv_no_focus_tag" />
+
+                    <ImageView
+                        android:id="@+id/player_go_forward"
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:layout_marginStart="80dp"
+                        android:src="@drawable/ic_baseline_arrow_forward_24"
+                        app:tint="@android:color/white"
+                        android:background="@drawable/video_tap_button_always_white"
+                        android:clickable="true"
+                        android:nextFocusRight="@id/player_go_forward"
+                        android:nextFocusLeft="@id/player_restart"
+                        android:nextFocusDown="@id/player_pause_play"
+                        android:nextFocusUp="@id/player_go_forward"
+                        android:contentDescription="@string/go_back_img_des"
+                        android:focusable="true"
+                        android:tag="@string/tv_no_focus_tag" />
+
                 </FrameLayout>
             </FrameLayout>
 
@@ -520,7 +556,7 @@
                         android:focusable="true"
                         android:focusableInTouchMode="true"
                         android:nextFocusUp="@id/skip_chapter_button"
-                        android:nextFocusDown="@id/player_skip_op"
+                        android:nextFocusDown="@id/player_lock_holder"
                         android:src="@drawable/netflix_pause"
 
                         android:tag="@string/tv_no_focus_tag"
@@ -669,17 +705,6 @@
                             app:icon="@drawable/ic_baseline_fast_forward_24" />
 
                         <com.google.android.material.button.MaterialButton
-                            android:id="@+id/player_skip_episode"
-                            style="@style/VideoButtonTV"
-                            android:nextFocusLeft="@id/player_skip_op"
-
-                            android:nextFocusRight="@id/player_resize_btt"
-                            android:nextFocusUp="@id/player_pause_play"
-                            android:nextFocusDown="@id/player_resize_btt"
-                            android:text="@string/next_episode"
-                            app:icon="@drawable/ic_baseline_skip_next_24" />
-
-                        <com.google.android.material.button.MaterialButton
                             android:id="@+id/player_resize_btt"
                             style="@style/VideoButtonTV"
                             android:nextFocusLeft="@id/player_skip_episode"
@@ -732,7 +757,7 @@
                             android:nextFocusRight="@id/player_skip_op"
                             android:nextFocusUp="@id/player_pause_play"
                             android:text="@string/tracks"
-                            app:icon="@drawable/ic_baseline_playlist_play_24" />
+                            app:icon="@drawable/ic_baseline_equalizer_24" />
                     </LinearLayout>
                 </HorizontalScrollView>
             </LinearLayout>

--- a/app/src/main/res/layout/subtitle_offset.xml
+++ b/app/src/main/res/layout/subtitle_offset.xml
@@ -30,28 +30,27 @@
 
         <ImageView
             android:id="@+id/subtitle_offset_subtract_more"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
             android:layout_gravity="center"
-            android:layout_weight="1"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="10dp"
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:focusable="true"
             android:nextFocusRight="@id/subtitle_offset_subtract"
-            android:padding="10dp"
             android:src="@drawable/ic_baseline_keyboard_arrow_left_24"
             app:tint="?attr/white"
             tools:ignore="ContentDescription" />
 
         <ImageView
             android:id="@+id/subtitle_offset_subtract"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
             android:layout_gravity="center"
-            android:layout_weight="1"
+            android:layout_marginEnd="10dp"
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:focusable="true"
             android:nextFocusLeft="@id/subtitle_offset_subtract_more"
-            android:padding="10dp"
             android:src="@drawable/baseline_remove_24"
             app:tint="?attr/white"
             tools:ignore="ContentDescription" />
@@ -67,29 +66,29 @@
 
         <ImageView
             android:id="@+id/subtitle_offset_add"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
             android:layout_gravity="center"
-            android:layout_weight="1"
+            android:layout_marginStart="10dp"
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:focusable="true"
             android:nextFocusRight="@id/subtitle_offset_add_more"
-            android:padding="10dp"
             android:src="@drawable/ic_baseline_add_24"
             app:tint="?attr/white"
             tools:ignore="ContentDescription" />
 
         <ImageView
             android:id="@+id/subtitle_offset_add_more"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
             android:layout_gravity="center"
-            android:layout_weight="1"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="10dp"
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:focusable="true"
             android:nextFocusLeft="@id/subtitle_offset_add"
             android:nextFocusDown="@id/apply_btt"
-            android:padding="10dp"
+
             android:src="@drawable/ic_baseline_keyboard_arrow_right_24"
             app:tint="?attr/white"
             tools:ignore="ContentDescription" />

--- a/app/src/main/res/layout/trailer_custom_layout.xml
+++ b/app/src/main/res/layout/trailer_custom_layout.xml
@@ -137,33 +137,110 @@
 
         <FrameLayout
             android:id="@+id/player_go_back_holder"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_margin="5dp"
-            android:clickable="false"
-            android:focusable="false"
-            android:focusableInTouchMode="false"
-            android:visibility="gone"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="20dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <ImageView
-                android:layout_width="30dp"
-                android:layout_height="30dp"
-                android:layout_gravity="center"
-                android:contentDescription="@string/go_back_img_des"
-                android:src="@drawable/ic_baseline_arrow_back_24"
-                app:tint="@android:color/white" />
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
+                android:id="@+id/player_go_back_root"
+                android:orientation="vertical">
 
-            <ImageView
-                android:id="@+id/player_go_back"
-                android:layout_width="70dp"
-                android:layout_height="70dp"
-                android:layout_gravity="center"
-                android:background="@drawable/video_tap_button_always_white"
-                android:clickable="true"
-                android:contentDescription="@string/go_back_img_des"
-                android:focusable="true" />
+                <ImageView
+                    android:id="@+id/player_go_back"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_baseline_arrow_back_24"
+                    app:tint="@android:color/white"
+                    android:background="@drawable/video_tap_button_always_white"
+                    android:clickable="true"
+                    android:contentDescription="@string/go_back_img_des"
+                    android:focusable="true"
+                    android:nextFocusRight="@id/player_restart"
+                    android:nextFocusLeft="@id/player_go_back"
+                    android:nextFocusDown="@id/player_pause_play"
+                    android:nextFocusUp="@id/player_go_back"
+                    android:tag="@string/tv_no_focus_tag" />
+
+                <TextView
+                    android:id="@+id/player_go_back_text"
+                    style="@style/ResultMarqueeButtonText"
+                    android:text="@string/go_back_img_des"
+                    android:visibility="gone"/>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="40dp"
+                android:layout_marginEnd="10dp"
+                android:id="@+id/player_restart_root"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/player_restart"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_baseline_replay_24"
+                    app:tint="@android:color/white"
+                    android:background="@drawable/video_tap_button_always_white"
+                    android:clickable="true"
+                    android:contentDescription="@string/restart"
+                    android:focusable="true"
+                    android:nextFocusRight="@id/player_go_forward"
+                    android:nextFocusLeft="@id/player_go_back"
+                    android:nextFocusDown="@id/player_pause_play"
+                    android:nextFocusUp="@id/player_restart"
+                    android:tag="@string/tv_no_focus_tag" />
+
+                <TextView
+                    android:id="@+id/player_restart_text"
+                    style="@style/ResultMarqueeButtonText"
+                    android:text="@string/restart"
+                    android:visibility="gone"/>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="80dp"
+                android:layout_marginEnd="10dp"
+                android:id="@+id/player_go_forward_root"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/player_go_forward"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_baseline_skip_next_rounded_24"
+                    app:tint="@android:color/white"
+                    android:background="@drawable/video_tap_button_always_white"
+                    android:clickable="true"
+                    android:nextFocusRight="@id/player_go_forward"
+                    android:nextFocusLeft="@id/player_restart"
+                    android:nextFocusDown="@id/player_pause_play"
+                    android:nextFocusUp="@id/player_go_forward"
+                    android:contentDescription="@string/next_episode"
+                    android:focusable="true"
+                    android:tag="@string/tv_no_focus_tag" />
+
+                <TextView
+                    android:id="@+id/player_go_forward_text"
+                    style="@style/ResultMarqueeButtonText"
+                    android:text="@string/next_episode"
+                    android:visibility="gone"/>
+
+            </LinearLayout>
+
         </FrameLayout>
     </FrameLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="home_next_random_img_des">Next Random</string>
     <string name="episode_play_img_des" translatable="false">@string/play_episode</string>
     <string name="go_back_img_des">Go back</string>
+    <string name="play_from_beginning_img_des">Play from the Beginning</string>
     <string name="change_providers_img_des" translatable="false">@string/home_change_provider_img_des</string>
     <string name="home_change_provider_img_des">Change Provider</string>
     <string name="preview_background_img_des">Preview Background</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -677,6 +677,7 @@
     <string name="action_mark_as_watched">Mark as watched</string>
     <string name="action_remove_from_watched">Remove from watched</string>
     <string name="confirm_exit_dialog">Are you sure you want to exit\?</string>
+    <string name="confirm_reset_subs_dialog">Are you sure you want to reset subtitles delay\?</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="ok">OK</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -677,7 +677,6 @@
     <string name="action_mark_as_watched">Mark as watched</string>
     <string name="action_remove_from_watched">Remove from watched</string>
     <string name="confirm_exit_dialog">Are you sure you want to exit\?</string>
-    <string name="confirm_reset_subs_dialog">Are you sure you want to reset subtitles delay\?</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="ok">OK</string>


### PR DESCRIPTION
- Fixes Title alignment in case of RTL languages.
- Adds "Restart" & "Next Episode" in top controls bar.
- Marquee under button titles.
- Removes the "Next Episode" button under progress seekbar.
- Changes "Tracks" icon.
- Margin for top bar is same on right & left.
- Removes the back button from player loading UI.
- Dialog for reset subtitles delay confirmation.
- Make reset subtitles + & - button focus smaller.