### PR TITLE
#1302 Option to not show exit confirmation dialog

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -125,6 +125,7 @@ import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.ui.settings.Globals.updateTv
 import com.lagradost.cloudstream3.ui.settings.SettingsGeneral
+import com.lagradost.cloudstream3.ui.settings.getExitDialogSupportedLayouts
 import com.lagradost.cloudstream3.ui.setup.HAS_DONE_SETUP_KEY
 import com.lagradost.cloudstream3.ui.setup.SetupFragmentExtensions
 import com.lagradost.cloudstream3.utils.ApkInstaller
@@ -1534,7 +1535,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                 }
             }
 
-            if (isLayout(TV or EMULATOR)) {
+            if (isLayout(getExitDialogSupportedLayouts())) {
                 if (navDestination.matchDestination(R.id.navigation_home)) {
                     attachBackPressedCallback {
                         showConfirmExitDialog()

--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -125,7 +125,7 @@ import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.ui.settings.Globals.updateTv
 import com.lagradost.cloudstream3.ui.settings.SettingsGeneral
-import com.lagradost.cloudstream3.ui.settings.getExitDialogSupportedLayouts
+import com.lagradost.cloudstream3.ui.settings.SettingsUI
 import com.lagradost.cloudstream3.ui.setup.HAS_DONE_SETUP_KEY
 import com.lagradost.cloudstream3.ui.setup.SetupFragmentExtensions
 import com.lagradost.cloudstream3.utils.ApkInstaller
@@ -616,7 +616,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
     @SuppressLint("ApplySharedPref") // commit since the op needs to be synchronous
     private fun showConfirmExitDialog() {
         val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
-        val confirmBeforeExit = settingsManager.getBoolean(getString(R.string.confirm_exit_key), true)
+        val confirmBeforeExit = settingsManager.getBoolean(getString(R.string.confirm_exit_key), SettingsUI.getConfirmExitDialogDefault())
         if (!confirmBeforeExit) {
             exitProcess(0)
             return
@@ -1535,16 +1535,14 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                 }
             }
 
-            if (isLayout(getExitDialogSupportedLayouts())) {
-                if (navDestination.matchDestination(R.id.navigation_home)) {
-                    attachBackPressedCallback {
-                        showConfirmExitDialog()
-                        window?.navigationBarColor =
-                            colorFromAttribute(R.attr.primaryGrayBackground)
-                        updateLocale()
-                    }
-                } else detachBackPressedCallback()
-            }
+            if (navDestination.matchDestination(R.id.navigation_home)) {
+                attachBackPressedCallback {
+                    showConfirmExitDialog()
+                    window?.navigationBarColor =
+                        colorFromAttribute(R.attr.primaryGrayBackground)
+                    updateLocale()
+                }
+            } else detachBackPressedCallback()
         }
 
         //val navController = findNavController(R.id.nav_host_fragment)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -69,8 +69,11 @@ class SettingsFragment : Fragment() {
         }
 
         /**
-         * Hide the Preference on selected layouts.
-         * @return [Preference] if visible otherwise null
+         * Hide the [Preference] on selected layouts.
+         * @return [Preference] if visible otherwise null.
+         *
+         * [hideOn] is usually followed by some actions on the preference which are mostly
+         * unnecessary when the preference is disabled for the said layout thus returning null.
          **/
         fun Preference?.hideOn(layoutFlags: Int): Preference? {
             if (this == null) return null

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -70,11 +70,12 @@ class SettingsFragment : Fragment() {
 
         /**
          * Hide the Preference on selected layouts.
+         * @return [Preference] if visible otherwise null
          **/
         fun Preference?.hideOn(layoutFlags: Int): Preference? {
             if (this == null) return null
             this.isVisible = !isLayout(layoutFlags)
-            return this
+            return if(this.isVisible) this else null
         }
 
         /**

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
@@ -127,6 +127,8 @@ val appLanguages = arrayListOf(
 /* end language list */
 ).sortedBy { it.second.lowercase() } //ye, we go alphabetical, so ppl don't put their lang on top
 
+fun getExitDialogSupportedLayouts() = TV or EMULATOR
+
 class SettingsGeneral : PreferenceFragmentCompat() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -210,14 +212,18 @@ class SettingsGeneral : PreferenceFragmentCompat() {
             return@setOnPreferenceClickListener true
         }
 
-        settingsManager.edit().putBoolean(
-            getString(R.string.confirm_exit_key),
-            getKey(getString(R.string.confirm_exit_key), true) ?: true
-        ).apply()
-        getPref(R.string.confirm_exit_key)?.setOnPreferenceChangeListener { _, newValue ->
-            setKey(getString(R.string.confirm_exit_key), newValue)
-            return@setOnPreferenceChangeListener true
-        }
+        getPref(R.string.confirm_exit_key)
+            ?.hideOn(getExitDialogSupportedLayouts().inv())
+            ?.let { pref ->
+                settingsManager.edit().putBoolean(
+                    getString(R.string.confirm_exit_key),
+                    getKey(getString(R.string.confirm_exit_key), true) ?: true
+                ).apply()
+                pref
+            }?.setOnPreferenceChangeListener { _, newValue ->
+                setKey(getString(R.string.confirm_exit_key), newValue)
+                return@setOnPreferenceChangeListener true
+            }
 
         getPref(R.string.battery_optimisation_key)?.hideOn(TV or EMULATOR)?.setOnPreferenceClickListener {
             val ctx = context ?: return@setOnPreferenceClickListener false

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
@@ -210,6 +210,15 @@ class SettingsGeneral : PreferenceFragmentCompat() {
             return@setOnPreferenceClickListener true
         }
 
+        settingsManager.edit().putBoolean(
+            getString(R.string.confirm_exit_key),
+            getKey(getString(R.string.confirm_exit_key), true) ?: true
+        ).apply()
+        getPref(R.string.confirm_exit_key)?.setOnPreferenceChangeListener { _, newValue ->
+            setKey(getString(R.string.confirm_exit_key), newValue)
+            return@setOnPreferenceChangeListener true
+        }
+
         getPref(R.string.battery_optimisation_key)?.hideOn(TV or EMULATOR)?.setOnPreferenceClickListener {
             val ctx = context ?: return@setOnPreferenceClickListener false
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
@@ -127,8 +127,6 @@ val appLanguages = arrayListOf(
 /* end language list */
 ).sortedBy { it.second.lowercase() } //ye, we go alphabetical, so ppl don't put their lang on top
 
-fun getExitDialogSupportedLayouts() = TV or EMULATOR
-
 class SettingsGeneral : PreferenceFragmentCompat() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -211,19 +209,6 @@ class SettingsGeneral : PreferenceFragmentCompat() {
             }
             return@setOnPreferenceClickListener true
         }
-
-        getPref(R.string.confirm_exit_key)
-            ?.hideOn(getExitDialogSupportedLayouts().inv())
-            ?.let { pref ->
-                settingsManager.edit().putBoolean(
-                    getString(R.string.confirm_exit_key),
-                    getKey(getString(R.string.confirm_exit_key), true) ?: true
-                ).apply()
-                pref
-            }?.setOnPreferenceChangeListener { _, newValue ->
-                setKey(getString(R.string.confirm_exit_key), newValue)
-                return@setOnPreferenceChangeListener true
-            }
 
         getPref(R.string.battery_optimisation_key)?.hideOn(TV or EMULATOR)?.setOnPreferenceClickListener {
             val ctx = context ?: return@setOnPreferenceClickListener false

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
@@ -5,10 +5,14 @@ import android.os.Bundle
 import android.view.View
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
+import com.lagradost.cloudstream3.AcraApplication.Companion.setKey
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.SearchQuality
 import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.ui.search.SearchResultBuilder
+import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
+import com.lagradost.cloudstream3.ui.settings.Globals.TV
+import com.lagradost.cloudstream3.ui.settings.Globals.isLayout
 import com.lagradost.cloudstream3.ui.settings.Globals.updateTv
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.getPref
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setPaddingBottom
@@ -20,6 +24,9 @@ import com.lagradost.cloudstream3.utils.SingleSelectionHelper.showMultiDialog
 import com.lagradost.cloudstream3.utils.UIHelper.hideKeyboard
 
 class SettingsUI : PreferenceFragmentCompat() {
+    companion object {
+        fun getConfirmExitDialogDefault() = isLayout(TV or EMULATOR)
+    }
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setUpToolbar(R.string.category_ui)
@@ -187,5 +194,12 @@ class SettingsUI : PreferenceFragmentCompat() {
             return@setOnPreferenceClickListener true
         }
 
+        setKey( // default value is layout specific
+            getString(R.string.confirm_exit_key),
+            settingsManager.getBoolean(
+                getString(R.string.confirm_exit_key),
+                getConfirmExitDialogDefault()
+            )
+        )
     }
 }

--- a/app/src/main/res/drawable/ic_baseline_exit_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_exit_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17,7l-1.41,1.41L18.17,11H8v2h10.17l-2.58,2.58L17,17l5,-5zM4,5h8V3H4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h8v-2H4V5z"/>
+    
+</vector>

--- a/app/src/main/res/layout/confirm_exit_dialog.xml
+++ b/app/src/main/res/layout/confirm_exit_dialog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="8dp">
+    <CheckBox
+        android:id="@+id/checkboxDontShowAgain"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/dont_show_again" />
+</LinearLayout>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -222,6 +222,17 @@
         <item>2</item>
     </array>
 
+    <array name="confirm_exit">
+        <item>@string/automatic</item>
+        <item>@string/show</item>
+        <item>@string/dont_show</item>
+    </array>
+    <array name="confirm_exit_values">
+        <item>-1</item>
+        <item>0</item>
+        <item>1</item>
+    </array>
+
     <string-array name="themes_overlay_names">
         <item>Normal</item>
         <item>Dandelion Yellow</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -808,7 +808,11 @@
     <string name="preview_seekbar">Seekbar preview</string>
     <string name="preview_seekbar_desc">Enable preview thumbnail on seekbar</string>
     <string name="no_subtitles_loaded">No subtitles loaded yet</string>
+    <!--confirm exit dialog-->
     <string name="confirm_before_exiting_title">Confirm before exiting</string>
-    <string name="confirm_before_exiting_desc">Ask before exiting the app</string>
+    <string name="confirm_before_exiting_desc">Show dialog before exiting the app</string>
     <string name="confirm_exit_key" translatable="false">confirm_exit_key</string>
+    <string name="show">Show</string>
+    <string name="dont_show">Don\'t Show</string>
+    <!--confirm exit dialog-->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -808,4 +808,7 @@
     <string name="preview_seekbar">Seekbar preview</string>
     <string name="preview_seekbar_desc">Enable preview thumbnail on seekbar</string>
     <string name="no_subtitles_loaded">No subtitles loaded yet</string>
+    <string name="confirm_before_exiting_title">Confirm before exiting</string>
+    <string name="confirm_before_exiting_desc">Ask before exiting the app</string>
+    <string name="confirm_exit_key" translatable="false">confirm_exit_key</string>
 </resources>

--- a/app/src/main/res/xml/settings_general.xml
+++ b/app/src/main/res/xml/settings_general.xml
@@ -5,8 +5,12 @@
         android:key="@string/locale_key"
         android:title="@string/app_language"
         android:icon="@drawable/ic_baseline_language_24" />
-
-
+    <SwitchPreference
+        android:defaultValue="true"
+        android:icon="@drawable/ic_baseline_exit_24"
+        android:key="@string/confirm_exit_key"
+        android:title="@string/confirm_before_exiting_title"
+        android:summary="@string/confirm_before_exiting_desc" />
 
     <Preference
             android:key="@string/legal_notice_key"

--- a/app/src/main/res/xml/settings_general.xml
+++ b/app/src/main/res/xml/settings_general.xml
@@ -5,12 +5,6 @@
         android:key="@string/locale_key"
         android:title="@string/app_language"
         android:icon="@drawable/ic_baseline_language_24" />
-    <SwitchPreference
-        android:defaultValue="true"
-        android:icon="@drawable/ic_baseline_exit_24"
-        android:key="@string/confirm_exit_key"
-        android:title="@string/confirm_before_exiting_title"
-        android:summary="@string/confirm_before_exiting_desc" />
 
     <Preference
             android:key="@string/legal_notice_key"

--- a/app/src/main/res/xml/settings_ui.xml
+++ b/app/src/main/res/xml/settings_ui.xml
@@ -57,7 +57,7 @@
                 android:title="@string/random_button_settings"
                 android:summary="@string/random_button_settings_desc"
                 app:defaultValue="false" />
-        <SwitchPreference
+        <Preference
             android:icon="@drawable/ic_baseline_exit_24"
             android:key="@string/confirm_exit_key"
             android:title="@string/confirm_before_exiting_title"

--- a/app/src/main/res/xml/settings_ui.xml
+++ b/app/src/main/res/xml/settings_ui.xml
@@ -57,6 +57,11 @@
                 android:title="@string/random_button_settings"
                 android:summary="@string/random_button_settings_desc"
                 app:defaultValue="false" />
+        <SwitchPreference
+            android:icon="@drawable/ic_baseline_exit_24"
+            android:key="@string/confirm_exit_key"
+            android:title="@string/confirm_before_exiting_title"
+            android:summary="@string/confirm_before_exiting_desc" />
         <Preference
             android:icon="@drawable/ic_baseline_filter_list_24"
             android:key="@string/pref_filter_search_quality_key"


### PR DESCRIPTION
Fixes: [Issue#1302](https://github.com/recloudstream/cloudstream/issues/1302)
- Tested on Debug & Release Builds
- Added a setting to hide it or show it again {only where it is supported -  TV/EMULATOR}
- Checkbox in dialog to disable it
- Let me know if I am supposed to handle translations for newly added strings, i believe the weblate bot does that.
- NOTE: check SettingsFragment.kt:71-79, now returns null when not visible so further actions on the preference dont happen unnecessarily. Checked other usages, works fine.

<img width="826" alt="Screenshot 2024-09-22 at 16 12 42" src="https://github.com/user-attachments/assets/5ed6deaa-11fb-4f33-8854-e83ae9b7a4a1">
<img width="1503" alt="Screenshot 2024-09-22 at 16 12 26" src="https://github.com/user-attachments/assets/36dfe538-fb55-43bc-861b-18a361813180">
