### PR TITLE
add singleton image loader, remove unused libs, increase disk & decrease memory cache

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ import java.io.ByteArrayOutputStream
 
 plugins {
     id("com.android.application")
-    id("com.google.devtools.ksp")
     id("kotlin-android")
     id("org.jetbrains.dokka")
 }
@@ -84,11 +83,6 @@ android {
             "\"" + (System.getenv("SIMKL_CLIENT_SECRET") ?: localProperties["simkl.secret"]) + "\""
         )
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-
-        ksp {
-            arg("room.schemaLocation", "$projectDir/schemas")
-            arg("exportSchema", "true")
-        }
     }
 
     buildTypes {
@@ -168,17 +162,11 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
 
     // Design & UI
-    implementation("jp.wasabeef:glide-transformations:4.3.0")
     implementation("androidx.preference:preference-ktx:1.2.1")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("io.coil-kt:coil:2.7.0") // Coil Image Loading
-
-    // For KSP -> Official Annotation Processors are Not Yet Supported for KSP
-    ksp("dev.zacsweers.autoservice:auto-service-ksp:1.2.0")
-    implementation("com.google.guava:guava:33.2.1-android")
-    implementation("dev.zacsweers.autoservice:auto-service-ksp:1.2.0")
 
     // Media 3 (ExoPlayer)
     implementation("androidx.media3:media3-ui:1.4.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,22 +154,22 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
 
     // Android Core & Lifecycle
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.core:core-ktx:1.13.1") // need sdk 35 and agp 8.2 for 1.15
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.navigation:navigation-ui-ktx:2.8.3")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.6")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
     implementation("androidx.navigation:navigation-fragment-ktx:2.8.3")
 
     // Design & UI
     implementation("androidx.preference:preference-ktx:1.2.1")
     implementation("com.google.android.material:material:1.12.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.constraintlayout:constraintlayout:2.2.0")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 
     // Coil Image Loading
-    implementation("io.coil-kt.coil3:coil:3.0.0-rc02")
-    implementation("io.coil-kt.coil3:coil-network-okhttp:3.0.0-rc02")
+    implementation("io.coil-kt.coil3:coil:3.0.0")
+    implementation("io.coil-kt.coil3:coil-network-okhttp:3.0.0")
 
     // Media 3 (ExoPlayer)
     implementation("androidx.media3:media3-ui:1.4.1")
@@ -214,8 +214,8 @@ dependencies {
     Level 25 or Less. */
 
     // Downloading & Networking
-    implementation("androidx.work:work-runtime:2.9.1")
-    implementation("androidx.work:work-runtime-ktx:2.9.1")
+    implementation("androidx.work:work-runtime:2.9.1") // need sdk 35 and agp 8.2 for 1.15
+    implementation("androidx.work:work-runtime-ktx:2.9.1") // need sdk 35 and agp 8.2 for 1.15
     implementation("com.github.Blatzar:NiceHttp:0.4.11") // HTTP Lib
 
     implementation(project(":library") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -185,7 +185,7 @@ dependencies {
     // PlayBack
     implementation("com.jaredrummler:colorpicker:1.1.0") // Subtitle Color Picker
     implementation("com.github.recloudstream:media-ffmpeg:1.1.0") // Custom FF-MPEG Lib for Audio Codecs
-    implementation("com.github.teamnewpipe:NewPipeExtractor:abba78c") /* For Trailers
+    implementation("com.github.teamnewpipe:NewPipeExtractor:v0.24.3") /* For Trailers
     ^ Update to Latest Commits if Trailers Misbehave, github.com/TeamNewPipe/NewPipeExtractor/commits/dev */
     implementation("com.github.albfernandez:juniversalchardet:2.5.0") // Subtitle Decoding
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,8 +168,8 @@ dependencies {
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 
     // Coil Image Loading
-    implementation("io.coil-kt.coil3:coil:3.0.0")
-    implementation("io.coil-kt.coil3:coil-network-okhttp:3.0.0")
+    implementation("io.coil-kt.coil3:coil:3.0.3")
+    implementation("io.coil-kt.coil3:coil-network-okhttp:3.0.3")
 
     // Media 3 (ExoPlayer)
     implementation("androidx.media3:media3-ui:1.4.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,17 +156,20 @@ dependencies {
     // Android Core & Lifecycle
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.3")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.3")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
+    implementation("androidx.navigation:navigation-ui-ktx:2.8.3")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.6")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.8.3")
 
     // Design & UI
     implementation("androidx.preference:preference-ktx:1.2.1")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
-    implementation("io.coil-kt:coil:2.7.0") // Coil Image Loading
+
+    // Coil Image Loading
+    implementation("io.coil-kt.coil3:coil:3.0.0-rc02")
+    implementation("io.coil-kt.coil3:coil-network-okhttp:3.0.0-rc02")
 
     // Media 3 (ExoPlayer)
     implementation("androidx.media3:media3-ui:1.4.1")
@@ -182,7 +185,7 @@ dependencies {
     // PlayBack
     implementation("com.jaredrummler:colorpicker:1.1.0") // Subtitle Color Picker
     implementation("com.github.recloudstream:media-ffmpeg:1.1.0") // Custom FF-MPEG Lib for Audio Codecs
-    implementation("com.github.teamnewpipe:NewPipeExtractor:v0.24.2") /* For Trailers
+    implementation("com.github.teamnewpipe:NewPipeExtractor:abba78c") /* For Trailers
     ^ Update to Latest Commits if Trailers Misbehave, github.com/TeamNewPipe/NewPipeExtractor/commits/dev */
     implementation("com.github.albfernandez:juniversalchardet:2.5.0") // Subtitle Decoding
 
@@ -205,14 +208,14 @@ dependencies {
     implementation("com.github.LagradOst:SafeFile:0.0.6") // To Prevent the URI File Fu*kery
     implementation("org.conscrypt:conscrypt-android:2.5.2") // To Fix SSL Fu*kery on Android 9
     implementation("com.uwetrottmann.tmdb2:tmdb-java:2.11.0") // TMDB API v3 Wrapper Made with RetroFit
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs_nio:2.0.4") //nio flavor needed for NewPipeExtractor
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs_nio:2.1.2") //nio flavor needed for NewPipeExtractor
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1") /* JSON Parser
     ^ Don't Bump Jackson above 2.13.1 , Crashes on Android TV's and FireSticks that have Min API
     Level 25 or Less. */
 
     // Downloading & Networking
-    implementation("androidx.work:work-runtime:2.9.0")
-    implementation("androidx.work:work-runtime-ktx:2.9.0")
+    implementation("androidx.work:work-runtime:2.9.1")
+    implementation("androidx.work:work-runtime-ktx:2.9.1")
     implementation("com.github.Blatzar:NiceHttp:0.4.11") // HTTP Lib
 
     implementation(project(":library") {

--- a/app/src/main/java/com/lagradost/cloudstream3/AcraApplication.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/AcraApplication.kt
@@ -8,6 +8,8 @@ import android.content.Intent
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
 import com.lagradost.api.setContext
 import com.lagradost.cloudstream3.mvvm.normalSafeApiCall
 import com.lagradost.cloudstream3.mvvm.suspendSafeApiCall
@@ -98,11 +100,13 @@ class ExceptionHandler(val errorFile: File, val onError: (() -> Unit)) :
 
 }
 
-class AcraApplication : Application() {
+class AcraApplication : Application(), SingletonImageLoader.Factory {
 
     override fun onCreate() {
         super.onCreate()
-        ImageLoader.initializeCoilImageLoader(this)
+        // if we want to initialise coil at earliest
+        // (maybe when loading an image or gif using in splash screen activity)
+        //ImageLoader.buildImageLoader(applicationContext)
 
         ExceptionHandler(filesDir.resolve("last_error")) {
             val intent = context!!.packageManager.getLaunchIntentForPackage(context!!.packageName)
@@ -135,6 +139,11 @@ class AcraApplication : Application() {
                 //opening this block automatically enables the plugin.
             }*/
         }
+    }
+
+    override fun newImageLoader(context: PlatformContext): coil3.ImageLoader {
+        // Coil Module will be initialized & setSafe globally when first loadImage() is invoked
+        return ImageLoader.buildImageLoader(applicationContext)
     }
 
     companion object {

--- a/app/src/main/java/com/lagradost/cloudstream3/network/RequestsHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/network/RequestsHelper.kt
@@ -17,9 +17,13 @@ import java.security.Security
 
 fun Requests.initClient(context: Context): OkHttpClient {
     normalSafeApiCall { Security.insertProviderAt(Conscrypt.newProvider(), 1) }
+    return buildDefaultClient(context)
+}
+
+fun buildDefaultClient(context: Context): OkHttpClient {
     val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
     val dns = settingsManager.getInt(context.getString(R.string.dns_pref), 0)
-    baseClient = OkHttpClient.Builder()
+    val baseClient = OkHttpClient.Builder()
         .followRedirects(true)
         .followSslRedirects(true)
         .ignoreAllSSLErrors()

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountAdapter.kt
@@ -6,7 +6,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
-import coil.transform.RoundedCornersTransformation
+import coil3.transform.RoundedCornersTransformation
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.databinding.AccountListItemAddBinding
 import com.lagradost.cloudstream3.databinding.AccountListItemBinding

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountHelper.kt
@@ -16,7 +16,6 @@ import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.lagradost.cloudstream3.AcraApplication.Companion.getActivity
 import com.lagradost.cloudstream3.MainActivity

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/source_priority/ProfilesAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/source_priority/ProfilesAdapter.kt
@@ -8,15 +8,14 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
-import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.isVisible
 import androidx.palette.graphics.Palette
 import androidx.recyclerview.widget.RecyclerView
-import coil3.asDrawable
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.databinding.PlayerQualityProfileItemBinding
 import com.lagradost.cloudstream3.utils.AppContextUtils
 import com.lagradost.cloudstream3.utils.ImageLoader.loadImage
+import com.lagradost.cloudstream3.utils.drawableToBitmap
 
 class ProfilesAdapter(
     override val items: MutableList<QualityDataHelper.QualityProfile>,
@@ -82,11 +81,14 @@ class ProfilesAdapter(
             }
 
             outline.isVisible = currentItem?.second?.id == item.id
-            profileBg.loadImage(art[index % art.size]) {
-                target { image ->
-                    // Convert Image to Bitmap
-                    val bitmap = image.asDrawable(itemView.context.resources).toBitmap()
+            val drawableResId = art[index % art.size]
+            profileBg.loadImage(drawableResId)
 
+            val drawable = ContextCompat.getDrawable(itemView.context, drawableResId)
+            if (drawable != null) {
+                // Convert Drawable to Bitmap
+                val bitmap = drawableToBitmap(drawable)
+                if (bitmap != null) {
                     // Use Palette to extract colors from the bitmap
                     Palette.from(bitmap).generate { palette ->
                         val color = palette?.getDarkVibrantColor(
@@ -96,8 +98,10 @@ class ProfilesAdapter(
                             )
                         )
 
-                        wifiText.backgroundTintList = ColorStateList.valueOf(color ?: return@generate)
-                        dataText.backgroundTintList = ColorStateList.valueOf(color)
+                        if (color != null) {
+                            wifiText.backgroundTintList = ColorStateList.valueOf(color)
+                            dataText.backgroundTintList = ColorStateList.valueOf(color)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/source_priority/ProfilesAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/source_priority/ProfilesAdapter.kt
@@ -89,17 +89,15 @@ class ProfilesAdapter(
 
                     // Use Palette to extract colors from the bitmap
                     Palette.from(bitmap).generate { palette ->
-                        palette?.let {
-                            val color = it.getDarkVibrantColor(
-                                ContextCompat.getColor(
-                                    itemView.context,
-                                    R.color.dubColorBg
-                                )
+                        val color = palette?.getDarkVibrantColor(
+                            ContextCompat.getColor(
+                                itemView.context,
+                                R.color.dubColorBg
                             )
+                        )
 
-                            wifiText.backgroundTintList = ColorStateList.valueOf(color)
-                            dataText.backgroundTintList = ColorStateList.valueOf(color)
-                        }
+                        wifiText.backgroundTintList = ColorStateList.valueOf(color ?: return@generate)
+                        dataText.backgroundTintList = ColorStateList.valueOf(color)
                     }
                 }
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/source_priority/ProfilesAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/source_priority/ProfilesAdapter.kt
@@ -12,6 +12,7 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.isVisible
 import androidx.palette.graphics.Palette
 import androidx.recyclerview.widget.RecyclerView
+import coil3.asDrawable
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.databinding.PlayerQualityProfileItemBinding
 import com.lagradost.cloudstream3.utils.AppContextUtils
@@ -81,12 +82,12 @@ class ProfilesAdapter(
             }
 
             outline.isVisible = currentItem?.second?.id == item.id
-
             profileBg.loadImage(art[index % art.size]) {
-                target { drawable ->
-                    // Convert drawable to bitmap to extract palette colors
-                    val bitmap = drawable.toBitmap()
+                target { image ->
+                    // Convert Image to Bitmap
+                    val bitmap = image.asDrawable(itemView.context.resources).toBitmap()
 
+                    // Use Palette to extract colors from the bitmap
                     Palette.from(bitmap).generate { palette ->
                         palette?.let {
                             val color = it.getDarkVibrantColor(

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
@@ -77,6 +77,7 @@ import com.lagradost.cloudstream3.utils.UIHelper.popCurrentPage
 import com.lagradost.cloudstream3.utils.UIHelper.populateChips
 import com.lagradost.cloudstream3.utils.UIHelper.popupMenuNoIconsAndNoStringRes
 import com.lagradost.cloudstream3.utils.VideoDownloadHelper
+import com.lagradost.cloudstream3.utils.getImageFromDrawable
 import com.lagradost.cloudstream3.utils.setText
 import com.lagradost.cloudstream3.utils.setTextHtml
 
@@ -706,10 +707,10 @@ open class ResultFragmentPhone : FullScreenPlayer() {
                     resultNextAiring.setText(d.nextAiringEpisode)
                     resultNextAiringTime.setText(d.nextAiringDate)
                     resultPoster.loadImage(d.posterImage, headers = d.posterHeaders) {
-                        error(R.drawable.default_cover)
+                        error{ getImageFromDrawable(context?: return@error null, R.drawable.default_cover) }
                     }
                     resultPosterBackground.loadImage(d.posterBackgroundImage, headers = d.posterHeaders) {
-                        error(R.drawable.default_cover)
+                        error{ getImageFromDrawable(context?: return@error null, R.drawable.default_cover) }
                     }
 
                     var isExpanded = false

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
@@ -54,6 +54,7 @@ import com.lagradost.cloudstream3.utils.UIHelper.colorFromAttribute
 import com.lagradost.cloudstream3.utils.UIHelper.dismissSafe
 import com.lagradost.cloudstream3.utils.UIHelper.hideKeyboard
 import com.lagradost.cloudstream3.utils.UIHelper.navigate
+import com.lagradost.cloudstream3.utils.getImageFromDrawable
 import com.lagradost.cloudstream3.utils.setText
 import com.lagradost.cloudstream3.utils.setTextHtml
 
@@ -886,9 +887,9 @@ class ResultFragmentTv : Fragment() {
                         //Change poster crop area to 20% from Top
                         backgroundPoster.cropYCenterOffsetPct = 0.20F
                         
-                        backgroundPoster.loadImage(
-                            d.posterBackgroundImage
-                        ) { error(error) }
+                        backgroundPoster.loadImage(d.posterBackgroundImage) {
+                            error { getImageFromDrawable(context ?: return@error null, error) }
+                        }
                         comingSoon = d.comingSoon
                         resultTvComingSoon.isVisible = d.comingSoon
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchResultBuilder.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchResultBuilder.kt
@@ -10,6 +10,7 @@ import androidx.cardview.widget.CardView
 import androidx.core.view.isVisible
 import androidx.palette.graphics.Palette
 import androidx.preference.PreferenceManager
+import coil3.request.error
 import com.lagradost.cloudstream3.AnimeSearchResponse
 import com.lagradost.cloudstream3.DubStatus
 import com.lagradost.cloudstream3.LiveSearchResponse
@@ -25,6 +26,7 @@ import com.lagradost.cloudstream3.utils.DataStoreHelper
 import com.lagradost.cloudstream3.utils.DataStoreHelper.fixVisual
 import com.lagradost.cloudstream3.utils.ImageLoader.loadImage
 import com.lagradost.cloudstream3.utils.SubtitleHelper
+import com.lagradost.cloudstream3.utils.getImageFromDrawable
 
 object SearchResultBuilder {
     private val showCache: MutableMap<String, Boolean> = mutableMapOf()
@@ -120,7 +122,7 @@ object SearchResultBuilder {
         cardText?.text = card.name
         cardText?.isVisible = showTitle
         cardView.isVisible = true
-        cardView.loadImage(card.posterUrl) { error(R.drawable.default_cover) }
+        cardView.loadImage(card.posterUrl) { error { getImageFromDrawable(itemView.context, R.drawable.default_cover) } }
 
         fun click(view: View?) {
             clickCallback.invoke(

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -186,7 +186,6 @@ class SettingsFragment : Fragment() {
 
                 binding?.settingsProfilePic?.let { imageView ->
                     imageView.loadImage(pic) {
-                        crossfade(true)  // Optional: for a fade-in animation
                         error(errorProfilePic)  // Fallback to random error drawable
                     }
                 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -32,6 +32,7 @@ import com.lagradost.cloudstream3.utils.UIHelper
 import com.lagradost.cloudstream3.utils.UIHelper.clipboardHelper
 import com.lagradost.cloudstream3.utils.UIHelper.navigate
 import com.lagradost.cloudstream3.utils.UIHelper.toPx
+import com.lagradost.cloudstream3.utils.getImageFromDrawable
 import java.io.File
 import java.text.DateFormat
 import java.text.SimpleDateFormat
@@ -186,7 +187,8 @@ class SettingsFragment : Fragment() {
 
                 binding?.settingsProfilePic?.let { imageView ->
                     imageView.loadImage(pic) {
-                        error(errorProfilePic)  // Fallback to random error drawable
+                        // Fallback to random error drawable
+                        error { getImageFromDrawable(context ?: return@error null, errorProfilePic) }
                     }
                 }
                 return true // sync profile exists

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginAdapter.kt
@@ -28,6 +28,7 @@ import com.lagradost.cloudstream3.utils.ImageLoader.loadImage
 import com.lagradost.cloudstream3.utils.SubtitleHelper.fromTwoLettersToLanguage
 import com.lagradost.cloudstream3.utils.SubtitleHelper.getFlagFromIso
 import com.lagradost.cloudstream3.utils.UIHelper.toPx
+import com.lagradost.cloudstream3.utils.getImageFromDrawable
 import org.junit.Assert
 import org.junit.Test
 import java.text.DecimalFormat
@@ -205,7 +206,7 @@ class PluginAdapter(
                         "%exact_size%",
                         "$iconSizeExact"
                     )
-                ) { error(R.drawable.ic_baseline_extension_24) }
+                ) { error(getImageFromDrawable(itemView.context, R.drawable.ic_baseline_extension_24)) }
 
             binding.extVersion.isVisible = true
             binding.extVersion.text = "v${metadata.version}"

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginDetailsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginDetailsFragment.kt
@@ -24,6 +24,7 @@ import com.lagradost.cloudstream3.utils.SubtitleHelper.fromTwoLettersToLanguage
 import com.lagradost.cloudstream3.utils.SubtitleHelper.getFlagFromIso
 import com.lagradost.cloudstream3.utils.UIHelper.colorFromAttribute
 import com.lagradost.cloudstream3.utils.UIHelper.toPx
+import com.lagradost.cloudstream3.utils.getImageFromDrawable
 
 
 class PluginDetailsFragment(val data: PluginViewData) : BottomSheetDialogFragment() {
@@ -63,7 +64,7 @@ class PluginDetailsFragment(val data: PluginViewData) : BottomSheetDialogFragmen
         binding?.apply {
             pluginIcon.loadImage(metadata.iconUrl?.replace("%size%", "$iconSize")
                 ?.replace("%exact_size%", "$iconSizeExact")) {
-                error(R.drawable.ic_baseline_extension_24)
+                error { getImageFromDrawable(context ?: return@error null , R.drawable.ic_baseline_extension_24) }
             }
             pluginName.text = metadata.name.removeSuffix("Provider")
             pluginVersion.text = metadata.version.toString()

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
@@ -41,13 +41,13 @@ object ImageLoader {
             .build()
 
         return ImageLoader.Builder(context)
-            .crossfade(300)
+            .crossfade(250)
             .respectCacheHeaders(false)
             /** !Only use default placeholders and errors, if not using this instance for local
              * image buttons because when animating this will appear or in more cases **/
             //.placeholder(R.drawable.logo)
             //.error(R.drawable.logo)
-            //.allowHardware(true) // takes a toll on battery (only allow if app is like instagram or photos)
+            .allowHardware(false) // takes a toll on battery (only allow if app is like instagram or photos)
             .memoryCache {
                 MemoryCache.Builder(context)
                     .maxSizePercent(0.10) // Use 10 % of the app's available memory for caching
@@ -60,7 +60,7 @@ object ImageLoader {
                     .maxSizePercent(0.04) // Use 4% of the device's storage space for disk caching
                     .build()
             }
-            .diskCachePolicy(CachePolicy.READ_ONLY)
+            .diskCachePolicy(CachePolicy.ENABLED)
             /** Pass interceptors with care, unnecessary passing tokens to servers
             or image hosting services causes unauthorized exceptions **/
             .okHttpClient(okHttpClient)

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
@@ -42,7 +42,7 @@ object ImageLoader {
              * image buttons because when animating this will appear or in more cases **/
             //.placeholder { getImageFromDrawable(context, R.drawable.x) }
             //.error { getImageFromDrawable(context, R.drawable.x) }
-            .allowHardware(SDK_INT >= 28)
+            .allowHardware(false) // SDK_INT >= 28, cant use hardware bitmaps for Palette Builder
             .memoryCache {
                 MemoryCache.Builder()
                     .maxSizePercent(context, 0.1) // Use 10 % of the app's available memory for caching

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
@@ -21,6 +21,7 @@ import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
+import coil3.request.bitmapConfig
 import coil3.request.crossfade
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.network.DdosGuardKiller
@@ -34,7 +35,7 @@ object ImageLoader {
 
     private const val TAG = "CoilImgLoader"
 
-    fun buildImageLoader(context: PlatformContext): ImageLoader {
+    internal fun buildImageLoader(context: PlatformContext): ImageLoader {
         val okHttpClient = OkHttpClient.Builder()
             .addInterceptor(DdosGuardKiller(alwaysBypass = false))
             .build()
@@ -45,7 +46,8 @@ object ImageLoader {
              * image buttons because when animating this will appear or in more cases **/
             //.placeholder { getImageFromDrawable(context, R.drawable.x) }
             //.error { getImageFromDrawable(context, R.drawable.x) }
-            .allowHardware(SDK_INT >= 28)
+            .allowHardware(false)
+            //^SDK_INT >= 28 will replace with this when coil solves problem with software bitmap render
             .memoryCache {
                 MemoryCache.Builder()
                     .maxSizePercent(context, 0.1) // Use 10 % of the app's available memory for caching

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
@@ -25,10 +25,11 @@ import java.nio.ByteBuffer
 object ImageLoader {
 
     private var instance: ImageLoader? = null
+    private const val TAG = "CoilImgLoader"
 
     fun initializeCoilImageLoader(context: Context) {
         if (instance == null) {
-            synchronized(this) {
+            synchronized(lock = this) {
                 instance = buildImageLoader(context.applicationContext)
             }
         }
@@ -40,43 +41,43 @@ object ImageLoader {
             .build()
 
         return ImageLoader.Builder(context)
-            .crossfade(true)
+            .crossfade(300)
             .respectCacheHeaders(false)
             /** !Only use default placeholders and errors, if not using this instance for local
              * image buttons because when animating this will appear or in more cases **/
             //.placeholder(R.drawable.logo)
             //.error(R.drawable.logo)
-            .allowHardware(true)
+            //.allowHardware(true) // takes a toll on battery (only allow if app is like instagram or photos)
             .memoryCache {
                 MemoryCache.Builder(context)
-                    .maxSizePercent(0.15) // Use 15% of the app's available memory for image caching
+                    .maxSizePercent(0.10) // Use 10 % of the app's available memory for caching
                     .build()
             }
             .diskCache {
                 coil.disk.DiskCache.Builder()
-                    .maxSizeBytes(128 * 1024 * 1024) // 128 MB
+                    .maxSizeBytes(256 * 1024 * 1024) // 256 MB
                     .directory(context.cacheDir.resolve("cs3_image_cache"))
-                    .maxSizePercent(0.02) // Use 2% of the device's storage space for disk caching
+                    .maxSizePercent(0.04) // Use 4% of the device's storage space for disk caching
                     .build()
             }
-            .diskCachePolicy(CachePolicy.ENABLED)
+            .diskCachePolicy(CachePolicy.READ_ONLY)
             /** Pass interceptors with care, unnecessary passing tokens to servers
             or image hosting services causes unauthorized exceptions **/
             .okHttpClient(okHttpClient)
             .eventListener(object : EventListener {
                 override fun onStart(request: ImageRequest) {
                     super.onStart(request)
-                    Log.i("CoilImageLoader", "Loading Image ${request.data}")
+                    Log.i(TAG, "Loading Image ${request.data}")
                 }
 
                 override fun onSuccess(request: ImageRequest, result: SuccessResult) {
                     super.onSuccess(request, result)
-                    Log.d("CoilImageLoader", "Image Loading successful")
+                    Log.d(TAG, "Image Loading successful")
                 }
 
                 override fun onError(request: ImageRequest, result: ErrorResult) {
                     super.onError(request, result)
-                    Log.e("CoilImageLoadError", "Error loading image: ${result.throwable}")
+                    Log.e(TAG, "Error loading image: ${result.throwable}")
                 }
             })
             .build()

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/ImageModuleCoil.kt
@@ -21,12 +21,10 @@ import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
-import coil3.request.bitmapConfig
 import coil3.request.crossfade
 import com.lagradost.cloudstream3.USER_AGENT
-import com.lagradost.cloudstream3.network.DdosGuardKiller
+import com.lagradost.cloudstream3.network.buildDefaultClient
 import okhttp3.HttpUrl
-import okhttp3.OkHttpClient
 import okio.Path.Companion.toOkioPath
 import java.io.File
 import java.nio.ByteBuffer
@@ -36,9 +34,7 @@ object ImageLoader {
     private const val TAG = "CoilImgLoader"
 
     internal fun buildImageLoader(context: PlatformContext): ImageLoader {
-        val okHttpClient = OkHttpClient.Builder()
-            .addInterceptor(DdosGuardKiller(alwaysBypass = false))
-            .build()
+        val okHttpClient = buildDefaultClient(context)
 
         return ImageLoader.Builder(context)
             .crossfade(250)
@@ -46,8 +42,7 @@ object ImageLoader {
              * image buttons because when animating this will appear or in more cases **/
             //.placeholder { getImageFromDrawable(context, R.drawable.x) }
             //.error { getImageFromDrawable(context, R.drawable.x) }
-            .allowHardware(false)
-            //^SDK_INT >= 28 will replace with this when coil solves problem with software bitmap render
+            .allowHardware(SDK_INT >= 28)
             .memoryCache {
                 MemoryCache.Builder()
                     .maxSizePercent(context, 0.1) // Use 10 % of the app's available memory for caching

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/ImageUtil.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/ImageUtil.kt
@@ -1,6 +1,10 @@
 package com.lagradost.cloudstream3.utils
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import coil3.Image
@@ -20,4 +24,21 @@ sealed class UiImage {
 
 fun getImageFromDrawable(context: Context, drawableRes: Int): Image? {
     return ContextCompat.getDrawable(context, drawableRes)?.asImage()
+}
+
+fun drawableToBitmap(drawable: Drawable): Bitmap? {
+    return when (drawable) {
+        is BitmapDrawable -> drawable.bitmap
+        else -> {
+            val bitmap = Bitmap.createBitmap(
+                drawable.intrinsicWidth,
+                drawable.intrinsicHeight,
+                Bitmap.Config.ARGB_8888
+            )
+            val canvas = Canvas(bitmap)
+            drawable.setBounds(0, 0, canvas.width, canvas.height)
+            drawable.draw(canvas)
+            bitmap
+        }
+    }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/ImageUtil.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/ImageUtil.kt
@@ -1,6 +1,11 @@
 package com.lagradost.cloudstream3.utils
 
+import android.content.Context
 import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import coil3.Image
+import coil3.asImage
+import coil3.request.ImageRequest
 
 /// Type safe any image, because THIS IS NOT PYTHON
 sealed class UiImage {
@@ -11,4 +16,8 @@ sealed class UiImage {
 
     data class Drawable(@DrawableRes val resId: Int) : UiImage()
     data class Bitmap(val bitmap: android.graphics.Bitmap) : UiImage()
+}
+
+fun getImageFromDrawable(context: Context, drawableRes: Int): Image? {
+    return ContextCompat.getDrawable(context, drawableRes)?.asImage()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,10 +22,6 @@ allprojects {
     }
 }
 
-plugins {
-    id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
-}
-
 //tasks.register<Delete>("clean") {
 //    delete(rootProject.layout.buildDirectory)
 //}


### PR DESCRIPTION
annotation processors are now needed if we shift to room sqlite or DI, kapt & ksp were for glide so as transformation lib