### PR TITLE
Feat: Added player notification and play in background via PIP.

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
@@ -106,7 +106,7 @@ abstract class AbstractPlayerFragment(
         throw NotImplementedError()
     }
 
-    open fun playerStatusChanged(){}
+    open fun playerStatusChanged() {}
 
     open fun playerDimensionsLoaded(width: Int, height: Int) {
         throw NotImplementedError()
@@ -360,9 +360,9 @@ abstract class AbstractPlayerFragment(
 
             is SocketTimeoutException -> {
                 /**
-                 * Ensures this is run on the UI thread to prevent issues 
-                 * caused by SocketTimeoutException in torrents. Running 
-                 * on another thread can break player interactions or 
+                 * Ensures this is run on the UI thread to prevent issues
+                 * caused by SocketTimeoutException in torrents. Running
+                 * on another thread can break player interactions or
                  * prevent switching to the next source.
                  */
                 activity?.runOnUiThread {
@@ -392,8 +392,9 @@ abstract class AbstractPlayerFragment(
         }
     }
 
+
     @SuppressLint("UnsafeOptInUsageError")
-    private fun playerUpdated(player: Any?) {
+    open fun playerUpdated(player: Any?) {
         if (player is ExoPlayer) {
             context?.let { ctx ->
                 mMediaSession?.release()
@@ -411,7 +412,7 @@ abstract class AbstractPlayerFragment(
         }
     }
 
-    private var mMediaSession: MediaSession? = null
+    protected var mMediaSession: MediaSession? = null
 
     // this can be used in the future for players other than exoplayer
     //private val mMediaSessionCallback: MediaSessionCompat.Callback = object : MediaSessionCompat.Callback() {
@@ -434,20 +435,21 @@ abstract class AbstractPlayerFragment(
     //    }
     //}
 
-    open fun onDownload(event : DownloadEvent) = Unit
+    open fun onDownload(event: DownloadEvent) = Unit
 
     /** This receives the events from the player, if you want to append functionality you do it here,
      * do note that this only receives events for UI changes,
      * and returning early WONT stop it from changing in eg the player time or pause status */
     open fun mainCallback(event: PlayerEvent) {
         // we don't want to spam DownloadEvent
-        if(event !is DownloadEvent) {
+        if (event !is DownloadEvent) {
             Log.i(TAG, "Handle event: $event")
         }
         when (event) {
             is DownloadEvent -> {
                 onDownload(event)
             }
+
             is ResizedEvent -> {
                 playerDimensionsLoaded(event.width, event.height)
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -63,6 +63,7 @@ import androidx.preference.PreferenceManager
 import com.lagradost.cloudstream3.APIHolder.getApiFromNameNull
 import com.lagradost.cloudstream3.AcraApplication.Companion.getKey
 import com.lagradost.cloudstream3.AcraApplication.Companion.setKey
+import com.lagradost.cloudstream3.CommonActivity.activity
 import com.lagradost.cloudstream3.ErrorLoadingException
 import com.lagradost.cloudstream3.MainActivity.Companion.deleteFileOnExit
 import com.lagradost.cloudstream3.R
@@ -143,6 +144,9 @@ class CS3IPlayer : IPlayer {
     private var playbackPosition: Long = 0
 
     private val subtitleHelper = PlayerSubtitleHelper()
+
+    /** If we want to play the audio only in the background when the app is not open */
+    private var isAudioOnlyBackground = false
 
     /**
      * This is a way to combine the MediaItem and its duration for the concatenating MediaSource.
@@ -574,6 +578,7 @@ class CS3IPlayer : IPlayer {
         //simpleCache?.release()
 
         exoPlayer = null
+        event(PlayerAttachedEvent(null))
         //simpleCache = null
     }
 
@@ -581,18 +586,23 @@ class CS3IPlayer : IPlayer {
         Log.i(TAG, "onStop")
 
         saveData()
-        handleEvent(CSPlayerEvent.Pause, PlayerEventSource.Player)
+        if (!isAudioOnlyBackground) {
+            handleEvent(CSPlayerEvent.Pause, PlayerEventSource.Player)
+        }
         //releasePlayer()
     }
 
     override fun onPause() {
         Log.i(TAG, "onPause")
         saveData()
-        handleEvent(CSPlayerEvent.Pause, PlayerEventSource.Player)
+        if (!isAudioOnlyBackground) {
+            handleEvent(CSPlayerEvent.Pause, PlayerEventSource.Player)
+        }
         //releasePlayer()
     }
 
     override fun onResume(context: Context) {
+        isAudioOnlyBackground = false
         if (exoPlayer == null)
             reloadPlayer(context)
     }
@@ -746,8 +756,11 @@ class CS3IPlayer : IPlayer {
                 ExoPlayer.Builder(context)
                     .setRenderersFactory { eventHandler, videoRendererEventListener, audioRendererEventListener, textRendererOutput, metadataRendererOutput ->
                         val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
-                        val current = settingsManager.getInt(context.getString(R.string.software_decoding_key), -1)
-                        val softwareDecoding = when(current) {
+                        val current = settingsManager.getInt(
+                            context.getString(R.string.software_decoding_key),
+                            -1
+                        )
+                        val softwareDecoding = when (current) {
                             0 -> true // yes
                             1 -> false // no
                             // -1 = automatic
@@ -1046,6 +1059,11 @@ class CS3IPlayer : IPlayer {
                             }
                             event(TimestampSkippedEvent(timestamp = lastTimeStamp, source = source))
                         }
+                    }
+
+                    CSPlayerEvent.PlayAsAudio -> {
+                        isAudioOnlyBackground = true
+                        activity?.moveTaskToBack(false)
                     }
                 }
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -27,6 +27,7 @@ import androidx.annotation.MainThread
 import androidx.annotation.OptIn
 import androidx.core.animation.addListener
 import androidx.core.app.NotificationCompat
+import androidx.core.app.PendingIntentCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -39,7 +40,6 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerNotificationManager
-import androidx.media3.ui.PlayerNotificationManager.ACTION_STOP
 import androidx.media3.ui.PlayerNotificationManager.EXTRA_INSTANCE_ID
 import androidx.media3.ui.PlayerNotificationManager.MediaDescriptionAdapter
 import androidx.preference.PreferenceManager
@@ -52,6 +52,7 @@ import com.lagradost.cloudstream3.LoadResponse.Companion.getAniListId
 import com.lagradost.cloudstream3.LoadResponse.Companion.getImdbId
 import com.lagradost.cloudstream3.LoadResponse.Companion.getMalId
 import com.lagradost.cloudstream3.LoadResponse.Companion.getTMDbId
+import com.lagradost.cloudstream3.MainActivity
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.TvType
 import com.lagradost.cloudstream3.amap
@@ -298,8 +299,8 @@ class GeneratorPlayer : FullScreenPlayer() {
                 }
 
                 override fun createCurrentContentIntent(player: Player): PendingIntent? {
-                    // When we click the notification, should we open the app?
-                    return null
+                    // Open the app without creating a new task to resume playback seamlessly
+                    return PendingIntentCompat.getActivity(context, 0, Intent(context, MainActivity::class.java), 0, false)
                 }
 
                 override fun getCurrentContentText(player: Player): CharSequence? {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1,11 +1,14 @@
 package com.lagradost.cloudstream3.ui.player
 
+import android.R.attr
 import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.app.Dialog
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
+import android.graphics.Bitmap
 import android.os.Build
 import android.os.Bundle
 import android.text.Spanned
@@ -23,6 +26,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.MainThread
 import androidx.annotation.OptIn
 import androidx.core.animation.addListener
+import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -30,7 +34,14 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Format.NO_VALUE
 import androidx.media3.common.MimeTypes
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.common.util.Util
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerNotificationManager
+import androidx.media3.ui.PlayerNotificationManager.ACTION_STOP
+import androidx.media3.ui.PlayerNotificationManager.EXTRA_INSTANCE_ID
+import androidx.media3.ui.PlayerNotificationManager.MediaDescriptionAdapter
 import androidx.preference.PreferenceManager
 import com.lagradost.cloudstream3.APIHolder.getApiFromNameNull
 import com.lagradost.cloudstream3.AcraApplication
@@ -94,18 +105,26 @@ import com.lagradost.cloudstream3.utils.UIHelper.dismissSafe
 import com.lagradost.cloudstream3.utils.UIHelper.hideSystemUI
 import com.lagradost.cloudstream3.utils.UIHelper.popCurrentPage
 import com.lagradost.cloudstream3.utils.UIHelper.toPx
+import com.lagradost.cloudstream3.utils.VideoDownloadManager.getImageBitmapFromUrl
 import com.lagradost.cloudstream3.utils.setText
 import com.lagradost.cloudstream3.utils.txt
 import com.lagradost.safefile.SafeFile
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.io.Serializable
 import java.util.Calendar
 import kotlin.math.abs
 
+
+@UnstableApi
 class GeneratorPlayer : FullScreenPlayer() {
     companion object {
+        const val NOTIFICATION_ID = 2326
+        const val CHANNEL_ID = 7340
+        const val STOP_ACTION = "stopcs3"
+
         private var lastUsedGenerator: IGenerator? = null
         fun newInstance(generator: IGenerator, syncData: HashMap<String, String>? = null): Bundle {
             Log.i(TAG, "newInstance = $syncData")
@@ -225,6 +244,200 @@ class GeneratorPlayer : FullScreenPlayer() {
             currentVerifyLink = ioSafe {
                 if (link.extractorData != null) {
                     getApiFromNameNull(link.source)?.extractorVerifierJob(link.extractorData)
+                }
+            }
+        }
+    }
+
+    // https://github.com/androidx/media/blob/main/libraries/ui/src/main/java/androidx/media3/ui/PlayerNotificationManager.java#L1517
+    private fun createBroadcastIntent(
+        action: String,
+        context: Context,
+        instanceId: Int
+    ): PendingIntent {
+        val intent: Intent = Intent(action).setPackage(context.packageName)
+        intent.putExtra(EXTRA_INSTANCE_ID, instanceId)
+        val pendingFlags = if (Util.SDK_INT >= 23) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+
+        return PendingIntent.getBroadcast(context, instanceId, intent, pendingFlags)
+    }
+
+    @OptIn(UnstableApi::class)
+    @UnstableApi
+    private var cachedPlayerNotificationManager: PlayerNotificationManager? = null
+
+    @OptIn(UnstableApi::class)
+    @UnstableApi
+    private fun getMediaNotification(context: Context): PlayerNotificationManager {
+        val cache = cachedPlayerNotificationManager
+        if (cache != null) return cache
+        return PlayerNotificationManager.Builder(
+            context,
+            NOTIFICATION_ID,
+            CHANNEL_ID.toString()
+        )
+            .setChannelNameResourceId(R.string.player_notification_channel_name)
+            .setChannelDescriptionResourceId(R.string.player_notification_channel_description)
+            .setMediaDescriptionAdapter(object : MediaDescriptionAdapter {
+                override fun getCurrentContentTitle(player: Player): CharSequence {
+                    return when (val meta = currentMeta) {
+                        is ResultEpisode -> {
+                            meta.headerName
+                        }
+
+                        is ExtractorUri -> {
+                            meta.headerName ?: meta.name
+                        }
+
+                        else -> null
+                    } ?: "Unknown"
+                }
+
+                override fun createCurrentContentIntent(player: Player): PendingIntent? {
+                    // When we click the notification, should we open the app?
+                    return null
+                }
+
+                override fun getCurrentContentText(player: Player): CharSequence? {
+                    return when (val meta = currentMeta) {
+                        is ResultEpisode -> {
+                            meta.name
+                        }
+
+                        is ExtractorUri -> {
+                            if (meta.headerName == null) {
+                                null
+                            } else {
+                                meta.name
+                            }
+                        }
+
+                        else -> null
+                    }
+                }
+
+                override fun getCurrentLargeIcon(
+                    player: Player,
+                    callback: PlayerNotificationManager.BitmapCallback
+                ): Bitmap? {
+                    ioSafe {
+                        val url = when (val meta = currentMeta) {
+                            is ResultEpisode -> {
+                                meta.poster
+                            }
+
+                            else -> null
+                        }
+                        // if we have a poster url try with it first
+                        if (url != null) {
+                            val urlBitmap = context.getImageBitmapFromUrl(url)
+                            if (urlBitmap != null) {
+                                callback.onBitmap(urlBitmap)
+                                return@ioSafe
+                            }
+                        }
+
+                        // retry several times with a preview in case the preview generator is slow
+                        for (i in 0..10) {
+                            val preview = this@GeneratorPlayer.player.getPreview(0.5f)
+                            if (preview == null) {
+                                delay(1000L)
+                                continue
+                            }
+                            callback.onBitmap(
+                                preview
+                            )
+                            break
+                        }
+                    }
+
+                    // return null as we want to use the callback
+                    return null
+                }
+            }).setCustomActionReceiver(object : PlayerNotificationManager.CustomActionReceiver {
+                // we have to use a custom action for stop if we want to exit the player instead of just stopping playback
+                override fun createCustomActions(
+                    context: Context,
+                    instanceId: Int
+                ): MutableMap<String, NotificationCompat.Action> {
+                    return mutableMapOf(
+                        STOP_ACTION to NotificationCompat.Action(
+                            R.drawable.baseline_stop_24,
+                            context.getString(androidx.media3.ui.R.string.exo_controls_stop_description),
+                            createBroadcastIntent(STOP_ACTION, context, instanceId)
+                        )
+                    )
+                }
+
+                override fun getCustomActions(player: Player): MutableList<String> {
+                    return mutableListOf(STOP_ACTION)
+                }
+
+                override fun onCustomAction(player: Player, action: String, intent: Intent) {
+                    when (action) {
+                        STOP_ACTION -> {
+                            exitFullscreen()
+                            this@GeneratorPlayer.player.release()
+                            activity?.popCurrentPage()
+                        }
+                    }
+                }
+            })
+            .setPlayActionIconResourceId(R.drawable.ic_baseline_play_arrow_24)
+            .setPauseActionIconResourceId(R.drawable.netflix_pause)
+            .setSmallIconResourceId(R.drawable.baseline_headphones_24)
+            .setStopActionIconResourceId(R.drawable.baseline_stop_24)
+            .setRewindActionIconResourceId(R.drawable.go_back_30)
+            .setFastForwardActionIconResourceId(R.drawable.go_forward_30)
+            .setNextActionIconResourceId(R.drawable.ic_baseline_skip_next_24)
+            .setPreviousActionIconResourceId(R.drawable.baseline_skip_previous_24)
+            .build().apply {
+                setColorized(true) // Color
+                setUseChronometer(true) // Seekbar
+
+                // Don't show the prev episode button
+                setUsePreviousAction(false)
+                setUsePreviousActionInCompactView(false)
+
+                // Don't show the next episode button
+                setUseNextAction(false)
+                setUseNextActionInCompactView(false)
+
+                // Show the skip 30s in both modes
+                setUseFastForwardAction(true)
+                setUseFastForwardActionInCompactView(true)
+
+                // Only show rewind in expanded
+                setUseRewindAction(true)
+                setUseFastForwardActionInCompactView(false)
+
+                // Use custom stop action
+                setUseStopAction(false)
+            }
+            .also { cachedPlayerNotificationManager = it }
+    }
+
+    override fun playerUpdated(player: Any?) {
+        super.playerUpdated(player)
+
+        // Cancel the notification when released
+        if (player == null) {
+            cachedPlayerNotificationManager?.setPlayer(null)
+            cachedPlayerNotificationManager = null
+            return
+        }
+
+        // setup the notification when starting the player
+        if (player is ExoPlayer) {
+            val ctx = context ?: return
+            getMediaNotification(ctx).apply {
+                setPlayer(player)
+                mMediaSession?.platformToken?.let {
+                    setMediaSessionToken(it)
                 }
             }
         }
@@ -470,7 +683,8 @@ class GeneratorPlayer : FullScreenPlayer() {
         val currentTempMeta = getMetaData()
 
         // bruh idk why it is not correct
-        val color = ColorStateList.valueOf(context.colorFromAttribute(androidx.appcompat.R.attr.colorAccent))
+        val color =
+            ColorStateList.valueOf(context.colorFromAttribute(androidx.appcompat.R.attr.colorAccent))
         binding.searchLoadingBar.progressTintList = color
         binding.searchLoadingBar.indeterminateTintList = color
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
@@ -40,6 +40,7 @@ enum class CSPlayerEvent(val value: Int) {
     PlayPauseToggle(7),
     ToggleMute(8),
     Restart(9),
+    PlayAsAudio(10),
 }
 
 enum class CSPlayerLoading {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerPipHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerPipHelper.kt
@@ -48,11 +48,19 @@ class PlayerPipHelper {
             actions.add(
                 getRemoteAction(
                     activity,
+                    R.drawable.baseline_headphones_24,
+                    R.string.audio_singluar,
+                    CSPlayerEvent.PlayAsAudio
+                )
+            )
+            /*actions.add(
+                getRemoteAction(
+                    activity,
                     R.drawable.go_back_30,
                     R.string.go_back_30,
                     CSPlayerEvent.SeekBack
                 )
-            )
+            )*/
 
             if (isPlaying) {
                 actions.add(

--- a/app/src/main/res/drawable/baseline_headphones_24.xml
+++ b/app/src/main/res/drawable/baseline_headphones_24.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/white"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,3c-4.97,0 -9,4.03 -9,9v7c0,1.1 0.9,2 2,2h4v-8H5v-1c0,-3.87 3.13,-7 7,-7s7,3.13 7,7v1h-4v8h4c1.1,0 2,-0.9 2,-2v-7C21,7.03 16.97,3 12,3z" />
+
+</vector>

--- a/app/src/main/res/drawable/baseline_skip_previous_24.xml
+++ b/app/src/main/res/drawable/baseline_skip_previous_24.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/white"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,6h2v12L6,18zM9.5,12l8.5,6L18,6z" />
+
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -846,4 +846,6 @@
     <string name="starting_plugin_update_manually">Starting plugin update process!</string>
     <string name="plugins_updated_manually">Successfully updated %d plugin(s)!</string>
     <string name="no_plugins_updated_manually">No plugins were updated.</string>
+    <string name="player_notification_channel_name">Player notifications</string>
+    <string name="player_notification_channel_description">The player notification for controlling the playback from the background</string>
 </resources>


### PR DESCRIPTION
This adds the PlayAsAudio event to the player, to play the video entirely in the background. Right now this is only available as an option after going into PIP, however this can later be added as an alternative to PIP as well. To be able to control it, the player always emits a notification that is able to control the playback. 