### PR TITLE
fix: new episode notifications for subscriptions not opening series page when clicking

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -193,6 +193,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
         var lastError: String? = null
 
         private const val FILE_DELETE_KEY = "FILES_TO_DELETE_KEY"
+        const val API_NAME_EXTRA_KEY = "API_NAME_EXTRA_KEY"
 
         /**
          * Transient files to delete on application exit.
@@ -255,7 +256,8 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
         fun handleAppIntentUrl(
             activity: FragmentActivity?,
             str: String?,
-            isWebview: Boolean
+            isWebview: Boolean,
+            extraArgs: Bundle? = null
         ): Boolean =
             with(activity) {
                 // TODO MUCH BETTER HANDLING
@@ -353,6 +355,16 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                             this.navigate(R.id.navigation_downloads)
                             return true
                         } else {
+                            val apiName = extraArgs?.getString(API_NAME_EXTRA_KEY)
+                                ?.takeIf { it.isNotBlank() }
+                            // if provided, try to match the api name instead of the api url
+                            // this is in order to also support providers that use JSON dataUrls
+                            // for example
+                            if (apiName != null) {
+                                loadResult(str, apiName, "")
+                                return true
+                            }
+
                             synchronized(apis) {
                                 for (api in apis) {
                                     if (str.startsWith(api.mainUrl)) {
@@ -667,7 +679,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
         if (intent == null) return
         val str = intent.dataString
         loadCache()
-        handleAppIntentUrl(this, str, false)
+        handleAppIntentUrl(this, str, false, intent.extras)
     }
 
     private fun NavDestination.matchDestination(@IdRes destId: Int): Boolean =

--- a/app/src/main/java/com/lagradost/cloudstream3/services/SubscriptionWorkManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/services/SubscriptionWorkManager.kt
@@ -186,7 +186,7 @@ class SubscriptionWorkManager(val context: Context, workerParams: WorkerParamete
                         val intent = Intent(context, MainActivity::class.java).apply {
                             data = savedData.url.toUri()
                             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                        }
+                        }.putExtra(MainActivity.API_NAME_EXTRA_KEY, api.name)
 
                         val pendingIntent =
                             if (SDK_INT >= Build.VERSION_CODES.M) {


### PR DESCRIPTION
There are multiple scenarios where the previous approach fails at the moment:
1. When the extension uses JSON data to as `dataUrl`, `handleIntentData` tries to match the JSON data to the main url of the engine, which obviously won't work because the JSON data isn't prefixed with the `mainUrl`
2. If the `mainUrl` is different to the used `dataUrl` for the series (e.g. because the mainUrl is the HTML url for the extension, but the internally used urls refer to the api url for the extension), there's no match
3. There are various multi-providers that accumulate stream sources from different sites but use `TMDB` internally to reference series (i.e. their TMDB URL). However, such providers either don't provide any `mainUrl`, and if they do, it's not guaranteed that the user will land on the right extension when clicking the link, because multiple providers possible use the same `mainUrl`.

The idea in this PR is to use the api name in order to identify the origin of the notifications `dataUrl`, so that the right api can be found (by its name).