### PR TITLE
Only load default player if there are no mediaItemSlices

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -811,6 +811,8 @@ class CS3IPlayer : IPlayer {
                             ).build()
                     )
 
+            // Don't load any sources if there are none.
+            if (mediaItemSlices.isEmpty()) return exoPlayerBuilder.build()
 
             val factory =
                 if (cacheFactory == null) DefaultMediaSourceFactory(context)


### PR DESCRIPTION
Otherwise it causes torrents to always fail.

I think this issue is caused by:
```kt
// load the initial UI, we require an exoPlayer to be alive
if (!retry) {
    // this causes a *bug* that restarts all torrents from 0
    // but I would call this a feature
    releasePlayer()
    loadExo(context, listOf(), listOf(), null)
}
```
In particular, `loadExo(context, listOf(), listOf(), null)` but since the comment says we just need exoplayer alive in this case then I assume torrents handle the rest, just exiting early when there are no mediaItemSlices seems like it would work here.