### PR TITLE
fix: don't attempt to fix urls that are JSON arrays

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -600,8 +600,8 @@ fun MainAPI.fixUrlNull(url: String?): String? {
 
 fun MainAPI.fixUrl(url: String): String {
     if (url.startsWith("http") ||
-        // Do not fix JSON objects when passed as urls.
-        url.startsWith("{\"")
+        // Do not fix JSON objects and arrays when passed as urls.
+        url.startsWith("{\"") || url.startsWith("[")
     ) {
         return url
     }


### PR DESCRIPTION
I noticed that some providers pass JSON arrays as data to `loadLinks`, which will be URL-fixed and thus such providers are broken.

Apart from that it can come in handy to pass the stream links directly as a list via JSON arrays instead of wrapping it into a JSON dictionary.
