### PR TITLE
Fix to define Cartoon as episode based

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -1274,7 +1274,12 @@ fun LoadResponse?.isAnimeBased(): Boolean {
 
 fun TvType?.isEpisodeBased(): Boolean {
     if (this == null) return false
-    return (this == TvType.TvSeries || this == TvType.Anime || this == TvType.AsianDrama)
+    return this in listOf(
+        TvType.Anime,
+        TvType.AsianDrama,
+        TvType.Cartoon,
+        TvType.TvSeries
+    )
 }
 
 data class NextAiring(

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -1273,13 +1273,13 @@ fun LoadResponse?.isAnimeBased(): Boolean {
 }
 
 fun TvType?.isEpisodeBased(): Boolean {
-    if (this == null) return false
-    return this in listOf(
+    return when (this) {
         TvType.Anime,
         TvType.AsianDrama,
         TvType.Cartoon,
-        TvType.TvSeries
-    )
+        TvType.TvSeries -> true
+        else -> false
+    }
 }
 
 data class NextAiring(


### PR DESCRIPTION
Supposed to be based on https://github.com/recloudstream/cloudstream/blob/282b25b665fd2fe9f7a596e3d6c9067ea540730c/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt#L643