### PR TITLE
fix: remove dead code from filesim extractor

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filesim.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filesim.kt
@@ -76,21 +76,11 @@ open class Filesim : ExtractorApi() {
             )
         }
 
-        var script = if (!getPacked(response.text).isNullOrEmpty()) {
+        val script = if (!getPacked(response.text).isNullOrEmpty()) {
             getAndUnpack(response.text)
         } else {
             response.document.selectFirst("script:containsData(sources:)")?.data()
-        }
-
-         //In my case packed function is not directly available in the first response, instead it is in iframe response
-        if(script == null){
-            val iframeUrl = Regex("""<iframe src="(.*?)"""").find(response.text,0)?.groupValues?.getOrNull(1)
-            if(iframeUrl != null){
-                val iframeResponse = app.get(iframeUrl,referer=null, headers = mapOf("Accept-Language" to "en-US,en;q=0.5"))
-                script = if (!getPacked(iframeResponse.text).isNullOrEmpty()) { getAndUnpack(iframeResponse.text) } else return
-            }
-            else return
-        }
+        } ?: return
 
         val m3u8 =
             Regex("file:\\s*\"(.*?m3u8.*?)\"").find(script)?.groupValues?.getOrNull(1)
@@ -100,5 +90,4 @@ open class Filesim : ExtractorApi() {
             mainUrl
         ).forEach(callback)
     }
-
 }


### PR DESCRIPTION
I forgot to remove that code with #1581, it's no longer used.