### PR TITLE
Updated folder names in `getFolder` method for tense consistency.

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -636,20 +636,20 @@ class ResultViewModel2 : ViewModel() {
             val sanitizedFileName = VideoDownloadManager.sanitizeFilename(titleName)
             return when (currentType) {
                 TvType.Anime -> "Anime/$sanitizedFileName"
-                TvType.Movie -> "Movies"
                 TvType.AnimeMovie -> "Movies"
-                TvType.TvSeries -> "TVSeries/$sanitizedFileName"
-                TvType.OVA -> "OVA"
-                TvType.Cartoon -> "Cartoons/$sanitizedFileName"
-                TvType.Torrent -> "Torrent"
-                TvType.Documentary -> "Documentaries"
-                TvType.AsianDrama -> "AsianDrama/$sanitizedFileName"
-                TvType.Live -> "LiveStreams"
-                TvType.NSFW -> "NSFW"
-                TvType.Others -> "Others"
-                TvType.Music -> "Music"
+                TvType.AsianDrama -> "AsianDramas/$sanitizedFileName"
                 TvType.AudioBook -> "AudioBooks"
+                TvType.Cartoon -> "Cartoons/$sanitizedFileName"
                 TvType.CustomMedia -> "Media"
+                TvType.Documentary -> "Documentaries"
+                TvType.Live -> "LiveStreams"
+                TvType.Movie -> "Movies"
+                TvType.Music -> "Music"
+                TvType.NSFW -> "NSFW"
+                TvType.OVA -> "OVAs"
+                TvType.Others -> "Others"
+                TvType.Torrent -> "Torrents"
+                TvType.TvSeries -> "TVSeries/$sanitizedFileName"
             }
         }
 


### PR DESCRIPTION
AsianDrama -> AsianDramas, OVA -> OVAs, Torrent -> Torrents


If the consistency doesn't matter I suppose this can be closed, but all 3 are likely minimal download targets considering till yesterday AsianDrama downloads were broken completely, I can't even find any OVAs in extensions (but that might just be me), and Torrents don't seem to be typically fully downloadable and the whole thing is fairly new.