### PR TITLE
Migrate dokka to 2.0.0

### DIFF
--- a/.github/workflows/generate_dokka.yml
+++ b/.github/workflows/generate_dokka.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/src/
           chmod +x gradlew
-          ./gradlew docs:dokkaHtml
+          ./gradlew docs:dokkaGeneratePublicationHtml
 
       - name: Copy Dokka
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,7 +178,6 @@ dependencies {
 
     // PlayBack
     implementation(libs.colorpicker) // Subtitle Color Picker
-    // implementation(libs.media.ffmpeg) // Custom FFmpeg Lib for Audio Codecs
     implementation(libs.newpipeextractor) // For Trailers
     implementation(libs.juniversalchardet) // Subtitle Decoding
 

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URI
 
@@ -53,13 +52,10 @@ dependencies {
     dokkaImplementation(libs.material)
     dokkaImplementation(libs.constraintlayout)
     dokkaImplementation(libs.swiperefreshlayout)
-    dokkaImplementation(libs.coil)
-    dokkaImplementation(libs.coil.network.okhttp)
     dokkaImplementation(libs.guava)
     dokkaImplementation(libs.auto.service.ksp)
     dokkaImplementation(libs.bundles.media3)
     dokkaImplementation(libs.colorpicker) // Subtitle Color Picker
-    // dokkaImplementation(libs.media.ffmpeg) // Custom FFmpeg Lib for Audio Codecs
     dokkaImplementation(libs.bundles.nextlibMedia3)
     dokkaImplementation(libs.newpipeextractor)
     dokkaImplementation(libs.juniversalchardet) // Subtitle Decoding
@@ -83,28 +79,30 @@ dependencies {
     dokkaImplementation(libs.nicehttp) // HTTP Lib
 }
 
-tasks.withType<DokkaTask>().configureEach {
+dokka {
     dokkaSourceSets {
         moduleName = "Cloudstream"
         register("cloudstream") {
             listOf("androidMain", "commonMain").forEach { srcName ->
-                sourceRoot("../library/src/$srcName/kotlin")
+                sourceRoots.from("../library/src/$srcName/kotlin")
             }
-            sourceRoot(file("../app/src/main/java"))
+            sourceRoots.from(file("../app/src/main/java"))
 
             classpath.from(android.bootClasspath)
             classpath.from(dokkaImplementation.files)
 
             sourceLink {
                 localDirectory = file("..")
-                remoteUrl = URI("https://github.com/recloudstream/cloudstream/tree/master").toURL()
+                remoteUrl("https://github.com/recloudstream/cloudstream/tree/master")
                 remoteLineSuffix = "#L"
             }
 
-            dokkaImplementation.dependencies.forEach {
-                externalDocumentationLink {
-                    url = URI("https://javadoc.io/doc/${it.group}/${it.name}/${it.version}").toURL()
-                    packageListUrl = URI("https://javadoc.io/doc/${it.group}/${it.name}/${it.version}/package-list").toURL()
+            externalDocumentationLinks {
+                dokkaImplementation.dependencies.forEach {
+                    register(it.name) {
+                        url = URI("https://javadoc.io/doc/${it.group}/${it.name}/${it.version}")
+                        packageListUrl = URI("https://javadoc.io/doc/${it.group}/${it.name}/${it.version}/package-list")
+                    }
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,7 @@ android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+
+# Dokka Gradle plugin V1 is deprecated, and will be removed in Dokka version 2.1.0
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,17 +3,17 @@ acraCore = "5.11.3"
 appcompat = "1.7.0"
 autoServiceKsp = "1.2.0"
 biometric = "1.2.0-alpha05"
-buildkonfigGradlePlugin = "0.15.1"
+buildkonfigGradlePlugin = "0.15.2"
 coil = "3.0.4"
 colorpicker = "1.1.0"
 conscryptAndroid = "2.5.2"
 constraintlayout = "2.2.0"
 coreKtx = "1.15.0"
 desugar_jdk_libs_nio = "2.1.4"
-dokkaGradlePlugin = "1.9.10"
+dokkaGradlePlugin = "2.0.0"
 espressoCore = "3.6.1"
 fuzzywuzzy = "1.4.0"
-gradle = "8.7.3"
+gradle = "8.8.0"
 guava = "33.3.1-android"
 jacksonModuleKotlin = "2.13.1"
 json = "20240303"
@@ -27,7 +27,6 @@ lifecycleLivedataKtx = "2.8.7"
 lifecycleViewmodelKtx = "2.8.7"
 material = "1.12.0"
 media3 = "1.5.1"
-mediaFfmpeg = "1.1.0"
 navigationFragmentKtx = "2.8.5"
 navigationUiKtx = "2.8.5"
 newpipeextractor = "v0.24.3"
@@ -86,7 +85,6 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleLivedataKtx" }
 lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
-media-ffmpeg = { module = "com.github.recloudstream:media-ffmpeg", version.ref = "mediaFfmpeg" }
 media3-cast = { module = "androidx.media3:media3-cast", version.ref = "media3" }
 media3-common = { module = "androidx.media3:media3-common", version.ref = "media3" }
 media3-datasource-okhttp = { module = "androidx.media3:media3-datasource-okhttp", version.ref = "media3" }


### PR DESCRIPTION
This was tested and works locally. This fixes a lot of compatability issues with kotlin 2 also, such as it currently giving `<Error class: unknown class>` for things like `listOf()`, `mutableListOf()`, and `typealias()`. It also adds support for configuration cache in Dokka (although still may need a few changes on our end for it which I may try to do in a follow-up patch) which will be required in a future gradle release, as well as has many improvements to the actual generated HTML docs.