### PR TITLE
feat: option to choose backup target directory

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
@@ -7,7 +7,6 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
@@ -35,6 +34,7 @@ import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.hideOn
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setPaddingBottom
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setToolBarScrollFlags
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setUpToolbar
+import com.lagradost.cloudstream3.ui.settings.utils.getChooseFolderLauncher
 import com.lagradost.cloudstream3.utils.BatteryOptimizationChecker.isAppRestricted
 import com.lagradost.cloudstream3.utils.BatteryOptimizationChecker.showBatteryOptimizationDialog
 import com.lagradost.cloudstream3.utils.SingleSelectionHelper.showBottomDialog
@@ -46,7 +46,6 @@ import com.lagradost.cloudstream3.utils.UIHelper.hideKeyboard
 import com.lagradost.cloudstream3.utils.USER_PROVIDER_API
 import com.lagradost.cloudstream3.utils.VideoDownloadManager
 import com.lagradost.cloudstream3.utils.VideoDownloadManager.getBasePath
-import com.lagradost.safefile.SafeFile
 
 // Change local language settings in the app.
 fun getCurrentLocale(context: Context): String {
@@ -146,34 +145,15 @@ class SettingsGeneral : PreferenceFragmentCompat() {
         val lang: String,
     )
 
-    // Open file picker
-    private val pathPicker =
-        registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
-            // It lies, it can be null if file manager quits.
-            if (uri == null) return@registerForActivityResult
-            val context = context ?: AcraApplication.context ?: return@registerForActivityResult
-            // RW perms for the path
-            val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
-                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-
-            context.contentResolver.takePersistableUriPermission(uri, flags)
-
-            val file = SafeFile.fromUri(context, uri)
-            val filePath = file?.filePath()
-            println("Selected URI path: $uri - Full path: $filePath")
-
-            // Stores the real URI using download_path_key
-            // Important that the URI is stored instead of filepath due to permissions.
-            PreferenceManager.getDefaultSharedPreferences(context)
-                .edit().putString(getString(R.string.download_path_key), uri.toString()).apply()
-
-            // From URI -> File path
-            // File path here is purely for cosmetic purposes in settings
-            (filePath ?: uri.toString()).let {
-                PreferenceManager.getDefaultSharedPreferences(context)
-                    .edit().putString(getString(R.string.download_path_pref), it).apply()
-            }
+    private val pathPicker = getChooseFolderLauncher { uri, path ->
+        val context = context ?: AcraApplication.context ?: return@getChooseFolderLauncher
+        (path ?: uri.toString()).let {
+            PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(getString(R.string.download_path_key), uri.toString())
+                .putString(getString(R.string.download_path_pref), it)
+                .apply()
         }
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         hideKeyboard()
@@ -371,7 +351,7 @@ class SettingsGeneral : PreferenceFragmentCompat() {
                     ?: context?.let { ctx -> VideoDownloadManager.getDefaultDir(ctx)?.filePath() }
 
             activity?.showBottomDialog(
-                dirs + listOf("Custom"),
+                dirs + listOf(getString(R.string.custom)),
                 dirs.indexOf(currentDir),
                 getString(R.string.download_path_pref),
                 true,

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
@@ -150,7 +150,7 @@ class SettingsGeneral : PreferenceFragmentCompat() {
         (path ?: uri.toString()).let {
             PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putString(getString(R.string.download_path_key), uri.toString())
-                .putString(getString(R.string.download_path_pref), it)
+                .putString(getString(R.string.download_path_key_visual), it)
                 .apply()
         }
     }
@@ -347,7 +347,7 @@ class SettingsGeneral : PreferenceFragmentCompat() {
             val dirs = getDownloadDirs()
 
             val currentDir =
-                settingsManager.getString(getString(R.string.download_path_pref), null)
+                settingsManager.getString(getString(R.string.download_path_key_visual), null)
                     ?: context?.let { ctx -> VideoDownloadManager.getDefaultDir(ctx)?.filePath() }
 
             activity?.showBottomDialog(
@@ -366,11 +366,11 @@ class SettingsGeneral : PreferenceFragmentCompat() {
                 } else {
                     // Sets both visual and actual paths.
                     // key = used path
-                    // pref = visual path
+                    // visual = visual path
                     settingsManager.edit()
-                        .putString(getString(R.string.download_path_key), dirs[it]).apply()
-                    settingsManager.edit()
-                        .putString(getString(R.string.download_path_pref), dirs[it]).apply()
+                        .putString(getString(R.string.download_path_key), dirs[it])
+                        .putString(getString(R.string.download_path_key_visual), dirs[it])
+                        .apply()
                 }
             }
             return@setOnPreferenceClickListener true

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
@@ -113,7 +113,7 @@ class SettingsUpdates : PreferenceFragmentCompat() {
             activity?.showBottomDialog(
                 dirs + listOf(getString(R.string.custom)),
                 dirs.indexOf(currentDir),
-                getString(R.string.backup_dir_key),
+                getString(R.string.backup_path_title),
                 true,
                 {}) {
                 // Last = custom

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
@@ -128,9 +128,9 @@ class SettingsUpdates : PreferenceFragmentCompat() {
                     // path = used uri
                     // dir = dir path
                     settingsManager.edit()
-                        .putString(getString(R.string.backup_path_key), dirs[it]).apply()
-                    settingsManager.edit()
-                        .putString(getString(R.string.backup_dir_key), dirs[it]).apply()
+                        .putString(getString(R.string.backup_path_key), dirs[it])
+                        .putString(getString(R.string.backup_dir_key), dirs[it])
+                        .apply()
                 }
             }
             return@setOnPreferenceClickListener true

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
@@ -1,5 +1,6 @@
 package com.lagradost.cloudstream3.ui.settings
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -14,13 +15,18 @@ import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.databinding.LogcatBinding
 import com.lagradost.cloudstream3.mvvm.logError
+import com.lagradost.cloudstream3.mvvm.normalSafeApiCall
 import com.lagradost.cloudstream3.network.initClient
 import com.lagradost.cloudstream3.services.BackupWorkManager
 import com.lagradost.cloudstream3.ui.result.txt
+import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
+import com.lagradost.cloudstream3.ui.settings.Globals.TV
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.getPref
+import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.hideOn
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setPaddingBottom
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setToolBarScrollFlags
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setUpToolbar
+import com.lagradost.cloudstream3.ui.settings.utils.getChooseFolderLauncher
 import com.lagradost.cloudstream3.utils.BackupUtils
 import com.lagradost.cloudstream3.utils.BackupUtils.restorePrompt
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
@@ -37,7 +43,8 @@ import java.io.InputStreamReader
 import java.io.OutputStream
 import java.lang.System.currentTimeMillis
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
+import java.util.Locale
 
 class SettingsUpdates : PreferenceFragmentCompat() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -47,10 +54,20 @@ class SettingsUpdates : PreferenceFragmentCompat() {
         setToolBarScrollFlags()
     }
 
+    private val pathPicker = getChooseFolderLauncher { uri, path ->
+        val context = context ?: AcraApplication.context ?: return@getChooseFolderLauncher
+        (path ?: uri.toString()).let {
+            PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(getString(R.string.backup_path_key), uri.toString())
+                .putString(getString(R.string.backup_dir_key), it)
+                .apply()
+        }
+    }
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         hideKeyboard()
         setPreferencesFromResource(R.xml.settings_updates, rootKey)
-        //val settingsManager = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        val settingsManager = PreferenceManager.getDefaultSharedPreferences(requireContext())
 
         getPref(R.string.backup_key)?.setOnPreferenceClickListener {
             BackupUtils.backup(activity)
@@ -58,8 +75,6 @@ class SettingsUpdates : PreferenceFragmentCompat() {
         }
 
         getPref(R.string.automatic_backup_key)?.setOnPreferenceClickListener {
-            val settingsManager = PreferenceManager.getDefaultSharedPreferences(requireContext())
-
             val prefNames = resources.getStringArray(R.array.periodic_work_names)
             val prefValues = resources.getIntArray(R.array.periodic_work_values)
             val current = settingsManager.getInt(getString(R.string.automatic_backup_key), 0)
@@ -89,6 +104,38 @@ class SettingsUpdates : PreferenceFragmentCompat() {
             activity?.restorePrompt()
             return@setOnPreferenceClickListener true
         }
+        getPref(R.string.backup_path_key)?.hideOn(TV or EMULATOR)?.setOnPreferenceClickListener {
+            val dirs = getBackupDirsForDisplay()
+            val currentDir =
+                settingsManager.getString(getString(R.string.backup_dir_key), null)
+                    ?: context?.let { ctx -> BackupUtils.getDefaultBackupDir(ctx)?.filePath() }
+
+            activity?.showBottomDialog(
+                dirs + listOf(getString(R.string.custom)),
+                dirs.indexOf(currentDir),
+                getString(R.string.backup_dir_key),
+                true,
+                {}) {
+                // Last = custom
+                if (it == dirs.size) {
+                    try {
+                        pathPicker.launch(Uri.EMPTY)
+                    } catch (e: Exception) {
+                        logError(e)
+                    }
+                } else {
+                    // Sets both visual and actual paths.
+                    // path = used uri
+                    // dir = dir path
+                    settingsManager.edit()
+                        .putString(getString(R.string.backup_path_key), dirs[it]).apply()
+                    settingsManager.edit()
+                        .putString(getString(R.string.backup_dir_key), dirs[it]).apply()
+                }
+            }
+            return@setOnPreferenceClickListener true
+        }
+
         getPref(R.string.show_logcat_key)?.setOnPreferenceClickListener { pref ->
             val builder =
                 AlertDialog.Builder(pref.context, R.style.AlertDialogCustom)
@@ -156,8 +203,6 @@ class SettingsUpdates : PreferenceFragmentCompat() {
         }
 
         getPref(R.string.apk_installer_key)?.setOnPreferenceClickListener {
-            val settingsManager = PreferenceManager.getDefaultSharedPreferences(it.context)
-
             val prefNames = resources.getStringArray(R.array.apk_installer_pref)
             val prefValues = resources.getIntArray(R.array.apk_installer_values)
 
@@ -196,8 +241,6 @@ class SettingsUpdates : PreferenceFragmentCompat() {
         }
 
         getPref(R.string.auto_download_plugins_key)?.setOnPreferenceClickListener {
-            val settingsManager = PreferenceManager.getDefaultSharedPreferences(it.context)
-
             val prefNames = resources.getStringArray(R.array.auto_download_plugin)
             val prefValues =
                 enumValues<AutoDownloadMode>().sortedBy { x -> x.value }.map { x -> x.value }
@@ -216,5 +259,19 @@ class SettingsUpdates : PreferenceFragmentCompat() {
             }
             return@setOnPreferenceClickListener true
         }
+    }
+
+    private fun getBackupDirsForDisplay(): List<String> {
+        return normalSafeApiCall {
+            context?.let { ctx ->
+                val defaultDir = BackupUtils.getDefaultBackupDir(ctx)?.filePath()
+                val first = listOf(defaultDir)
+                (runCatching {
+                    first + BackupUtils.getCurrentBackupDir(ctx).let {
+                                it.first?.filePath() ?: it.second
+                            }
+                }.getOrNull() ?: first).filterNotNull().distinct()
+            }
+        } ?: emptyList()
     }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/utils/DirectoryPicker.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/utils/DirectoryPicker.kt
@@ -1,0 +1,27 @@
+package com.lagradost.cloudstream3.ui.settings.utils
+
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.Fragment
+import com.lagradost.cloudstream3.AcraApplication
+import com.lagradost.safefile.SafeFile
+
+fun Fragment.getChooseFolderLauncher(dirSelected: (uri: Uri?, path: String?) -> Unit) =
+    registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+        // It lies, it can be null if file manager quits.
+        if (uri == null) return@registerForActivityResult
+        val context = context ?: AcraApplication.context ?: return@registerForActivityResult
+        // RW perms for the path
+        val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+
+        context.contentResolver.takePersistableUriPermission(uri, flags)
+
+        val filePath = SafeFile.fromUri(context, uri)?.filePath()
+        println("Selected URI path: $uri - Full path: $filePath")
+
+        // store the actual URI instead of the path due to permissions.
+        // filePath should only be used for cosmetic purposes.
+        dirSelected(uri, filePath)
+    }

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
@@ -7,7 +7,9 @@ import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.WorkerThread
+import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
+import androidx.preference.PreferenceManager
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.lagradost.cloudstream3.AcraApplication.Companion.getActivity
@@ -35,8 +37,14 @@ import com.lagradost.cloudstream3.utils.DataStore.getSharedPrefs
 import com.lagradost.cloudstream3.utils.DataStore.mapper
 import com.lagradost.cloudstream3.utils.UIHelper.checkWrite
 import com.lagradost.cloudstream3.utils.UIHelper.requestRW
+import com.lagradost.cloudstream3.utils.VideoDownloadManager.StreamData
+import com.lagradost.cloudstream3.utils.VideoDownloadManager.getBasePath
 import com.lagradost.cloudstream3.utils.VideoDownloadManager.setupStream
+import com.lagradost.safefile.MediaFileContentType
+import com.lagradost.safefile.SafeFile
 import okhttp3.internal.closeQuietly
+import java.io.File
+import java.io.IOException
 import java.io.OutputStream
 import java.io.PrintWriter
 import java.lang.System.currentTimeMillis
@@ -69,7 +77,12 @@ object BackupUtils {
 
         "biometric_key", // can lock down users if backup is shared on a incompatible device
         "nginx_user", // Nginx user key
-        "download_path_key" // No access rights after restore data from backup
+
+        // No access rights after restore data from backup
+        "download_path_key",
+        "download_path_pref",
+        "backup_path_key",
+        "backup_dir_path_key"
     )
 
     /** false if key should not be contained in backup */
@@ -166,10 +179,9 @@ object BackupUtils {
             }
 
             val date = SimpleDateFormat("yyyy_MM_dd_HH_mm").format(Date(currentTimeMillis()))
-            val ext = "txt"
             val displayName = "CS3_Backup_${date}"
             val backupFile = getBackup(context)
-            val stream = setupStream(context, displayName, null, ext, false)
+            val stream = setupBackupStream(context, displayName)
 
             fileStream = stream.openNew()
             printStream = PrintWriter(fileStream)
@@ -193,6 +205,18 @@ object BackupUtils {
             printStream?.closeQuietly()
             fileStream?.closeQuietly()
         }
+    }
+
+    @Throws(IOException::class)
+    private fun setupBackupStream(context: Context, name: String, ext: String = "txt"): StreamData {
+        return setupStream(
+            baseFile = getCurrentBackupDir(context).first ?: getDefaultBackupDir(context)
+            ?: throw IOException("Bad config"),
+            name,
+            folder = null,
+            extension = ext,
+            tryResume = false
+        )
     }
 
     fun FragmentActivity.setUpBackup() {
@@ -263,5 +287,28 @@ object BackupUtils {
             }
         }
         editor.apply()
+    }
+
+    /**
+     * Copy of [VideoDownloadManager.basePathToFile], [VideoDownloadManager.getDefaultDir] and [VideoDownloadManager.getBasePath]
+     * modded for backup specific paths
+     * */
+
+    fun getDefaultBackupDir(context: Context): SafeFile? {
+        return SafeFile.fromMedia(context, MediaFileContentType.Downloads)
+    }
+
+    fun getCurrentBackupDir(context: Context): Pair<SafeFile?, String?> {
+        val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
+        val basePathSetting = settingsManager.getString(context.getString(R.string.backup_path_key), null)
+        return baseBackupPathToFile(context, basePathSetting) to basePathSetting
+    }
+
+    private fun baseBackupPathToFile(context: Context, path: String?): SafeFile? {
+        return when {
+            path.isNullOrBlank() -> getDefaultBackupDir(context)
+            path.startsWith("content://") -> SafeFile.fromUri(context, path.toUri())
+            else -> SafeFile.fromFile(context, File(path))
+        }
     }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/BackupUtils.kt
@@ -80,7 +80,7 @@ object BackupUtils {
 
         // No access rights after restore data from backup
         "download_path_key",
-        "download_path_pref",
+        "download_path_key_visual",
         "backup_path_key",
         "backup_dir_path_key"
     )

--- a/app/src/main/res/drawable/ic_baseline_folder_open_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_folder_open_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,6h-8l-2,-2L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,8c0,-1.1 -0.9,-2 -2,-2zM20,18L4,18L4,8h16v10z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="dns_key" translatable="false">dns_key</string>
     <string name="jsdelivr_proxy_key" translatable="false">jsdelivr_proxy_key</string>
     <string name="download_path_key" translatable="false">download_path_key</string>
+    <string name="download_path_key_visual" translatable="false">download_path_key_visual</string>
     <string name="app_name_download_path" translatable="false">Cloudstream</string>
     <string name="app_layout_key" translatable="false">app_layout_key</string>
     <string name="primary_color_key" translatable="false">primary_color_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -808,6 +808,10 @@
     <string name="preview_seekbar">Seekbar preview</string>
     <string name="preview_seekbar_desc">Enable preview thumbnail on seekbar</string>
     <string name="no_subtitles_loaded">No subtitles loaded yet</string>
+    <string name="backup_path_key" translatable="false">backup_path_key</string>
+    <string name="backup_path_title">Backup folder location</string>
+    <string name="backup_dir_key" translatable="false">backup_dir_key</string>
+    <string name="custom">Custom</string>
     <!--confirm exit dialog-->
     <string name="confirm_before_exiting_title">Confirm before exiting</string>
     <string name="confirm_before_exiting_desc">Show dialog before exiting the app</string>

--- a/app/src/main/res/xml/settings_updates.xml
+++ b/app/src/main/res/xml/settings_updates.xml
@@ -46,6 +46,11 @@
             android:icon="@drawable/baseline_restore_page_24"
             android:key="@string/restore_key"
             android:title="@string/restore_settings" />
+
+        <Preference
+            android:icon="@drawable/ic_baseline_folder_open_24"
+            android:key="@string/backup_path_key"
+            android:title="@string/backup_path_title" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Fixes: #1152 and #1106 
- Settings option to choose backup target directory only in PHONE {Currently saved in the open in Downloads/}
- I don't recommend having a different default directory since that fails in TVs and choosers are anyways not present in most of them.

![Screenshot_2024-09-27-09-38-58-27_bba4627ecec1346e77f282610a5b88e8](https://github.com/user-attachments/assets/9c718f1a-c587-439e-8edc-6ddc623c3417)

