### PR TITLE
Update Turkish Translation

### DIFF
--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -194,7 +194,7 @@
     <string name="season_format">%1$s %2$d%3$s</string>
     <string name="no_season">Sezon yok</string>
     <string name="episode">Bölüm</string>
-    <string name="episodes">Bölümler</string>
+    <string name="episodes">Bölüm</string>
     <string name="episodes_range">%1$d-%2$d</string>
     <string name="episode_format" formatted="true">%1$d %2$s</string>
     <string name="season_short">S</string>


### PR DESCRIPTION
In Turkish, plural forms are generally not used with numbers. For example, "10 Bölümler" ("10 Episodes") is incorrect, while "10 Bölüm" ("10 Episode") is the correct form. The "episodes" string value was updated from "Bölümler" to "Bölüm" to align with Turkish grammar rules. This change ensures linguistic accuracy and improves the user interface for Turkish-speaking users.