### PR TITLE
Fix subtitle deletion for scoped storage

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/SubtitleUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/SubtitleUtils.kt
@@ -1,9 +1,9 @@
 package com.lagradost.cloudstream3.utils
 
 import android.content.Context
+import android.net.Uri
 import com.lagradost.api.Log
 import com.lagradost.cloudstream3.utils.VideoDownloadManager.getFolder
-import com.lagradost.safefile.SafeFile
 
 object SubtitleUtils {
 
@@ -20,11 +20,19 @@ object SubtitleUtils {
 
         getFolder(context, relative, info.basePath)?.forEach { (name, uri) ->
             if (isMatchingSubtitle(name, display, cleanDisplay)) {
-                val subtitleFile = SafeFile.fromUri(context, uri)
-                if (subtitleFile == null || !subtitleFile.delete()) {
-                    Log.e("SubtitleDeletion", "Failed to delete subtitle file: ${subtitleFile?.name()}")
-                }
+                deleteSubtitleFile(context, uri)
             }
+        }
+    }
+
+    private fun deleteSubtitleFile(context: Context, uri: Uri) {
+        try {
+            val rowsDeleted = context.contentResolver.delete(uri, null, null)
+            if (rowsDeleted <= 0) {
+                Log.e("SubtitleDeletion", "Failed to delete subtitle file: $uri")
+            }
+        } catch (e: Exception) {
+            Log.e("SubtitleDeletion", "Error deleting subtitle file: ${e.message}")
         }
     }
 


### PR DESCRIPTION
The current way only works for non scoped storage directories therefore it doesn't work for the default Downloads directory. Using `context.contentResolver.delete` *should* make it work for scoped storage directories as well. We start with `SafeFile` and fallback to `contentResolver` to ensure both `file://` and `content://` schemes work.