### PR TITLE
Fix issue when removing last element of List

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadManager.kt
@@ -1737,7 +1737,7 @@ object VideoDownloadManager {
     ) {
         if (!(currentDownloads.size < maxConcurrentDownloads && downloadQueue.size > 0)) return
 
-        val pkg = downloadQueue.removeFirst()
+        val pkg = downloadQueue.removeAt(0)
         val item = pkg.item
         val id = item.ep.id
         if (currentDownloads.contains(id)) { // IF IT IS ALREADY DOWNLOADING, RESUME IT

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/M3u8Helper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/M3u8Helper.kt
@@ -133,7 +133,7 @@ object M3u8Helper2 {
 
     private fun getParentLink(uri: String): String {
         val split = uri.split("/").toMutableList()
-        split.removeLast()
+        split.removeAt(split.lastIndex)
         return split.joinToString("/")
     }
 


### PR DESCRIPTION
This fixes the new extension issue after bumping to sdk 35 (when running on A14 and lower)

According to https://developer.android.com/about/versions/15/behavior-changes-15#openjdk-api-changes
There is a Collision with [MutableList.removeFirst()](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/remove-first.html) and [MutableList.removeLast()](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/remove-last.html) extension functions in kotlin-stdlib
leads to:
```
java.lang.NoSuchMethodError: No virtual method
removeFirst()Ljava/lang/Object; in class Ljava/util/ArrayList;
```