### PR TITLE
fix: update switch track color to match primary theme color

### DIFF
--- a/app/src/main/res/color/toggle_selector.xml
+++ b/app/src/main/res/color/toggle_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="true" android:color="?attr/colorControlActivated"/>
+    <item android:state_checked="true" android:color="?attr/colorPrimaryDark"/>
     <item android:color="?attr/grayTextColor"/>
 </selector>

--- a/app/src/main/res/layout/subtitle_settings.xml
+++ b/app/src/main/res/layout/subtitle_settings.xml
@@ -164,6 +164,7 @@
             android:nextFocusUp="@id/subs_download_languages"
             android:nextFocusDown="@id/subtitles_remove_captions"
             android:text="@string/subtitles_remove_bloat"
+            app:trackTint="@color/toggle_selector"
             app:drawableEndCompat="@null" />
 
         <com.google.android.material.switchmaterial.SwitchMaterial
@@ -177,6 +178,7 @@
             android:nextFocusUp="@id/subtitles_remove_bloat"
             android:nextFocusDown="@id/subtitles_filter_sub_lang"
             android:text="@string/subtitles_remove_captions"
+            app:trackTint="@color/toggle_selector"
             app:drawableEndCompat="@null" />
 
         <com.google.android.material.switchmaterial.SwitchMaterial
@@ -190,6 +192,7 @@
             android:nextFocusUp="@id/subtitles_remove_captions"
             android:nextFocusDown="@id/subtitles_uppercase"
             android:text="@string/subtitles_filter_lang"
+            app:trackTint="@color/toggle_selector"
             app:drawableEndCompat="@null" />
 
         <com.google.android.material.switchmaterial.SwitchMaterial
@@ -203,6 +206,7 @@
             android:nextFocusUp="@id/subtitles_filter_sub_lang"
             android:nextFocusDown="@id/apply_btt"
             android:text="@string/uppercase_all_subtitles"
+            app:trackTint="@color/toggle_selector"
             app:drawableEndCompat="@null" />
 
         <TextView


### PR DESCRIPTION
Fixes #1566 
When switches are enabled in the Subtitles menu, their track color now correctly reflects the user's selected primary color from Layout settings.

Issue:
- Switch track colors were not inheriting the primary theme color
- Affected only the 4 switches in Settings > Player > Subtitles menu
- Track color remained static even when switches were enabled

Fix:
- Updated switch styling to properly inherit primary color theme
- Ensures consistent theming across the subtitle preferences interface