### PR TITLE
Properly fix jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17 # Same JDK as github workflow


### PR DESCRIPTION
The jitpack build fails due to JDK version issues.
With this the cloudstream library as a dependency works, finalizing the possibility of cross platform development.

I plan to look into repositories to also make them generate jar files.