### PR TITLE
Fix path for AsianDrama downloads

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -643,7 +643,7 @@ class ResultViewModel2 : ViewModel() {
                 TvType.Cartoon -> "Cartoons/$sanitizedFileName"
                 TvType.Torrent -> "Torrent"
                 TvType.Documentary -> "Documentaries"
-                TvType.AsianDrama -> "AsianDrama"
+                TvType.AsianDrama -> "AsianDrama/$sanitizedFileName"
                 TvType.Live -> "LiveStreams"
                 TvType.NSFW -> "NSFW"
                 TvType.Others -> "Others"


### PR DESCRIPTION
It is defined as episode based and saves in the format of Episode X but not in a series sub folder which means it can easily conflict if you have 2 like that etc...