### PR TITLE
gradle: enable build and configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,9 @@ android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+
 # Dokka Gradle plugin V1 is deprecated, and will be removed in Dokka version 2.1.0
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true


### PR DESCRIPTION
#1493 and #1494 adds full support for this.

This shouldn't break any extensions or anything but the next step is adding support for configuration cache for plugins themselves in the [Cloudstream Gradle Plugin](/recloudstream/gradle).