### PR TITLE
Fix back button touch size

### DIFF
--- a/app/src/main/res/layout/player_custom_layout.xml
+++ b/app/src/main/res/layout/player_custom_layout.xml
@@ -170,24 +170,24 @@
 
                 <FrameLayout
                     android:id="@+id/player_go_back_holder"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="20dp"
+                    android:layout_width="70dp"
+                    android:layout_height="70dp"
+                    android:layout_margin="5dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent">
 
                     <LinearLayout
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginEnd="10dp"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
                         android:id="@+id/player_go_back_root"
                         android:orientation="vertical">
 
                         <ImageView
                             android:id="@+id/player_go_back"
-                            android:layout_width="30dp"
-                            android:layout_height="30dp"
+                            android:layout_width="70dp"
+                            android:layout_height="70dp"
                             android:layout_gravity="center"
+                            android:padding="20dp"
                             android:src="@drawable/ic_baseline_arrow_back_24"
                             app:tint="@android:color/white"
                             android:background="@drawable/video_tap_button_always_white"


### PR DESCRIPTION
The previous back button touch size was hilariously small, often leading to missed touches
This change makes it consistent with the loading screen