### PR TITLE
refactor: replace PendingIntent#getActivity with PendingIntentCompat#getActivity

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/services/PackageInstallerService.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/services/PackageInstallerService.kt
@@ -1,16 +1,15 @@
 package com.lagradost.cloudstream3.services
 
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.app.PendingIntentCompat
 import com.lagradost.cloudstream3.MainActivity
 import com.lagradost.cloudstream3.MainActivity.Companion.deleteFileOnExit
 import com.lagradost.cloudstream3.R
@@ -29,13 +28,9 @@ class PackageInstallerService : Service() {
     private var installer: ApkInstaller? = null
 
     private val baseNotification by lazy {
-        val flag = if (SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_IMMUTABLE
-        } else 0
-
         val intent = Intent(this, MainActivity::class.java)
         val pendingIntent =
-            PendingIntent.getActivity(this, 0, intent, flag)
+            PendingIntentCompat.getActivity(this, 0, intent, 0, false)
 
         NotificationCompat.Builder(this, UPDATE_CHANNEL_ID)
             .setAutoCancel(false)

--- a/app/src/main/java/com/lagradost/cloudstream3/services/SubscriptionWorkManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/services/SubscriptionWorkManager.kt
@@ -1,14 +1,12 @@
 package com.lagradost.cloudstream3.services
 
-import android.annotation.SuppressLint
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import androidx.core.app.NotificationCompat
+import androidx.core.app.PendingIntentCompat
 import androidx.core.net.toUri
 import androidx.work.*
 import com.lagradost.cloudstream3.*
@@ -100,7 +98,6 @@ class SubscriptionWorkManager(val context: Context, workerParams: WorkerParamete
         )
     }
 
-    @SuppressLint("UnspecifiedImmutableFlag")
     override suspend fun doWork(): Result {
         try {
 //        println("Update subscriptions!")
@@ -189,16 +186,7 @@ class SubscriptionWorkManager(val context: Context, workerParams: WorkerParamete
                         }
 
                         val pendingIntent =
-                            if (SDK_INT >= Build.VERSION_CODES.M) {
-                                PendingIntent.getActivity(
-                                    context,
-                                    0,
-                                    intent,
-                                    PendingIntent.FLAG_IMMUTABLE
-                                )
-                            } else {
-                                PendingIntent.getActivity(context, 0, intent, 0)
-                            }
+                            PendingIntentCompat.getActivity(context, 0, intent, 0, false)
 
                         val poster = ioWork {
                             savedData.posterUrl?.let { url ->

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadManager.kt
@@ -19,6 +19,7 @@ import androidx.annotation.DrawableRes
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.PendingIntentCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
 import androidx.preference.PreferenceManager
@@ -321,13 +322,8 @@ object VideoDownloadManager {
                     data = source.toUri()
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 }
-                val pendingIntent: PendingIntent =
-                    if (SDK_INT >= Build.VERSION_CODES.M) {
-                        PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
-                    } else {
-                        //fixme Specify a better flag
-                        PendingIntent.getActivity(context, 0, intent, 0)
-                    }
+                val pendingIntent =
+                    PendingIntentCompat.getActivity(context, 0, intent, 0, false)
                 builder.setContentIntent(pendingIntent)
             }
 


### PR DESCRIPTION
`PendingIntentCompat#getActivity` does exactly the same as the previous version code check does, so we can get rid of that extra sdk version checks here.