### PR TITLE
Fix BackPressedCallback conflict between activities

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
@@ -38,7 +38,7 @@ class DownloadChildFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        detachBackPressedCallback()
+        activity?.detachBackPressedCallback()
         binding = null
         super.onDestroyView()
     }
@@ -113,7 +113,7 @@ class DownloadChildFragment : Fragment() {
             adapter?.setIsMultiDeleteState(isMultiDeleteState)
             binding?.downloadDeleteAppbar?.isVisible = isMultiDeleteState
             if (!isMultiDeleteState) {
-                detachBackPressedCallback()
+                activity?.detachBackPressedCallback()
                 downloadsViewModel.clearSelectedItems()
                 binding?.downloadChildToolbar?.isVisible = true
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
@@ -68,7 +68,7 @@ class DownloadFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        detachBackPressedCallback()
+        activity?.detachBackPressedCallback()
         binding = null
         super.onDestroyView()
     }
@@ -160,7 +160,7 @@ class DownloadFragment : Fragment() {
             adapter?.setIsMultiDeleteState(isMultiDeleteState)
             binding?.downloadDeleteAppbar?.isVisible = isMultiDeleteState
             if (!isMultiDeleteState) {
-                detachBackPressedCallback()
+                activity?.detachBackPressedCallback()
                 downloadsViewModel.clearSelectedItems()
                 // Prevent race condition and make sure
                 // we don't display it early

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
@@ -160,7 +160,7 @@ open class ResultTrailerPlayer : ResultFragmentPhone() {
             activity?.attachBackPressedCallback {
                 updateFullscreen(false)
             }
-        } else detachBackPressedCallback()
+        } else activity?.detachBackPressedCallback()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
There is another, more simple way to do this by just detatching the callback everytime it is pressed in DownloadedPlayerActivity, however, I figured this method was more future-proofed if more activities are added later so went with this, but if you want me to go to do the more simple method I can also.