### PR TITLE
Fix installer on some older devices

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/services/PackageInstallerService.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/services/PackageInstallerService.kt
@@ -15,6 +15,7 @@ import com.lagradost.cloudstream3.MainActivity
 import com.lagradost.cloudstream3.MainActivity.Companion.deleteFileOnExit
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.utils.ApkInstaller
 import com.lagradost.cloudstream3.utils.AppContextUtils.createNotificationChannel
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
@@ -106,6 +107,7 @@ class PackageInstallerService : Service() {
             }
             return true
         } catch (e: Exception) {
+            logError(e)
             updateNotificationProgress(0f, ApkInstaller.InstallProgressStatus.Failed)
             return false
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/PackageInstaller.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/PackageInstaller.kt
@@ -111,17 +111,20 @@ class ApkInstaller(private val service: PackageInstallerService) {
                 }
 
             // We must create an explicit intent or it will fail on Android 15+
-            val installIntent = Intent(service, PackageInstallerService::class.java).apply {
-                action = INSTALL_ACTION
+            val installIntent = Intent(
+                service, PackageInstallerService::class.java
+            ).apply { setAction(INSTALL_ACTION) }.takeIf {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+            } ?: Intent(INSTALL_ACTION)
+
+            val installFlags = when {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> PendingIntent.FLAG_MUTABLE
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> PendingIntent.FLAG_IMMUTABLE
+                else -> 0
             }
 
             val intentSender = PendingIntent.getBroadcast(
-                service,
-                activeSession,
-                installIntent,
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    PendingIntent.FLAG_MUTABLE
-                } else 0,
+                service, activeSession, installIntent, installFlags
             ).intentSender
 
             // Use delayed installations on android 13 and only if "allow from unknown sources" is enabled

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/PackageInstaller.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/PackageInstaller.kt
@@ -114,7 +114,7 @@ class ApkInstaller(private val service: PackageInstallerService) {
             val installIntent = Intent(
                 service, PackageInstallerService::class.java
             ).apply { setAction(INSTALL_ACTION) }.takeIf {
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE 
             } ?: Intent(INSTALL_ACTION)
 
             val installFlags = when {

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/PackageInstaller.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/PackageInstaller.kt
@@ -111,11 +111,10 @@ class ApkInstaller(private val service: PackageInstallerService) {
                 }
 
             // We must create an explicit intent or it will fail on Android 15+
-            val installIntent = Intent(
-                service, PackageInstallerService::class.java
-            ).apply { setAction(INSTALL_ACTION) }.takeIf {
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE 
-            } ?: Intent(INSTALL_ACTION)
+            val installIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) { 
+                Intent(service, PackageInstallerService::class.java)
+                    .setAction(INSTALL_ACTION) 
+            } else Intent(INSTALL_ACTION) 
 
             val installFlags = when {
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> PendingIntent.FLAG_MUTABLE


### PR DESCRIPTION
Not 100% sure when this starts working however I am 100% sure it works on SDK 34 & 35 so we just start there and use the old behavior on older APIs just to maintain that it will work for certain.