### PR TITLE
Fix fcast m3u

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/actions/temp/fcast/FcastAction.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/actions/temp/fcast/FcastAction.kt
@@ -53,7 +53,7 @@ class FcastAction: VideoClickAction() {
             session.sendMessage(
                 Opcode.Play,
                 PlayMessage(
-                    "video/*",
+                    link.type.getMimeType(),
                     link.url,
                     time = position?.let { it / 1000.0 },
                     headers = mapOf(


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/recloudstream/cloudstream/pull/1329 where the mime type was hardcoded to video/*, preventing m3u playlists from working.