### PR TITLE
refactor: Use kotlin based new fuzzy lib (levenshtein distance)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -203,7 +203,7 @@ dependencies {
     // Extensions & Other Libs
     implementation(libs.rhino) // Run JavaScript
     implementation(libs.quickjs)
-    implementation(libs.fuzzywuzzy) // Library/Ext Searching with Levenshtein Distance
+    implementation(libs.fuzzywuzzy.kotlin) // Library/Ext Searching with Levenshtein Distance
     implementation(libs.safefile) // To Prevent the URI File Fu*kery
     coreLibraryDesugaring(libs.desugar.jdk.libs.nio) // NIO Flavor Needed for NewPipeExtractor
     implementation(libs.conscrypt.android) {

--- a/app/src/main/java/com/lagradost/cloudstream3/syncproviders/SyncApi.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/syncproviders/SyncApi.kt
@@ -1,10 +1,10 @@
 package com.lagradost.cloudstream3.syncproviders
 
+import com.frosch2010.fuzzywuzzy_kotlin.FuzzySearch
 import com.lagradost.cloudstream3.*
 import com.lagradost.cloudstream3.ui.SyncWatchType
 import com.lagradost.cloudstream3.ui.library.ListSorting
 import com.lagradost.cloudstream3.utils.UiText
-import me.xdrop.fuzzywuzzy.FuzzySearch
 import java.util.Date
 
 interface SyncAPI : OAuth2API {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginsViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginsViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
+import com.frosch2010.fuzzywuzzy_kotlin.FuzzySearch
 import com.lagradost.cloudstream3.CommonActivity.showToast
 import com.lagradost.cloudstream3.PROVIDER_STATUS_DOWN
 import com.lagradost.cloudstream3.R
@@ -19,11 +20,10 @@ import com.lagradost.cloudstream3.plugins.PluginManager
 import com.lagradost.cloudstream3.plugins.PluginManager.getPluginPath
 import com.lagradost.cloudstream3.plugins.RepositoryManager
 import com.lagradost.cloudstream3.plugins.SitePlugin
-import com.lagradost.cloudstream3.utils.txt
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.Coroutines.main
 import com.lagradost.cloudstream3.utils.Coroutines.runOnMainThread
-import me.xdrop.fuzzywuzzy.FuzzySearch
+import com.lagradost.cloudstream3.utils.txt
 import java.io.File
 
 typealias Plugin = Pair<String, SitePlugin>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,8 @@ coreKtx = "1.15.0"
 desugar_jdk_libs_nio = "2.1.4"
 dokkaGradlePlugin = "2.0.0"
 espressoCore = "3.6.1"
-fuzzywuzzy = "1.4.0"
+#fuzzywuzzy = "1.4.0"
+fuzzywuzzyKotlin = "1.0.0"
 gradle = "8.8.0"
 jacksonModuleKotlin = "2.13.1"
 json = "20250107"
@@ -68,7 +69,8 @@ desugar_jdk_libs_nio = { module = "com.android.tools:desugar_jdk_libs_nio", vers
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokkaGradlePlugin" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
 ext-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
-fuzzywuzzy = { module = "me.xdrop:fuzzywuzzy", version.ref = "fuzzywuzzy" }
+#fuzzywuzzy = { module = "me.xdrop:fuzzywuzzy", version.ref = "fuzzywuzzy" }
+fuzzywuzzy-kotlin = { module = "com.github.jens-muenker:fuzzywuzzy-kotlin", version.ref = "fuzzywuzzyKotlin" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jacksonModuleKotlin" }
 jetbrains-kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePluginVersion" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import com.codingfeline.buildkonfig.compiler.FieldSpec
 import org.jetbrains.dokka.gradle.engine.parameters.KotlinPlatform
 import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
@@ -28,7 +29,7 @@ kotlin {
             implementation(libs.nicehttp) // HTTP Lib
             implementation(libs.jackson.module.kotlin) // JSON Parser
             implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.fuzzywuzzy) // Match Extractors
+            implementation(libs.fuzzywuzzy.kotlin)
             implementation(libs.rhino) // Run JavaScript
             implementation(libs.newpipeextractor)
             implementation(libs.tmdb.java) // TMDB API v3 Wrapper Made with RetroFit

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -290,7 +290,6 @@ import com.lagradost.cloudstream3.extractors.ZplayerV2
 import com.lagradost.cloudstream3.extractors.Ztreamhub
 import com.lagradost.cloudstream3.mvvm.logError
 import kotlinx.coroutines.delay
-import me.xdrop.fuzzywuzzy.FuzzySearch
 import org.jsoup.Jsoup
 import java.net.URI
 import java.util.UUID


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/07b4af63-77d7-4cc5-9855-27a1fd13668f)


This is new and updated lib written in kotlin based on xDropFuzzy and has fixes over it. This is slightly smaller too 

https://github.com/jens-muenker/fuzzywuzzy-kotlin?tab=readme-ov-file#changelog

This is draft as i am unable to test it, as the library module is giving error, I have imported this in syncapi and plugin viewmodel but it is not importing in ExtractorAPI 

@KingLucius 
@Blatzar 
