### PR TITLE
Add new TVTypes for generic Audio and Podcast

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -249,6 +249,8 @@ fun LoadResponse.toResultData(repo: APIRepository): ResultData {
                 TvType.Music -> R.string.music_singlar
                 TvType.AudioBook -> R.string.audio_book_singular
                 TvType.CustomMedia -> R.string.custom_media_singluar
+                TvType.Audio -> R.string.audio_singluar
+                TvType.Podcast -> R.string.podcast_singluar
             }
         ),
         yearText = txt(year?.toString()),
@@ -650,6 +652,8 @@ class ResultViewModel2 : ViewModel() {
                 TvType.Music -> "Music"
                 TvType.AudioBook -> "AudioBooks"
                 TvType.CustomMedia -> "Media"
+                TvType.Audio -> "Audio"
+                TvType.Podcast -> "Podcasts"
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -373,6 +373,8 @@
     <string name="music_singlar">Music</string>
     <string name="audio_book_singular">Audio Book</string>
     <string name="custom_media_singluar">Media</string>
+    <string name="audio_singluar">Audio</string>
+    <string name="podcast_singluar">Podcast</string>
     <string name="source_error">Source error</string>
     <string name="remote_error">Remote error</string>
     <string name="render_error">Renderer error</string>

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -681,8 +681,11 @@ enum class TvType(value: Int?) {
     Music(13),
     AudioBook(14),
 
-    /** Wont load the built in player, make your own interaction */
+    /** Won't load the built in player, make your own interaction */
     CustomMedia(15),
+
+    Audio(16),
+    Podcast(17),
 }
 
 public enum class AutoDownloadMode(val value: Int) {
@@ -698,9 +701,22 @@ public enum class AutoDownloadMode(val value: Int) {
     }
 }
 
-// IN CASE OF FUTURE ANIME MOVIE OR SMTH
 fun TvType.isMovieType(): Boolean {
-    return this == TvType.Movie || this == TvType.AnimeMovie || this == TvType.Torrent || this == TvType.Live
+    return this in listOf(
+        TvType.AnimeMovie,
+        TvType.Live,
+        TvType.Movie,
+        TvType.Torrent
+    )
+}
+
+fun TvType.isAudioType(): Boolean {
+    return this in listOf(
+        TvType.Audio,
+        TvType.AudioBook,
+        TvType.Music,
+        TvType.Podcast
+    )
 }
 
 fun TvType.isLiveStream(): Boolean {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -702,21 +702,23 @@ public enum class AutoDownloadMode(val value: Int) {
 }
 
 fun TvType.isMovieType(): Boolean {
-    return this in listOf(
+    return when (this) {
         TvType.AnimeMovie,
         TvType.Live,
         TvType.Movie,
-        TvType.Torrent
-    )
+        TvType.Torrent -> true
+        else -> false
+    }
 }
 
 fun TvType.isAudioType(): Boolean {
-    return this in listOf(
+    return when (this) {
         TvType.Audio,
         TvType.AudioBook,
         TvType.Music,
-        TvType.Podcast
-    )
+        TvType.Podcast -> true
+        else -> false
+    }
 }
 
 fun TvType.isLiveStream(): Boolean {


### PR DESCRIPTION
I also added `isAudioType` for an eventual change to player to better accommodate audio-only playback.