### PR TITLE
Revert "Filesim"

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filesim.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filesim.kt
@@ -4,7 +4,6 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.*
 import com.lagradost.cloudstream3.utils.M3u8Helper.Companion.generateM3u8
-import org.json.JSONArray
 
 class Guccihide : Filesim() {
     override val name = "Guccihide"
@@ -100,20 +99,6 @@ open class Filesim : ExtractorApi() {
             m3u8 ?: return,
             mainUrl
         ).forEach(callback)
-
-        val tracksJson = Regex("tracks:\\s*\\[(.*?)]", RegexOption.DOT_MATCHES_ALL).find(script)?.groupValues?.getOrNull(1) ?: return
-        val tracksArray = JSONArray("[$tracksJson]")
-
-        for (i in 0 until tracksArray.length()) {
-            val track = tracksArray.getJSONObject(i)
-            if (track.optString("kind") == "captions") {
-                subtitleCallback(
-                    SubtitleFile(
-                        track.optString("label"),
-                        track.optString("file")
-                    )
-                )
-            }
-        }
     }
+
 }


### PR DESCRIPTION
Reverts recloudstream/cloudstream#1597

`file:///home/runner/work/cloudstream/cloudstream/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filesim.kt:7:12 Unresolved reference 'json'.` Json does not work for the lib. Please use the build in json instead.