### PR TITLE
Add StringUtils

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/StringUtils.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/StringUtils.kt
@@ -1,0 +1,14 @@
+package com.lagradost.cloudstream3.utils
+
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+object StringUtils {
+    fun String.encodeUri(): String {
+        URLEncoder.encode(this, "UTF-8")
+    }
+
+    fun String.decodeUri(): String {
+        URLDecoder.decode(this, "UTF-8")
+    }
+}

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/StringUtils.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/StringUtils.kt
@@ -5,10 +5,10 @@ import java.net.URLEncoder
 
 object StringUtils {
     fun String.encodeUri(): String {
-        URLEncoder.encode(this, "UTF-8")
+        return URLEncoder.encode(this, "UTF-8")
     }
 
     fun String.decodeUri(): String {
-        URLDecoder.decode(this, "UTF-8")
+        return URLDecoder.decode(this, "UTF-8")
     }
 }


### PR DESCRIPTION
This may be completely useless (but did plan to use it myself) so feel free to close if you feel it is absolutely unnecessary. This is meant for use by extensions for URI manipulation since the same method seems to be used across many providers and extractors ([search](https://github.com/search?q=cloudstream+String.encodeUri+language%3AKotlin&type=code)), so these methods were just meant to streamline that.

I also plan to potential expand it with more String methods later which is why it is StringX not URIX.