### PR TITLE
fix: filesim extractor doesn't work anymore due to embeds

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filesim.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filesim.kt
@@ -65,8 +65,17 @@ open class Filesim : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val embedUrl = url.replace("/download/", "/e/")
-        val response = app.get(embedUrl, referer = referer)
+        var response = app.get(url.replace("/download/", "/e/"), referer = referer)
+        val iframe = response.document.selectFirst("iframe")
+        if (iframe != null) {
+            response = app.get(
+                iframe.attr("src"), headers = mapOf(
+                    "Accept-Language" to "en-US,en;q=0.5",
+                    "Sec-Fetch-Dest" to "iframe"
+                ), referer = response.url
+            )
+        }
+
         var script = if (!getPacked(response.text).isNullOrEmpty()) {
             getAndUnpack(response.text)
         } else {
@@ -84,7 +93,7 @@ open class Filesim : ExtractorApi() {
         }
 
         val m3u8 =
-            Regex("file:\\s*\"(.*?m3u8.*?)\"").find(script ?: return)?.groupValues?.getOrNull(1)
+            Regex("file:\\s*\"(.*?m3u8.*?)\"").find(script)?.groupValues?.getOrNull(1)
         generateM3u8(
             name,
             m3u8 ?: return,


### PR DESCRIPTION
URL to test: https://filemoon.sx/e/r2am0cmd9vb8

It appears that the only Filesim instances that still exist are the Filemoon ones btw.