### PR TITLE
Fix navigation bar in light mode

### DIFF
--- a/app/src/main/res/color/item_select_color.xml
+++ b/app/src/main/res/color/item_select_color.xml
@@ -3,5 +3,5 @@
     <item android:color="?attr/colorPrimary" android:state_checked="true"/>
     <item android:color="?attr/colorPrimary" android:state_focused="true"/>
     <item android:color="?attr/colorPrimary" android:state_selected="true"/>
-    <item android:color="@color/whiteSmoke" android:state_checked="false"/>
+    <item android:color="?attr/textColor" android:state_checked="false"/>
 </selector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -89,5 +89,4 @@
     <color name="colorTestPass">#48E484</color>
     <color name="colorTestFail">#ea596e</color>
     <color name="colorTestWarning">#FF9800</color>
-    <color name="whiteSmoke">#F5F5F5</color>
 </resources>


### PR DESCRIPTION
Resolves #1349 

This does however use textColor. It is similar, but not identical to the previous shade of white. 
@KingLucius is there any specific intent behind the shade? Is textColor satisfactory? It is possible to make whiteSmoke dynamic, but that felt like overkill given the available option of textColor.

Previous:
![image](https://github.com/user-attachments/assets/520a347c-2aed-4a73-911c-bb03358de4f2)
New:
![image](https://github.com/user-attachments/assets/9ce59597-7849-493d-b105-fde05aad94a8)

Previous:
![image](https://github.com/user-attachments/assets/09e84cb1-8636-47b2-bc1a-86a072ced154)

New:
![image](https://github.com/user-attachments/assets/ae356a42-2be5-4058-a68b-383b5df5b0b1)

