### PR TITLE
Remove repository from tibdex/github-app-token

### DIFF
--- a/.github/workflows/build_to_archive.yml
+++ b/.github/workflows/build_to_archive.yml
@@ -23,14 +23,12 @@ jobs:
       with:
         app_id: ${{ secrets.GH_APP_ID }}
         private_key: ${{ secrets.GH_APP_KEY }}
-        repository: "recloudstream/secrets"
     - name: Generate access token (archive)
       id: generate_archive_token
       uses: tibdex/github-app-token@v2
       with:
         app_id: ${{ secrets.GH_APP_ID }}
         private_key: ${{ secrets.GH_APP_KEY }}
-        repository: "recloudstream/cloudstream-archive"
     - uses: actions/checkout@v4
     - name: Set up JDK 17
       uses: actions/setup-java@v4

--- a/.github/workflows/generate_dokka.yml
+++ b/.github/workflows/generate_dokka.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_KEY }}
-          repository: "recloudstream/dokka"
       - name: Checkout
         uses: actions/checkout@master
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,7 +22,6 @@ jobs:
       with:
         app_id: ${{ secrets.GH_APP_ID }}
         private_key: ${{ secrets.GH_APP_KEY }}
-        repository: "recloudstream/secrets"
     - uses: actions/checkout@v4
     - name: Set up JDK 17
       uses: actions/setup-java@v4

--- a/.github/workflows/update_locales.yml
+++ b/.github/workflows/update_locales.yml
@@ -22,7 +22,6 @@ jobs:
       with:
         app_id: ${{ secrets.GH_APP_ID }}
         private_key: ${{ secrets.GH_APP_KEY }}
-        repository: "recloudstream/cloudstream"
     - uses: actions/checkout@v4
       with:
         token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
This was removed in v2 which means it's just defaulting to the current repository of recloudstream/cloudstream, this could be replaced if you still want to use other repositories though but just removes because that keeps the behavior it does now (AFAIK)