### PR TITLE
feat(Extensions): newExtractorLink for developers

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
@@ -352,7 +352,7 @@ class DownloadFragment : Fragment() {
                         LinkGenerator(
                             listOf(BasicLink(url)),
                             extract = true,
-                            referer = referer,
+                            refererUrl = referer,
                             isM3u8 = binding.hlsSwitch.isChecked
                         )
                     )

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/LinkGenerator.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/LinkGenerator.kt
@@ -8,6 +8,7 @@ import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.loadExtractor
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.unshortenLinkSafe
 
 data class ExtractorUri(
@@ -36,7 +37,7 @@ data class BasicLink(
 class LinkGenerator(
     private val links: List<BasicLink>,
     private val extract: Boolean = true,
-    private val referer: String? = null,
+    private val refererUrl: String? = null,
     private val isM3u8: Boolean? = null
 ) : IGenerator {
     override val hasCache = false
@@ -77,7 +78,7 @@ class LinkGenerator(
         isCasting: Boolean
     ): Boolean {
         links.amap { link ->
-            if (!extract || !loadExtractor(link.url, referer, {
+            if (!extract || !loadExtractor(link.url, refererUrl, {
                     subtitleCallback(PlayerSubtitleHelper.getSubtitleData(it))
                 }) {
                     callback(it to null)
@@ -85,14 +86,15 @@ class LinkGenerator(
 
                 // if don't extract or if no extractor found simply return the link
                 callback(
-                    ExtractorLink(
+                    newExtractorLink(
                         "",
                         link.name ?: link.url,
                         unshortenLinkSafe(link.url), // unshorten because it might be a raw link
-                        referer ?: "",
-                        Qualities.Unknown.value,
                         type = INFER_TYPE,
-                    ) to null
+                    ) {
+                        this.referer = refererUrl ?: ""
+                        this.quality = Qualities.Unknown.value
+                    } to null
                 )
             }
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -2484,15 +2484,16 @@ class ResultViewModel2 : ViewModel() {
                                 { links.add(it) }) && trailerData.raw
                         ) {
                             arrayListOf(
-                                ExtractorLink(
+                                newExtractorLink(
                                     "",
                                     "Trailer",
                                     trailerData.extractorUrl,
-                                    trailerData.referer ?: "",
-                                    Qualities.Unknown.value,
-                                    headers = trailerData.headers,
                                     type = INFER_TYPE
-                                )
+                                ) {
+                                    this.referer = trailerData.referer ?: ""
+                                    this.quality = Qualities.Unknown.value
+                                    this.headers = trailerData.headers
+                                }
                             ) to arrayListOf()
                         } else {
                             links to subs

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/AStreamHub.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/AStreamHub.kt
@@ -4,6 +4,7 @@ import com.lagradost.api.Log
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.newExtractorLink
 
@@ -27,8 +28,8 @@ open class AStreamHub : ExtractorApi() {
                             name = name,
                             source = name,
                             url = m3link,
+                            type = ExtractorLinkType.M3U8
                         ) {
-                            this.isM3u8 = true
                             this.quality = Qualities.Unknown.value
                             this.referer = referer ?: url
                         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/AStreamHub.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/AStreamHub.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class AStreamHub : ExtractorApi() {
     override val name = "AStreamHub"
@@ -22,14 +23,15 @@ open class AStreamHub : ExtractorApi() {
                 Log.i("Dev", "m3link => $m3link")
                 if (m3link.isNotBlank()) {
                     sources.add(
-                        ExtractorLink(
+                        newExtractorLink(
                             name = name,
                             source = name,
                             url = m3link,
-                            isM3u8 = true,
-                            quality = Qualities.Unknown.value,
-                            referer = referer ?: url
-                        )
+                        ) {
+                            this.isM3u8 = true
+                            this.quality = Qualities.Unknown.value
+                            this.referer = referer ?: url
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Acefile.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Acefile.kt
@@ -24,13 +24,10 @@ open class Acefile : ExtractorApi() {
         val video = app.get(serverUrl ?: return, referer = "$mainUrl/").parsedSafe<Source>()?.data
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
-                video ?: return,
-                "",
-                Qualities.Unknown.value,
-                INFER_TYPE
+                video ?: return
             )
         )
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/AsianLoad.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/AsianLoad.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.M3u8Helper
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import java.net.URI
 
 open class AsianLoad : ExtractorApi() {
@@ -30,13 +31,14 @@ open class AsianLoad : ExtractorApi() {
                     }
                 } else if (extractedUrl.endsWith(".mp4")) {
                     extractedLinksList.add(
-                        ExtractorLink(
-                            name,
-                            name,
-                            extractedUrl,
-                            url.replace(" ", "%20"),
-                            getQualityFromName(sourceMatch.groupValues[2]),
-                        )
+                        newExtractorLink(
+                            source = name,
+                            name = name,
+                            url = extractedUrl,
+                        ) {
+                            this.referer = url.replace(" ", "%20")
+                            this.quality = getQualityFromName(sourceMatch.groupValues[2])
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Blogger.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Blogger.kt
@@ -19,17 +19,18 @@ open class Blogger : ExtractorApi() {
                         .substringBefore("]")
                     tryParseJson<List<ResponseSource>>("[$data]")?.map {
                         sources.add(
-                            ExtractorLink(
+                            newExtractorLink(
                                 name,
                                 name,
                                 it.play_url,
-                                referer = "https://www.youtube.com/",
-                                quality = when (it.format_id) {
+                            ) {
+                                this.referer = "https://www.youtube.com/"
+                                this.quality = when (it.format_id) {
                                     18 -> 360
                                     22 -> 720
                                     else -> Qualities.Unknown.value
                                 }
-                            )
+                            }
                         )
                     }
                 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/ByteShare.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/ByteShare.kt
@@ -10,12 +10,10 @@ open class ByteShare : ExtractorApi() {
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink> {
         val sources = mutableListOf<ExtractorLink>()
         sources.add(
-            ExtractorLink(
-                name,
-                name,
-                url.replace("/embed/", "/download/"),
-                "",
-                Qualities.Unknown.value,
+            newExtractorLink(
+                source = name,
+                name = name,
+                url = url.replace("/embed/", "/download/"),
             )
         )
         return sources

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Chillx.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Chillx.kt
@@ -9,6 +9,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import java.security.MessageDigest
 
 
@@ -106,15 +107,15 @@ open class Chillx : ExtractorApi() {
                 "user-agent" to USER_AGENT,
             )
         callback.invoke(
-            ExtractorLink(
-                name,
-                name,
-                m3u8,
-                mainUrl,
-                Qualities.P1080.value,
-                INFER_TYPE,
-                headers = header
-            )
+            newExtractorLink(
+                source = name,
+                name = name,
+                url = m3u8,
+            ) {
+                this.referer = mainUrl
+                this.quality = Qualities.P1080.value
+                this.headers = header
+            }
         )
 
         val subtitles = extractSrtSubtitles(decoded)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/ContentXExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/ContentXExtractor.kt
@@ -37,14 +37,15 @@ open class ContentX : ExtractorApi() {
         val m3uLink    = vidExtract.replace("\\", "")
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source  = this.name,
                 name    = this.name,
                 url     = m3uLink,
-                referer = url,
-                quality = Qualities.Unknown.value,
-                isM3u8  = true
-            )
+            ) {
+                this.referer = url
+                this.quality = Qualities.Unknown.value
+                this.isM3u8  = true
+            }
         )
 
         val iDublaj = Regex(""",\"([^']+)\",\"Türkçe""").find(iSource)!!.groups[1]?.value
@@ -54,14 +55,15 @@ open class ContentX : ExtractorApi() {
             val dublajLink    = dublajExtract.replace("\\", "")
 
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source  = "${this.name} Türkçe Dublaj",
                     name    = "${this.name} Türkçe Dublaj",
                     url     = dublajLink,
-                    referer = url,
-                    quality = Qualities.Unknown.value,
-                    isM3u8  = true
-                )
+                ) {
+                    this.referer = url
+                    this.quality = Qualities.Unknown.value
+                    this.isM3u8  = true
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/ContentXExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/ContentXExtractor.kt
@@ -41,10 +41,10 @@ open class ContentX : ExtractorApi() {
                 source  = this.name,
                 name    = this.name,
                 url     = m3uLink,
+                type = ExtractorLinkType.M3U8
             ) {
                 this.referer = url
                 this.quality = Qualities.Unknown.value
-                this.isM3u8  = true
             }
         )
 
@@ -59,10 +59,10 @@ open class ContentX : ExtractorApi() {
                     source  = "${this.name} Türkçe Dublaj",
                     name    = "${this.name} Türkçe Dublaj",
                     url     = dublajLink,
+                    type = ExtractorLinkType.M3U8
                 ) {
                     this.referer = url
                     this.quality = Qualities.Unknown.value
-                    this.isM3u8  = true
                 }
             )
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/DoodExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/DoodExtractor.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import java.net.URI
 import kotlin.random.Random
 
@@ -98,14 +99,14 @@ open class DoodLaExtractor : ExtractorApi() {
             ?.getOrNull(0)
 		
 	callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
                 trueUrl,
-                "$mainUrl/",
-                getQualityFromName(quality),
-                INFER_TYPE,
-            )
+            ) {
+                this.referer = "$mainUrl/"
+                this.quality = getQualityFromName(quality)
+            }
         )
 
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EPlay.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EPlay.kt
@@ -14,14 +14,14 @@ open class EPlayExtractor : ExtractorApi() {
         val response = app.get(url).document
         val trueUrl = response.select("source").attr("src")
         return listOf(
-                ExtractorLink(
+                newExtractorLink(
                         this.name,
                         this.name,
                         trueUrl,
-                        mainUrl,
-                        getQualityFromName(""), // this needs to be auto
-                        false
-                )
+                ) {
+                    this.referer = mainUrl
+                    this.quality = getQualityFromName("") // this needs to be auto
+                }
         )
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Embedgram.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Embedgram.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getQualityFromName
 import com.lagradost.cloudstream3.utils.httpsify
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Embedgram : ExtractorApi() {
     override val name = "Embedgram"
@@ -22,16 +23,17 @@ open class Embedgram : ExtractorApi() {
         val link = document.select("video source:last-child").attr("src")
         val quality = document.select("video source:last-child").attr("title")
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
                 httpsify(link),
-                "$mainUrl/",
-                getQualityFromName(quality),
-                headers = mapOf(
+            ) {
+                this.referer = "$mainUrl/"
+                this.quality = getQualityFromName(quality)
+                this.headers = mapOf(
                     "Range" to "bytes=0-"
                 )
-            )
+            }
         )
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.newExtractorLink
 
@@ -29,10 +30,10 @@ open class EmturbovidExtractor : ExtractorApi() {
                     source = name,
                     name = name,
                     url = m3u8Url,
+                    type = ExtractorLinkType.M3U8
                 ) {
                     this.referer = "$mainUrl/"
                     this.quality = Qualities.Unknown.value
-                    this.isM3u8 = true
                 }
             )
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class EmturbovidExtractor : ExtractorApi() {
     override var name = "Emturbovid"
@@ -24,14 +25,15 @@ open class EmturbovidExtractor : ExtractorApi() {
                 playerScript.substringAfter("var urlPlay = '").substringBefore("'")
 
             sources.add(
-                ExtractorLink(
+                newExtractorLink(
                     source = name,
                     name = name,
                     url = m3u8Url,
-                    referer = "$mainUrl/",
-                    quality = Qualities.Unknown.value,
-                    isM3u8 = true
-                )
+                ) {
+                    this.referer = "$mainUrl/"
+                    this.quality = Qualities.Unknown.value
+                    this.isM3u8 = true
+                }
             )
         }
         return sources

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Evolaod.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Evolaod.kt
@@ -23,13 +23,14 @@ open class Evoload : ExtractorApi() {
         val r = app.post("https://evoload.io/SecurePlayer", data=(payload)).text
         val link = Regex("src\":\"(.*?)\"").find(r)?.destructured?.component1() ?: return listOf()
         return listOf(
-            ExtractorLink(
+            newExtractorLink(
                 name,
                 name,
                 link,
-                url,
-                Qualities.Unknown.value,
-            )
+            ) {
+                this.referer = url
+                this.quality = Qualities.Unknown.value
+            }
         )
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GMPlayer.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GMPlayer.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.newExtractorLink
 
@@ -28,14 +29,14 @@ open class GMPlayer : ExtractorApi() {
 
         return listOf(
             newExtractorLink(
-                this.name,
-                this.name,
-                m3u8,
+                source = this.name,
+                name = this.name,
+                url = m3u8,
+                type = ExtractorLinkType.M3U8
             ) {
                 this.referer = ref
                 this.quality = Qualities.Unknown.value
                 this.headers = mapOf("accept" to "*/*")
-                this.isM3u8 = true
             }
         )
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GMPlayer.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GMPlayer.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class GMPlayer : ExtractorApi() {
     override val name = "GM Player"
@@ -26,15 +27,16 @@ open class GMPlayer : ExtractorApi() {
         ).parsed<GmResponse>().videoSource ?: return null
 
         return listOf(
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
                 m3u8,
-                ref,
-                Qualities.Unknown.value,
-                headers = mapOf("accept" to "*/*"),
-                isM3u8 = true
-            )
+            ) {
+                this.referer = ref
+                this.quality = Qualities.Unknown.value
+                this.headers = mapOf("accept" to "*/*")
+                this.isM3u8 = true
+            }
         )
     }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GamoVideo.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GamoVideo.kt
@@ -17,13 +17,14 @@ open class GamoVideo : ExtractorApi() {
             .firstOrNull { it.html().contains("sources:") }!!.html().substringAfter("file: \"")
             .substringBefore("\",").let {
             listOf(
-                ExtractorLink(
+                newExtractorLink(
                     name,
                     name,
                     it,
-                    url,
-                    Qualities.Unknown.value,
-                )
+                ) {
+                    this.referer = url
+                    this.quality = Qualities.Unknown.value
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Gdriveplayer.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Gdriveplayer.kt
@@ -94,14 +94,15 @@ open class Gdriveplayer : ExtractorApi() {
             it.groupValues[1] to it.groupValues[2]
         }.toList().distinctBy { it.second }.map { (link, quality) ->
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source = this.name,
                     name = this.name,
                     url = "${httpsify(link)}&res=$quality",
-                    referer = mainUrl,
-                    quality = quality.toIntOrNull() ?: Qualities.Unknown.value,
-                    headers = mapOf("Range" to "bytes=0-")
-                )
+                ) {
+                    this.referer = mainUrl
+                    this.quality = quality.toIntOrNull() ?: Qualities.Unknown.value
+                    this.headers = mapOf("Range" to "bytes=0-")
+                }
             )
         }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Gofile.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Gofile.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Gofile : ExtractorApi() {
     override val name = "Gofile"
@@ -27,16 +28,16 @@ open class Gofile : ExtractorApi() {
         app.get("$mainApi/getContent?contentId=$id&token=$token&wt=$websiteToken")
             .parsedSafe<Source>()?.data?.contents?.forEach {
                 callback.invoke(
-                    ExtractorLink(
+                    newExtractorLink(
                         this.name,
                         this.name,
                         it.value["link"] ?: return,
-                        "",
-                        getQuality(it.value["name"]),
-                        headers = mapOf(
+                    ) {
+                        this.quality = getQuality(it.value["name"])
+                        this.headers = mapOf(
                             "Cookie" to "accountToken=$token"
                         )
-                    )
+                    }
                 )
             }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GoodstreamExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GoodstreamExtractor.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 class GoodstreamExtractor : ExtractorApi() {
     override var name = "Goodstream"
@@ -22,13 +23,13 @@ class GoodstreamExtractor : ExtractorApi() {
                 val urlRegex = Regex("file: \"(https:\\/\\/[a-z0-9.\\/-_?=&]+)\",")
                 urlRegex.find(script.data())?.groupValues?.get(1).let { link ->
                     callback.invoke(
-                        ExtractorLink(
+                        newExtractorLink(
                             name,
                             name,
                             link!!,
-                            mainUrl,
-                            Qualities.Unknown.value,
-                        )
+                        ) {
+                            this.referer = mainUrl
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GuardareStream.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GuardareStream.kt
@@ -57,14 +57,14 @@ open class GuardareStream : ExtractorApi() {
         val jsonVideoData = AppUtils.parseJson<GuardareJsonData>(response)
         jsonVideoData.data.forEach {
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     this.name,
                     this.name,
                     it.file + ".${it.type}",
-                    mainUrl,
-                    it.label.filter { it.isDigit() }.toInt(),
-                    false
-                )
+                ) {
+                    this.referer = mainUrl
+                    this.quality = it.label.filter { it.isDigit() }.toInt()
+                }
             )
         }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/HDMomPlayerExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/HDMomPlayerExtractor.kt
@@ -49,14 +49,15 @@ open class HDMomPlayer : ExtractorApi() {
         }
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source  = this.name,
                 name    = this.name,
                 url     = m3uLink ?: throw ErrorLoadingException("m3u link not found"),
-                referer = url,
-                quality = Qualities.Unknown.value,
-                isM3u8  = true
-            )
+            ) {
+                this.referer = url
+                this.quality = Qualities.Unknown.value
+                this.isM3u8  = true
+            }
         )
     }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/HDMomPlayerExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/HDMomPlayerExtractor.kt
@@ -53,10 +53,10 @@ open class HDMomPlayer : ExtractorApi() {
                 source  = this.name,
                 name    = this.name,
                 url     = m3uLink ?: throw ErrorLoadingException("m3u link not found"),
+                type = ExtractorLinkType.M3U8
             ) {
                 this.referer = url
                 this.quality = Qualities.Unknown.value
-                this.isM3u8  = true
             }
         )
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/HDPlayerSystemExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/HDPlayerSystemExtractor.kt
@@ -38,14 +38,13 @@ open class HDPlayerSystem : ExtractorApi() {
         val m3uLink       = videoResponse.securedLink
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source  = this.name,
                 name    = this.name,
-                url     = m3uLink,
-                referer = extRef,
-                quality = Qualities.Unknown.value,
-                type    = INFER_TYPE
-            )
+                url     = m3uLink
+            ) {
+                this.referer = extRef
+            }
         )
     }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Hxfile.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Hxfile.kt
@@ -49,12 +49,13 @@ open class Hxfile : ExtractorApi() {
                         getAndUnpack(script.data()).substringAfter("sources:[").substringBefore("]")
                     tryParseJson<List<ResponseSource>>("[$data]")?.map {
                         sources.add(
-                            ExtractorLink(
+                            newExtractorLink(
                                 name,
                                 name,
                                 it.file,
-                                referer = mainUrl,
-                                quality = when {
+                            ) {
+                                this.referer = mainUrl
+                                this.quality = when {
                                     url.contains("hxfile.co") -> getQualityFromName(
                                         Regex("\\d\\.(.*?).mp4").find(
                                             document.select("title").text()
@@ -62,24 +63,25 @@ open class Hxfile : ExtractorApi() {
                                     )
                                     else -> getQualityFromName(it.label)
                                 }
-                            )
+                            }
                         )
                     }
                 } else if (script.data().contains("\"sources\":[")) {
                     val data = script.data().substringAfter("\"sources\":[").substringBefore("]")
                     tryParseJson<List<ResponseSource>>("[$data]")?.map {
                         sources.add(
-                            ExtractorLink(
+                            newExtractorLink(
                                 name,
                                 name,
                                 it.file,
-                                referer = mainUrl,
-                                quality = when {
+                            ) {
+                                this.referer = mainUrl
+                                this.quality = when {
                                     it.label?.contains("HD") == true -> Qualities.P720.value
                                     it.label?.contains("SD") == true -> Qualities.P480.value
                                     else -> getQualityFromName(it.label)
                                 }
-                            )
+                            }
                         )
                     }
                 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/InternetArchive.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/InternetArchive.kt
@@ -7,6 +7,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.StringUtils.decodeUri
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import org.jsoup.nodes.Document
 
 open class InternetArchive : ExtractorApi() {
@@ -98,13 +99,13 @@ open class InternetArchive : ExtractorApi() {
                     "$fileNameCleaned ($fileExtension)"
                 } else this.name
                 callback(
-                    ExtractorLink(
+                    newExtractorLink(
                         this.name,
                         name,
-                        mediaUrl,
-                        "",
-                        quality
-                    )
+                        mediaUrl
+                    ) {
+                        this.quality = quality
+                    }
                 )
             }
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/JWPlayer.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/JWPlayer.kt
@@ -7,6 +7,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 class Meownime : JWPlayer() {
     override val name = "Meownime"
@@ -55,17 +56,18 @@ open class JWPlayer : ExtractorApi() {
 
             tryParseJson<List<ResponseSource>>("$data")?.map {
                 sources.add(
-                    ExtractorLink(
+                    newExtractorLink(
                         name,
                         name,
                         it.file,
-                        referer = url,
-                        quality = getQualityFromName(
+                    ) {
+                        this.referer = url
+                        this.quality = getQualityFromName(
                             Regex("(\\d{3,4}p)").find(it.file)?.groupValues?.get(
                                 1
                             )
                         )
-                    )
+                    }
                 )
             }
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Krakenfiles.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Krakenfiles.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.httpsify
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Krakenfiles : ExtractorApi() {
     override val name = "Krakenfiles"
@@ -23,12 +24,10 @@ open class Krakenfiles : ExtractorApi() {
         val link = doc.selectFirst("source")?.attr("src")
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
                 httpsify(link ?: return),
-                "",
-                Qualities.Unknown.value
             )
         )
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Linkbox.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Linkbox.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Linkbox : ExtractorApi() {
     override val name = "Linkbox"
@@ -23,13 +24,14 @@ open class Linkbox : ExtractorApi() {
         app.get("$mainUrl/api/file/detail?itemId=$id", referer = url)
             .parsedSafe<Responses>()?.data?.itemInfo?.resolutionList?.map { link ->
                 callback.invoke(
-                    ExtractorLink(
+                    newExtractorLink(
                         name,
                         name,
                         link.url ?: return@map null,
-                        url,
-                        getQualityFromName(link.resolution)
-                    )
+                    ) {
+                        this.referer = url
+                        this.quality = getQualityFromName(link.resolution)
+                    }
                 )
             }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/LuluStream.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/LuluStream.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 class Lulustream1 : LuluStream() {
     override val name = "Lulustream"
@@ -43,14 +44,14 @@ open class LuluStream : ExtractorApi() {
             ?.let { script ->
                 Regex("file:\"(.*)\"").find(script)?.groupValues?.get(1)?.let { link ->
                     callback(
-                        ExtractorLink(
+                        newExtractorLink(
                             name,
                             name,
                             link,
-                            mainUrl,
-                            Qualities.P1080.value,
-                            type = INFER_TYPE
-                        )
+                        ) {
+                            this.referer = mainUrl
+                            this.quality = Qualities.P1080.value
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MailRuExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MailRuExtractor.kt
@@ -26,15 +26,16 @@ open class MailRu : ExtractorApi() {
             val videoUrl = if (video.url.startsWith("//")) "https:${video.url}" else video.url
 
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source  = this.name,
                     name    = this.name,
                     url     = videoUrl,
-                    referer = url,
-                    headers = mapOf("Cookie" to "video_key=${videoKey}"),
-                    quality = getQualityFromName(video.key),
-                    isM3u8  = false
-                )
+                ) {
+                    this.referer = url
+                    this.headers = mapOf("Cookie" to "video_key=${videoKey}")
+                    this.quality = getQualityFromName(video.key)
+                    this.isM3u8  = false
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MailRuExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MailRuExtractor.kt
@@ -30,11 +30,11 @@ open class MailRu : ExtractorApi() {
                     source  = this.name,
                     name    = this.name,
                     url     = videoUrl,
+                    type    = ExtractorLinkType.M3U8
                 ) {
                     this.referer = url
                     this.headers = mapOf("Cookie" to "video_key=${videoKey}")
                     this.quality = getQualityFromName(video.key)
-                    this.isM3u8  = false
                 }
             )
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Mediafire.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Mediafire.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Mediafire : ExtractorApi() {
     override val name = "Mediafire"
@@ -23,14 +24,13 @@ open class Mediafire : ExtractorApi() {
         val video = res.selectFirst("a#downloadButton")?.attr("href")
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
-                video ?: return,
-                "",
-                getQuality(title),
-                INFER_TYPE
-            )
+                video ?: return
+            ) {
+                this.quality = getQuality(title)
+            }
         )
 
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MixDrop.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MixDrop.kt
@@ -33,13 +33,14 @@ open class MixDrop : ExtractorApi() {
             getAndUnpack(this.text).let { unpackedText ->
                 srcRegex.find(unpackedText)?.groupValues?.get(1)?.let { link ->
                     return listOf(
-                        ExtractorLink(
+                        newExtractorLink(
                             name,
                             name,
                             httpsify(link),
-                            url,
-                            Qualities.Unknown.value,
-                        )
+                        ) {
+                            this.referer = url
+                            this.quality = Qualities.Unknown.value
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Mp4Upload.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Mp4Upload.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getAndUnpack
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Mp4Upload : ExtractorApi() {
     override var name = "Mp4Upload"
@@ -24,24 +25,26 @@ open class Mp4Upload : ExtractorApi() {
             unpackedText.lowercase().substringAfter(" height=").substringBefore(" ").toIntOrNull()
         srcRegex.find(unpackedText)?.groupValues?.get(1)?.let { link ->
             return listOf(
-                ExtractorLink(
+                newExtractorLink(
                     name,
                     name,
                     link,
-                    url,
-                    quality ?: Qualities.Unknown.value,
-                )
+                ) {
+                    this.referer = url
+                    this.quality = quality ?: Qualities.Unknown.value
+                }
             )
         }
         srcRegex2.find(unpackedText)?.groupValues?.get(1)?.let { link ->
             return listOf(
-                ExtractorLink(
+                newExtractorLink(
                     name,
                     name,
                     link,
-                    url,
-                    quality ?: Qualities.Unknown.value,
-                )
+                ) {
+                    this.referer = url
+                    this.quality = quality ?: Qualities.Unknown.value
+                }
             )
         }
         return null

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MultiQuality.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MultiQuality.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getQualityFromName
 import com.lagradost.cloudstream3.utils.newExtractorLink
@@ -31,13 +32,13 @@ open class MultiQuality : ExtractorApi() {
                         m3u8Regex.findAll(this.text).forEach { match ->
                             extractedLinksList.add(
                                 newExtractorLink(
-                                    name,
+                                    source = name,
                                     name = name,
-                                    urlRegex.find(this.url)!!.groupValues[1] + match.groupValues[0],
+                                    url = urlRegex.find(this.url)!!.groupValues[1] + match.groupValues[0],
+                                    type = ExtractorLinkType.M3U8
                                 ) {
                                     this.referer = url
                                     this.quality = getQualityFromName(match.groupValues[1])
-                                    this.isM3u8 = true
                                 }
                             )
                         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MultiQuality.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/MultiQuality.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import java.net.URI
 
 open class MultiQuality : ExtractorApi() {
@@ -29,27 +30,29 @@ open class MultiQuality : ExtractorApi() {
                     with(app.get(extractedUrl)) {
                         m3u8Regex.findAll(this.text).forEach { match ->
                             extractedLinksList.add(
-                                ExtractorLink(
+                                newExtractorLink(
                                     name,
                                     name = name,
                                     urlRegex.find(this.url)!!.groupValues[1] + match.groupValues[0],
-                                    url,
-                                    getQualityFromName(match.groupValues[1]),
-                                    isM3u8 = true
-                                )
+                                ) {
+                                    this.referer = url
+                                    this.quality = getQualityFromName(match.groupValues[1])
+                                    this.isM3u8 = true
+                                }
                             )
                         }
 
                     }
                 } else if (extractedUrl.endsWith(".mp4")) {
                     extractedLinksList.add(
-                        ExtractorLink(
+                        newExtractorLink(
                             name,
                             "$name ${sourceMatch.groupValues[2]}",
                             extractedUrl,
-                            url.replace(" ", "%20"),
-                            Qualities.Unknown.value,
-                        )
+                        ) {
+                            this.referer = url.replace(" ", "%20")
+                            this.quality = Qualities.Unknown.value
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Mvidoo.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Mvidoo.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Mvidoo : ExtractorApi() {
     override val name = "Mvidoo"
@@ -31,16 +32,17 @@ open class Mvidoo : ExtractorApi() {
             ?.removeSurrounding("[", "]")?.replace("\"", "")?.replace("\\x", "")?.split(",")?.map { it.decodeHex() }?.reversed()?.joinToString("") ?: return
         Regex("source\\s*src=\"([^\"]+)").find(data)?.groupValues?.get(1)?.let { link ->
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     this.name,
                     this.name,
-                    link,
-                    "$mainUrl/",
-                    Qualities.Unknown.value,
-                    headers = mapOf(
+                    link
+                ) {
+                    this.referer = "$mainUrl/"
+                    this.quality = Qualities.Unknown.value
+                    this.headers = mapOf(
                         "Range" to "bytes=0-"
                     )
-                )
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/OdnoklassnikiExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/OdnoklassnikiExtractor.kt
@@ -11,6 +11,7 @@ import com.lagradost.cloudstream3.utils.AppUtils
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Odnoklassniki : ExtractorApi() {
     override val name            = "Odnoklassniki"
@@ -50,15 +51,16 @@ open class Odnoklassniki : ExtractorApi() {
                 .replace("ULTRA",  "4k")
 
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source  = this.name,
                     name    = this.name,
                     url     = videoUrl,
-                    referer = "$mainUrl/",
-                    quality = getQualityFromName(quality),
-                    headers = headers,
-                    isM3u8  = false,
-                )
+                ) {
+                    this.referer = "$mainUrl/"
+                    this.quality = getQualityFromName(quality)
+                    this.headers = headers
+                    this.isM3u8  = false
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/OdnoklassnikiExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/OdnoklassnikiExtractor.kt
@@ -10,6 +10,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.AppUtils
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.getQualityFromName
 import com.lagradost.cloudstream3.utils.newExtractorLink
 
@@ -55,11 +56,11 @@ open class Odnoklassniki : ExtractorApi() {
                     source  = this.name,
                     name    = this.name,
                     url     = videoUrl,
+                    type    = ExtractorLinkType.M3U8
                 ) {
                     this.referer = "$mainUrl/"
                     this.quality = getQualityFromName(quality)
                     this.headers = headers
-                    this.isM3u8  = false
                 }
             )
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Okrulink.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Okrulink.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 data class Okrulinkdata (
     @JsonProperty("status" ) var status : String? = null,
@@ -24,13 +25,10 @@ open class Okrulink: ExtractorApi() {
         ).parsedSafe<Okrulinkdata>()
         if (request?.url != null) {
             sources.add(
-                ExtractorLink(
+                newExtractorLink(
                     name,
                     name,
-                    request.url!!,
-                    "",
-                    Qualities.Unknown.value,
-                    isM3u8 = false
+                    request.url!!
                 )
             )
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PeaceMakerstExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PeaceMakerstExtractor.kt
@@ -49,14 +49,14 @@ open class PeaceMakerst : ExtractorApi() {
         }
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source  = this.name,
                 name    = this.name,
                 url     = m3uLink ?: throw ErrorLoadingException("m3u link not found"),
-                referer = extRef,
-                quality = Qualities.Unknown.value,
-                type    = INFER_TYPE
-            )
+            ) {
+                this.referer = extRef
+                this.quality = Qualities.Unknown.value
+            }
         )
     }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Pelisplus.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Pelisplus.kt
@@ -9,6 +9,7 @@ import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.extractorApis
 import com.lagradost.cloudstream3.utils.getQualityFromName
 import com.lagradost.cloudstream3.utils.loadExtractor
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import org.jsoup.Jsoup
 
 /**
@@ -61,14 +62,14 @@ open class Pelisplus(val mainUrl: String) {
 
                     if (!loadExtractor(href, link, subtitleCallback, callback)) {
                         callback.invoke(
-                            ExtractorLink(
+                            newExtractorLink(
                                 this.name,
                                 name = this.name,
-                                href,
-                                page.url,
-                                getQualityFromName(qual),
-                                type = INFER_TYPE
-                            )
+                                href
+                            ) {
+                                this.referer = page.url
+                                this.quality = getQualityFromName(qual)
+                            }
                         )
                     }
                 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PixelDrainExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PixelDrainExtractor.kt
@@ -15,24 +15,24 @@ open class PixelDrain : ExtractorApi() {
         if (mId.isNullOrEmpty())
         {
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     this.name,
                     this.name,
-                    url,
-                    url,
-                    Qualities.Unknown.value,
-                )
+                    url
+                ) {
+                    this.referer = url
+                }
             )
         }
         else {
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     this.name,
                     this.name,
                     "$mainUrl/api/file/${mId}?download",
-                    url,
-                    Qualities.Unknown.value,
-                )
+                ) {
+                    this.referer = url
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PlayLtXyz.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PlayLtXyz.kt
@@ -65,10 +65,10 @@ open class PlayLtXyz: ExtractorApi() {
                                 source = name,
                                 name = name,
                                 url = linkUrl,
+                                type = ExtractorLinkType.M3U8
                             ) {
                                 this.referer = url
                                 this.quality = Qualities.Unknown.value
-                                this.isM3u8 = true
                             }
                         )
                     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PlayLtXyz.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PlayLtXyz.kt
@@ -61,14 +61,15 @@ open class PlayLtXyz: ExtractorApi() {
                     val linkUrl = item.data ?: ""
                     if (linkUrl.isNotBlank()) {
                         extractedLinksList.add(
-                            ExtractorLink(
+                            newExtractorLink(
                                 source = name,
                                 name = name,
                                 url = linkUrl,
-                                referer = url,
-                                quality = Qualities.Unknown.value,
-                                isM3u8 = true
-                            )
+                            ) {
+                                this.referer = url
+                                this.quality = Qualities.Unknown.value
+                                this.isM3u8 = true
+                            }
                         )
                     }
                 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/RapidVidExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/RapidVidExtractor.kt
@@ -50,10 +50,10 @@ open class RapidVid : ExtractorApi() {
                 source  = this.name,
                 name    = this.name,
                 url     = decoded,
+                type    = ExtractorLinkType.M3U8
             ) {
                 this.referer = extRef
                 this.quality = Qualities.Unknown.value
-                this.isM3u8  = true
             }
         )
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/RapidVidExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/RapidVidExtractor.kt
@@ -46,14 +46,15 @@ open class RapidVid : ExtractorApi() {
         }
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source  = this.name,
                 name    = this.name,
                 url     = decoded,
-                referer = extRef,
-                quality = Qualities.Unknown.value,
-                isM3u8  = true
-            )
+            ) {
+                this.referer = extRef
+                this.quality = Qualities.Unknown.value
+                this.isM3u8  = true
+            }
         )
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SBPlay.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SBPlay.kt
@@ -7,6 +7,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getPostForm
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import org.jsoup.Jsoup
 
 //class SBPlay1 : SBPlay() {
@@ -39,20 +40,25 @@ open class SBPlay : ExtractorApi() {
                     val hash = it.groupValues[3]
                     val href = "https://sbplay.one/dl?op=download_orig&id=$id&mode=$mode&hash=$hash"
                     val hrefResponse = app.get(href).text
-                    app.post("https://sbplay.one/?op=notifications&open=&_=$unixTimeMS", referer = href)
+                    app.post(
+                        "https://sbplay.one/?op=notifications&open=&_=$unixTimeMS",
+                        referer = href
+                    )
                     val hrefDocument = Jsoup.parse(hrefResponse)
                     val hrefSpan = hrefDocument.selectFirst("span > a")
                     if (hrefSpan == null) {
                         getPostForm(href, hrefResponse)?.let { form ->
                             val postDocument = Jsoup.parse(form)
-                            val downloadBtn = postDocument.selectFirst("a.downloadbtn")?.attr("href")
+                            val downloadBtn =
+                                postDocument.selectFirst("a.downloadbtn")?.attr("href")
                             if (downloadBtn.isNullOrEmpty()) {
                                 val hrefSpan2 = postDocument.selectFirst("span > a")?.attr("href")
                                 if (hrefSpan2?.startsWith("https://") == true) {
                                     links.add(
-                                        ExtractorLink(
-                                            this.name, name,
-                                            hrefSpan2, "", Qualities.Unknown.value, false
+                                        newExtractorLink(
+                                            this.name,
+                                            name,
+                                            hrefSpan2
                                         )
                                     )
                                 } else {
@@ -60,20 +66,23 @@ open class SBPlay : ExtractorApi() {
                                 }
                             } else {
                                 links.add(
-                                    ExtractorLink(
+                                    newExtractorLink(
                                         this.name,
                                         name,
-                                        downloadBtn,
-                                        "",
-                                        Qualities.Unknown.value,
-                                        false
+                                        downloadBtn
                                     )
                                 )
                             }
                         }
                     } else {
                         val link = hrefSpan.attr("href")
-                        links.add(ExtractorLink(this.name, name, link, "", Qualities.Unknown.value, false))
+                        links.add(
+                            newExtractorLink(
+                                this.name,
+                                name,
+                                link
+                            )
+                        )
                     }
                 }
             } catch (e: Exception) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SibNetExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SibNetExtractor.kt
@@ -19,14 +19,13 @@ open class SibNet : ExtractorApi() {
         m3uLink = "${mainUrl}${m3uLink}"
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source  = this.name,
                 name    = this.name,
                 url     = m3uLink,
-                referer = url,
-                quality = Qualities.Unknown.value,
-                type    = INFER_TYPE
-            )
+            ) {
+                this.referer = url
+            }
         )
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SobreatsesuypExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SobreatsesuypExtractor.kt
@@ -34,14 +34,13 @@ open class Sobreatsesuyp : ExtractorApi() {
             val videoData = app.post("${mainUrl}/playlist/${item.file.substring(1)}.txt", referer = extRef).text
 
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source  = this.name,
                     name    = "${this.name} - ${item.title}",
                     url     = videoData,
-                    referer = extRef,
-                    quality = Qualities.Unknown.value,
-                    type    = INFER_TYPE
-                )
+                ) {
+                    this.referer = extRef
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Solidfiles.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Solidfiles.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 
 open class Solidfiles : ExtractorApi() {
@@ -22,13 +23,14 @@ open class Solidfiles : ExtractorApi() {
                     val source = tryParseJson<ResponseSource>("{$data}")
                     val quality = Regex("\\d{3,4}p").find(source!!.nodeName)?.groupValues?.get(0)
                     sources.add(
-                        ExtractorLink(
+                        newExtractorLink(
                             name,
                             name,
                             source.streamUrl,
-                            referer = url,
-                            quality = getQualityFromName(quality)
-                        )
+                        ) {
+                            this.referer = url
+                            this.quality = getQualityFromName(quality)
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamTape.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamTape.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import org.mozilla.javascript.Context
 
 class StreamTapeNet : StreamTape() {
@@ -45,13 +46,14 @@ open class StreamTape : ExtractorApi() {
             if(!result.isNullOrEmpty()){
                 val extractedUrl = "https:${result}&stream=1"
                 return listOf(
-                    ExtractorLink(
+                    newExtractorLink(
                         name,
                         name,
                         extractedUrl,
-                        url,
-                        Qualities.Unknown.value,
-                    )
+                    ) {
+                        this.referer = url
+                        this.quality = Qualities.Unknown.value
+                    }
                 )
             }
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamhub.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamhub.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.JsUnpacker
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import java.net.URI
 
 open class Streamhub : ExtractorApi() {
@@ -22,14 +23,13 @@ open class Streamhub : ExtractorApi() {
             JsUnpacker("eval$jsEval").unpack()?.let { unPacked ->
                 Regex("sources:\\[\\{src:\"(.*?)\"").find(unPacked)?.groupValues?.get(1)?.let { link ->
                     return listOf(
-                        ExtractorLink(
+                        newExtractorLink(
                             this.name,
                             this.name,
-                            link,
-                            referer ?: "",
-                            Qualities.Unknown.value,
-                            URI(link).path.endsWith(".m3u8")
-                        )
+                            link
+                        ) {
+                            this.isM3u8 = URI(link).path.endsWith(".m3u8")
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamhub.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamhub.kt
@@ -3,6 +3,8 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.JsUnpacker
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.newExtractorLink
@@ -24,12 +26,10 @@ open class Streamhub : ExtractorApi() {
                 Regex("sources:\\[\\{src:\"(.*?)\"").find(unPacked)?.groupValues?.get(1)?.let { link ->
                     return listOf(
                         newExtractorLink(
+                            source = this.name,
                             this.name,
-                            this.name,
-                            link
-                        ) {
-                            this.isM3u8 = URI(link).path.endsWith(".m3u8")
-                        }
+                            link,
+                        )
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamlare.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamlare.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.nicehttp.RequestBodyTypes
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -45,15 +46,16 @@ open class Slmaxed : ExtractorApi() {
         ).parsed<JsonResponse>()
         return json.result?.mapNotNull {
             it.value.let { result ->
-                ExtractorLink(
+                newExtractorLink(
                     this.name,
                     this.name,
                     result.file ?: return@mapNotNull null,
-                    url,
-                    result.label?.replace("p", "", ignoreCase = true)?.trim()?.toIntOrNull()
-                        ?: Qualities.Unknown.value,
-                    isM3u8 = result.type?.contains("hls", ignoreCase = true) == true
-                )
+                ) {
+                    this.referer =  url
+                    this.quality = result.label?.replace("p", "", ignoreCase = true)?.trim()?.toIntOrNull()
+                        ?: Qualities.Unknown.value
+                    this.isM3u8 = result.type?.contains("hls", ignoreCase = true) == true
+                }
             }
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamlare.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamlare.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.nicehttp.RequestBodyTypes
@@ -50,11 +52,16 @@ open class Slmaxed : ExtractorApi() {
                     this.name,
                     this.name,
                     result.file ?: return@mapNotNull null,
+                    type = if (result.type?.contains(
+                            "hls",
+                            ignoreCase = true
+                        ) == true
+                    ) ExtractorLinkType.M3U8 else INFER_TYPE
                 ) {
-                    this.referer =  url
-                    this.quality = result.label?.replace("p", "", ignoreCase = true)?.trim()?.toIntOrNull()
-                        ?: Qualities.Unknown.value
-                    this.isM3u8 = result.type?.contains("hls", ignoreCase = true) == true
+                    this.referer = url
+                    this.quality =
+                        result.label?.replace("p", "", ignoreCase = true)?.trim()?.toIntOrNull()
+                            ?: Qualities.Unknown.value
                 }
             }
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamplay.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamplay.kt
@@ -53,20 +53,21 @@ open class Streamplay : ExtractorApi() {
                 .replace("label", "\"label\"")
             tryParseJson<List<Source>>("[$data}]")?.map { res ->
                 callback.invoke(
-                    ExtractorLink(
+                    newExtractorLink(
                         this.name,
                         this.name,
                         res.file ?: return@map null,
-                        "$mainServer/",
-                        when (res.label) {
+                    ) {
+                        this.referer = "$mainServer/"
+                        this.quality = when (res.label) {
                             "HD" -> Qualities.P720.value
                             "SD" -> Qualities.P480.value
                             else -> Qualities.Unknown.value
-                        },
-                        headers = mapOf(
+                        }
+                        this.headers = mapOf(
                             "Range" to "bytes=0-"
                         )
-                    )
+                    }
                 )
             }
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/TRsTXExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/TRsTXExtractor.kt
@@ -52,14 +52,13 @@ open class TRsTX : ExtractorApi() {
             val m3uLink = mapEntry["videoData"] ?: continue
 
 	        callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source  = this.name,
                     name    = "${this.name} - ${title}",
                     url     = m3uLink,
-                    referer = extRef,
-                    quality = Qualities.Unknown.value,
-                    type    = INFER_TYPE
-                )
+                ) {
+                    this.referer = extRef
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Tantifilm.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Tantifilm.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.AppUtils.parseJson
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Tantifilm : ExtractorApi() {
     override var name = "Tantifilm"
@@ -29,14 +30,14 @@ open class Tantifilm : ExtractorApi() {
         val response = app.post(link).text.replace("""\""","")
         val jsonvideodata = parseJson<TantifilmJsonData>(response)
         return jsonvideodata.data.map {
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
-                it.file+".${it.type}",
-                mainUrl,
-                it.label.filter{ it.isDigit() }.toInt(),
-                false
-            )
+                it.file+".${it.type}"
+            ) {
+                this.referer = mainUrl
+                this.quality = it.label.filter{ it.isDigit() }.toInt()
+            }
         }
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/TauVideoExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/TauVideoExtractor.kt
@@ -21,14 +21,14 @@ open class TauVideo : ExtractorApi() {
 
         for (video in api.urls) {
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source  = this.name,
                     name    = this.name,
                     url     = video.url,
-                    referer = extRef,
-                    quality = getQualityFromName(video.label),
-                    type    = INFER_TYPE
-                )
+                ) {
+                    this.referer = extRef
+                    this.quality = getQualityFromName(video.label)
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Tomatomatela.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Tomatomatela.kt
@@ -49,13 +49,10 @@ open class Tomatomatela : ExtractorApi() {
         ).parsedSafe<Tomato>()
         if (server?.file != null) {
             sources.add(
-                ExtractorLink(
+                newExtractorLink(
                     name,
                     name,
                     server.file,
-                    "",
-                    Qualities.Unknown.value,
-                    isM3u8 = false
                 )
             )
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Uqload.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Uqload.kt
@@ -22,13 +22,13 @@ open class Uqload : ExtractorApi() {
         with(app.get(url)) {  // raised error ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED (3003) is due to the response: "error_nofile"
             srcRegex.find(this.text)?.groupValues?.get(1)?.replace("\"", "")?.let { link ->
                 return listOf(
-                    ExtractorLink(
+                    newExtractorLink(
                         name,
                         name,
-                        link,
-                        url,
-                        Qualities.Unknown.value,
-                    )
+                        link
+                    ) {
+                        this.referer = url
+                    }
                 )
             }
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userload.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userload.kt
@@ -103,13 +103,14 @@ open class Userload : ExtractorApi() {
         val videoLink = videoLinkPage.text
         val nameSource = app.get(url).document.head().selectFirst("title")!!.text()
         extractedLinksList.add(
-            ExtractorLink(
+            newExtractorLink(
                 name,
                 name,
-                videoLink,
-                mainUrl,
-                getQualityFromName(nameSource),
-            )
+                videoLink
+            ) {
+                this.referer = mainUrl
+                this.quality = getQualityFromName(nameSource)
+            }
         )
 
         return extractedLinksList

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userscloud.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userscloud.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Userscloud : ExtractorApi() {
     override val name = "Userscloud"
@@ -21,19 +22,20 @@ open class Userscloud : ExtractorApi() {
         val video = res.selectFirst("video#vjsplayer source")?.attr("src")
         val quality = res.selectFirst("div.innerTB h2 b")?.text()
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
                 video ?: return,
-                "$mainUrl/",
-                getQuality(quality),
-                headers = mapOf(
+            ) {
+                this.referer = "$mainUrl/"
+                this.quality = getQuality(quality)
+                this.headers = mapOf(
                     "Accept" to "video/webm,video/ogg,video/*;q=0.9,application/ogg;q=0.7,audio/*;q=0.6,*/*;q=0.5",
                     "Range" to "bytes=0-",
                     "Sec-Fetch-Dest" to "video",
                     "Sec-Fetch-Mode" to "no-cors",
                 )
-            )
+            }
         )
     }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Uservideo.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Uservideo.kt
@@ -7,6 +7,7 @@ import com.lagradost.cloudstream3.utils.AppUtils
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Uservideo : ExtractorApi() {
     override val name: String = "Uservideo"
@@ -30,13 +31,14 @@ open class Uservideo : ExtractorApi() {
 
         sources?.map { source ->
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     name,
                     name,
-                    source.src ?: return@map null,
-                    url,
-                    quality ?: Qualities.Unknown.value,
-                )
+                    source.src ?: return@map null
+                ) {
+                    this.referer = url
+                    this.quality = quality ?: Qualities.Unknown.value
+                }
             )
         }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vicloud.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vicloud.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Vicloud : ExtractorApi() {
     override val name: String = "Vicloud"
@@ -27,13 +28,14 @@ open class Vicloud : ExtractorApi() {
             referer = url
         ).parsedSafe<Responses>()?.sources?.map { source ->
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     name,
                     name,
                     source.file ?: return@map null,
-                    url,
-                    getQualityFromName(source.label),
-                )
+                ) {
+                    this.referer = url
+                    this.quality = getQualityFromName(source.label)
+                }
             )
         }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidMoxyExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidMoxyExtractor.kt
@@ -46,14 +46,15 @@ open class VidMoxy : ExtractorApi() {
         }
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 source  = this.name,
                 name    = this.name,
                 url     = decoded,
-                referer = extRef,
-                quality = Qualities.Unknown.value,
-                isM3u8  = true
-            )
+            ) {
+                this.referer = extRef
+                this.quality = Qualities.Unknown.value
+                this.isM3u8  = true
+            }
         )
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidMoxyExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidMoxyExtractor.kt
@@ -50,10 +50,10 @@ open class VidMoxy : ExtractorApi() {
                 source  = this.name,
                 name    = this.name,
                 url     = decoded,
+                type = ExtractorLinkType.M3U8
             ) {
                 this.referer = extRef
                 this.quality = Qualities.Unknown.value
-                this.isM3u8  = true
             }
         )
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidSrcExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidSrcExtractor.kt
@@ -7,6 +7,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.loadExtractor
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import java.util.Base64
 
 class VidSrcExtractor2 : VidSrcExtractor() {
@@ -46,14 +47,15 @@ open class VidSrcExtractor : ExtractorApi() {
                         decodeUrl(encodedElement.attr("id"), encodedElement.text()) ?: return@amap
 
                 callback.invoke(
-                        ExtractorLink(
+                        newExtractorLink(
                                 this.name,
                                 this.name,
-                                decodedUrl,
-                                apiUrl,
-                                Qualities.Unknown.value,
-                                isM3u8 = true
-                        )
+                                decodedUrl
+                        ) {
+                            this.referer = apiUrl
+                            this.quality = Qualities.Unknown.value
+                            this.isM3u8 = true
+                        }
                 )
             } else {
                 loadExtractor(res.url, url, subtitleCallback, callback)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidSrcExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidSrcExtractor.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.amap
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.loadExtractor
 import com.lagradost.cloudstream3.utils.newExtractorLink
@@ -21,41 +22,41 @@ open class VidSrcExtractor : ExtractorApi() {
     override val requiresReferer = false
 
     override suspend fun getUrl(
-            url: String,
-            referer: String?,
-            subtitleCallback: (SubtitleFile) -> Unit,
-            callback: (ExtractorLink) -> Unit
+        url: String,
+        referer: String?,
+        subtitleCallback: (SubtitleFile) -> Unit,
+        callback: (ExtractorLink) -> Unit
     ) {
         val iframedoc = app.get(url).document
 
         val srcrcpList =
-                iframedoc.select("div.serversList > div.server").mapNotNull {
-                    val datahash = it.attr("data-hash") ?: return@mapNotNull null
-                    val rcpLink = "$apiUrl/rcp/$datahash"
-                    val rcpRes = app.get(rcpLink, referer = apiUrl).text
-                    val srcrcpLink =
-                            Regex("src:\\s*'(.*)',").find(rcpRes)?.destructured?.component1()
-                                    ?: return@mapNotNull null
-                    "https:$srcrcpLink"
-                }
+            iframedoc.select("div.serversList > div.server").mapNotNull {
+                val datahash = it.attr("data-hash") ?: return@mapNotNull null
+                val rcpLink = "$apiUrl/rcp/$datahash"
+                val rcpRes = app.get(rcpLink, referer = apiUrl).text
+                val srcrcpLink =
+                    Regex("src:\\s*'(.*)',").find(rcpRes)?.destructured?.component1()
+                        ?: return@mapNotNull null
+                "https:$srcrcpLink"
+            }
 
         srcrcpList.amap { server ->
             val res = app.get(server, referer = apiUrl)
             if (res.url.contains("/prorcp")) {
                 val encodedElement = res.document.select("div#reporting_content+div")
                 val decodedUrl =
-                        decodeUrl(encodedElement.attr("id"), encodedElement.text()) ?: return@amap
+                    decodeUrl(encodedElement.attr("id"), encodedElement.text()) ?: return@amap
 
                 callback.invoke(
-                        newExtractorLink(
-                                this.name,
-                                this.name,
-                                decodedUrl
-                        ) {
-                            this.referer = apiUrl
-                            this.quality = Qualities.Unknown.value
-                            this.isM3u8 = true
-                        }
+                    newExtractorLink(
+                        source = this.name,
+                        name = this.name,
+                        url = decodedUrl,
+                        type = ExtractorLinkType.M3U8
+                    ) {
+                        this.referer = apiUrl
+                        this.quality = Qualities.Unknown.value
+                    }
                 )
             } else {
                 loadExtractor(res.url, url, subtitleCallback, callback)
@@ -109,15 +110,15 @@ open class VidSrcExtractor : ExtractorApi() {
     private fun IGLImMhWrI(a: String): String {
         val b = a.reversed()
         val c =
-                b
-                        .map {
-                            when (it) {
-                                in 'a'..'m', in 'A'..'M' -> it + 13
-                                in 'n'..'z', in 'N'..'Z' -> it - 13
-                                else -> it
-                            }
-                        }
-                        .joinToString("")
+            b
+                .map {
+                    when (it) {
+                        in 'a'..'m', in 'A'..'M' -> it + 13
+                        in 'n'..'z', in 'N'..'Z' -> it - 13
+                        else -> it
+                    }
+                }
+                .joinToString("")
         val d = c.reversed()
         return String(Base64.getDecoder().decode(d))
     }
@@ -160,60 +161,60 @@ open class VidSrcExtractor : ExtractorApi() {
 
     private fun nZlUnj2VSo(a: String): String {
         val b =
-                mapOf(
-                        'x' to 'a',
-                        'y' to 'b',
-                        'z' to 'c',
-                        'a' to 'd',
-                        'b' to 'e',
-                        'c' to 'f',
-                        'd' to 'g',
-                        'e' to 'h',
-                        'f' to 'i',
-                        'g' to 'j',
-                        'h' to 'k',
-                        'i' to 'l',
-                        'j' to 'm',
-                        'k' to 'n',
-                        'l' to 'o',
-                        'm' to 'p',
-                        'n' to 'q',
-                        'o' to 'r',
-                        'p' to 's',
-                        'q' to 't',
-                        'r' to 'u',
-                        's' to 'v',
-                        't' to 'w',
-                        'u' to 'x',
-                        'v' to 'y',
-                        'w' to 'z',
-                        'X' to 'A',
-                        'Y' to 'B',
-                        'Z' to 'C',
-                        'A' to 'D',
-                        'B' to 'E',
-                        'C' to 'F',
-                        'D' to 'G',
-                        'E' to 'H',
-                        'F' to 'I',
-                        'G' to 'J',
-                        'H' to 'K',
-                        'I' to 'L',
-                        'J' to 'M',
-                        'K' to 'N',
-                        'L' to 'O',
-                        'M' to 'P',
-                        'N' to 'Q',
-                        'O' to 'R',
-                        'P' to 'S',
-                        'Q' to 'T',
-                        'R' to 'U',
-                        'S' to 'V',
-                        'T' to 'W',
-                        'U' to 'X',
-                        'V' to 'Y',
-                        'W' to 'Z'
-                )
+            mapOf(
+                'x' to 'a',
+                'y' to 'b',
+                'z' to 'c',
+                'a' to 'd',
+                'b' to 'e',
+                'c' to 'f',
+                'd' to 'g',
+                'e' to 'h',
+                'f' to 'i',
+                'g' to 'j',
+                'h' to 'k',
+                'i' to 'l',
+                'j' to 'm',
+                'k' to 'n',
+                'l' to 'o',
+                'm' to 'p',
+                'n' to 'q',
+                'o' to 'r',
+                'p' to 's',
+                'q' to 't',
+                'r' to 'u',
+                's' to 'v',
+                't' to 'w',
+                'u' to 'x',
+                'v' to 'y',
+                'w' to 'z',
+                'X' to 'A',
+                'Y' to 'B',
+                'Z' to 'C',
+                'A' to 'D',
+                'B' to 'E',
+                'C' to 'F',
+                'D' to 'G',
+                'E' to 'H',
+                'F' to 'I',
+                'G' to 'J',
+                'H' to 'K',
+                'I' to 'L',
+                'J' to 'M',
+                'K' to 'N',
+                'L' to 'O',
+                'M' to 'P',
+                'N' to 'Q',
+                'O' to 'R',
+                'P' to 'S',
+                'Q' to 'T',
+                'R' to 'U',
+                'S' to 'V',
+                'T' to 'W',
+                'U' to 'X',
+                'V' to 'Y',
+                'W' to 'Z'
+            )
         return a.map { b[it] ?: it }.joinToString("")
     }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidStack.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidStack.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.newExtractorLink
 import javax.crypto.Cipher
@@ -22,13 +23,13 @@ open class VidStack : ExtractorApi() {
         val m3u8=Regex("\"source\":\"(.*?)\"").find(decryptedText)?.groupValues?.get(1)?.replace("\\/","/") ?:""
         return listOf(
             newExtractorLink(
-                this.name,
-                this.name,
-                m3u8,
+                source = this.name,
+                name = this.name,
+                url = m3u8,
+                type = ExtractorLinkType.M3U8
             ) {
                 this.referer = url
                 this.quality = Qualities.Unknown.value
-                this.isM3u8 = true
             }
         )
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidStack.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidStack.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
@@ -20,14 +21,15 @@ open class VidStack : ExtractorApi() {
         val decryptedText = AesHelper.decryptAES(encoded, "kiemtienmua911ca", "0123456789abcdef")
         val m3u8=Regex("\"source\":\"(.*?)\"").find(decryptedText)?.groupValues?.get(1)?.replace("\\/","/") ?:""
         return listOf(
-            ExtractorLink(
+            newExtractorLink(
                 this.name,
                 this.name,
                 m3u8,
-                url,
-                Qualities.Unknown.value,
-                isM3u8 = true
-            )
+            ) {
+                this.referer = url
+                this.quality = Qualities.Unknown.value
+                this.isM3u8 = true
+            }
         )
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VideoSeyredExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VideoSeyredExtractor.kt
@@ -36,14 +36,14 @@ open class VideoSeyred : ExtractorApi() {
 
         for (source in response.sources) {
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     source  = this.name,
                     name    = this.name,
                     url     = source.file,
-                    referer = "${mainUrl}/",
-                    quality = Qualities.Unknown.value,
-                    type    = INFER_TYPE
-                )
+                ) {
+                    this.referer = "${mainUrl}/"
+                    this.quality = Qualities.Unknown.value
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidguard.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidguard.kt
@@ -8,6 +8,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.NativeJSON
 import org.mozilla.javascript.NativeObject
@@ -45,14 +46,13 @@ open class Vidguardto : ExtractorApi() {
             val watchlink = sigDecode(jsonStr2.stream)
 
             callback.invoke(
-                ExtractorLink(
+                newExtractorLink(
                     this.name,
                     name,
                     watchlink,
-                    this.mainUrl,
-                    Qualities.Unknown.value,
-                    INFER_TYPE
-                )
+                ) {
+                    this.referer = mainUrl
+                }
             )
         }
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidhideExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidhideExtractor.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.network.WebViewResolver
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.newExtractorLink
 
@@ -25,10 +26,10 @@ open class VidhideExtractor : ExtractorApi() {
                     source = name,
                     name = name,
                     url = response.url,
+                    type = ExtractorLinkType.M3U8
                 ) {
                     this.referer = referer ?: "$mainUrl/"
                     this.quality = Qualities.Unknown.value
-                    this.isM3u8 = true
                 }
             )
         return sources

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidhideExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidhideExtractor.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.network.WebViewResolver
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class VidhideExtractor : ExtractorApi() {
     override var name = "VidHide"
@@ -20,14 +21,15 @@ open class VidhideExtractor : ExtractorApi() {
         val sources = mutableListOf<ExtractorLink>()
         if (response.url.contains("m3u8"))
             sources.add(
-                ExtractorLink(
+                newExtractorLink(
                     source = name,
                     name = name,
                     url = response.url,
-                    referer = referer ?: "$mainUrl/",
-                    quality = Qualities.Unknown.value,
-                    isM3u8 = true
-                )
+                ) {
+                    this.referer = referer ?: "$mainUrl/"
+                    this.quality = Qualities.Unknown.value
+                    this.isM3u8 = true
+                }
             )
         return sources
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vido.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vido.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getAndUnpack
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 class Vido : ExtractorApi() {
     override var name = "Vido"
@@ -18,14 +19,15 @@ class Vido : ExtractorApi() {
             //val quality = unpackedText.lowercase().substringAfter(" height=").substringBefore(" ").toIntOrNull()
             srcRegex.find(this.text)?.groupValues?.get(1)?.let { link ->
                 return listOf(
-                    ExtractorLink(
+                    newExtractorLink(
                         name,
                         name,
                         link,
-                        url,
-                        Qualities.Unknown.value,
-                        true,
-                    )
+                    ) {
+                        this.referer = url
+                        this.quality = Qualities.Unknown.value
+                        this.isM3u8 = true
+                    }
                 )
             }
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vido.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vido.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getAndUnpack
 import com.lagradost.cloudstream3.utils.newExtractorLink
@@ -20,13 +21,13 @@ class Vido : ExtractorApi() {
             srcRegex.find(this.text)?.groupValues?.get(1)?.let { link ->
                 return listOf(
                     newExtractorLink(
-                        name,
-                        name,
-                        link,
+                        source = name,
+                        name = name,
+                        url = link,
+                        type = ExtractorLinkType.M3U8
                     ) {
                         this.referer = url
                         this.quality = Qualities.Unknown.value
-                        this.isM3u8 = true
                     }
                 )
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidstream.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidstream.kt
@@ -9,6 +9,7 @@ import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.extractorApis
 import com.lagradost.cloudstream3.utils.getQualityFromName
 import com.lagradost.cloudstream3.utils.loadExtractor
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import org.jsoup.Jsoup
 
 /**
@@ -65,14 +66,15 @@ class Vidstream(val mainUrl: String) {
 
                     if (!loadExtractor(href, link, subtitleCallback, callback)) {
                         callback.invoke(
-                            ExtractorLink(
+                            newExtractorLink(
                                 this.name,
                                 name = this.name,
                                 href,
-                                page.url,
-                                getQualityFromName(qual),
                                 type = INFER_TYPE
-                            )
+                            ) {
+                                this.referer = page.url
+                                this.quality = getQualityFromName(qual)
+                            }
                         )
                     }
                 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vtbe.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vtbe.kt
@@ -23,14 +23,15 @@ open class Vtbe : ExtractorApi() {
             JsUnpacker(extractedpack).unpack()?.let { unPacked ->
                 Regex("sources:\\[\\{file:\"(.*?)\"").find(unPacked)?.groupValues?.get(1)?.let { link ->
                     return listOf(
-                        ExtractorLink(
+                        newExtractorLink(
                             this.name,
                             this.name,
                             link,
-                            referer ?: "",
-                            Qualities.Unknown.value,
-                            URI(link).path.endsWith(".m3u8")
-                        )
+                        ) {
+                            this.referer = referer ?: ""
+                            this.quality = Qualities.Unknown.value
+                            this.isM3u8 = URI(link).path.endsWith(".m3u8")
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vtbe.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vtbe.kt
@@ -30,7 +30,6 @@ open class Vtbe : ExtractorApi() {
                         ) {
                             this.referer = referer ?: ""
                             this.quality = Qualities.Unknown.value
-                            this.isM3u8 = URI(link).path.endsWith(".m3u8")
                         }
                     )
                 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/WcoStream.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/WcoStream.kt
@@ -7,6 +7,7 @@ import com.lagradost.cloudstream3.extractors.helper.NineAnimeHelper.encrypt
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.Qualities
 
@@ -127,7 +128,15 @@ open class WcoStream : ExtractorApi() {
 
         if (!response.text.startsWith("{")) throw ErrorLoadingException("Seems like 9Anime kiddies changed stuff again, Go touch some grass for bout an hour Or use a different Server")
         return response.parsed<Response>().data.media.sources.map {
-            ExtractorLink(name, it.file, it.file, host, Qualities.Unknown.value, type = INFER_TYPE)
+            newExtractorLink(
+                name,
+                it.file,
+                it.file,
+                type = INFER_TYPE
+            ) {
+                this.referer = host
+                this.quality = Qualities.Unknown.value
+            }
         }
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Wibufile.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Wibufile.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class Wibufile : ExtractorApi() {
     override val name: String = "Wibufile"
@@ -22,14 +23,15 @@ open class Wibufile : ExtractorApi() {
         val video = Regex("src: ['\"](.*?)['\"]").find(res)?.groupValues?.get(1)
 
         callback.invoke(
-            ExtractorLink(
+            newExtractorLink(
                 name,
                 name,
                 video ?: return,
-                "$mainUrl/",
-                Qualities.Unknown.value,
                 type = INFER_TYPE
-            )
+            ) {
+                this.referer = "$mainUrl/"
+                this.quality = Qualities.Unknown.value
+            }
         )
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Wibufile.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Wibufile.kt
@@ -27,7 +27,6 @@ open class Wibufile : ExtractorApi() {
                 name,
                 name,
                 video ?: return,
-                type = INFER_TYPE
             ) {
                 this.referer = "$mainUrl/"
                 this.quality = Qualities.Unknown.value

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/XStreamCdn.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/XStreamCdn.kt
@@ -7,6 +7,7 @@ import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 class StreamM4u : XStreamCdn() {
     override val name: String = "StreamM4u"
@@ -120,13 +121,14 @@ open class XStreamCdn : ExtractorApi() {
                 if (it.success && it.data != null) {
                     it.data.map { source ->
                         callback.invoke(
-                            ExtractorLink(
+                            newExtractorLink(
                                 name,
                                 name = name,
                                 source.file,
-                                url,
-                                getQualityFromName(source.label),
-                            )
+                            ) {
+                                this.referer = url
+                                this.quality = getQualityFromName(source.label)
+                            }
                         )
                     }
                 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YourUpload.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YourUpload.kt
@@ -6,6 +6,7 @@ import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class YourUpload: ExtractorApi() {
     override val name = "Yourupload"
@@ -26,13 +27,14 @@ open class YourUpload: ExtractorApi() {
                         }}"
                     )
                     sources.add(
-                        ExtractorLink(
+                        newExtractorLink(
                             source = name,
                             name = name,
                             url = link!!.file,
-                            referer = url,
-                            quality = getQualityFromName(quality)
-                        )
+                        ) {
+                            this.referer = url
+                            this.quality = getQualityFromName(quality)
+                        }
                     )
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YoutubeExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YoutubeExtractor.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.schemaStripRegex
@@ -75,12 +76,11 @@ open class YoutubeExtractor : ExtractorApi() {
         ytVideos[url]?.let {
             callback(
                 newExtractorLink(
-                    this.name,
-                    this.name,
-                    it
-                ) {
-                    this.isM3u8 = true
-                }
+                    source = this.name,
+                    name = this.name,
+                    url = it,
+                    type = ExtractorLinkType.M3U8
+                )
             )
         }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YoutubeExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YoutubeExtractor.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import com.lagradost.cloudstream3.utils.schemaStripRegex
 import org.schabi.newpipe.extractor.ServiceList
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamExtractor
@@ -73,14 +74,13 @@ open class YoutubeExtractor : ExtractorApi() {
         }
         ytVideos[url]?.let {
             callback(
-                ExtractorLink(
+                newExtractorLink(
                     this.name,
                     this.name,
-                    it,
-                    "",
-                    Qualities.Unknown.value,
-                    isM3u8 = true
-                )
+                    it
+                ) {
+                    this.isM3u8 = true
+                }
             )
         }
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/GogoHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/GogoHelper.kt
@@ -11,6 +11,7 @@ import com.lagradost.cloudstream3.utils.AppUtils
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.M3u8Helper
 import com.lagradost.cloudstream3.utils.getQualityFromName
+import com.lagradost.cloudstream3.utils.newExtractorLink
 import org.jsoup.nodes.Document
 import java.net.URI
 import javax.crypto.Cipher
@@ -124,13 +125,14 @@ object GogoHelper {
                 ).forEach(sourceCallback)
             } else {
                 sourceCallback.invoke(
-                    ExtractorLink(
+                    newExtractorLink(
                         mainApiName,
                         mainApiName,
                         source.file,
-                        mainUrl,
-                        getQualityFromName(source.label),
-                    )
+                    ) {
+                        this.referer = mainUrl
+                        this.quality = getQualityFromName(source.label)
+                    }
                 )
             }
         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/VstreamhubHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/VstreamhubHelper.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors.helper
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.loadExtractor
 import com.lagradost.cloudstream3.utils.newExtractorLink
@@ -33,10 +34,10 @@ class VstreamhubHelper {
                                 name = "$baseName m3u8",
                                 source = baseName,
                                 url = linkUrl,
+                                type = ExtractorLinkType.M3U8
                             ) {
                                 this.quality = Qualities.Unknown.value
                                 this.referer = url
-                                this.isM3u8 = true
                             }
                             callback.invoke(exlink)
                         }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/VstreamhubHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/VstreamhubHelper.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.loadExtractor
+import com.lagradost.cloudstream3.utils.newExtractorLink
 
 class VstreamhubHelper {
     companion object {
@@ -28,14 +29,15 @@ class VstreamhubHelper {
                             val linkUrl =
                                 aa.substring(startString.length + 1, aa.indexOf("\",")).trim()
                             //Log.i(baseName, "Result => (linkUrl) ${linkUrl}")
-                            val exlink = ExtractorLink(
+                            val exlink = newExtractorLink(
                                 name = "$baseName m3u8",
                                 source = baseName,
                                 url = linkUrl,
-                                quality = Qualities.Unknown.value,
-                                referer = url,
-                                isM3u8 = true
-                            )
+                            ) {
+                                this.quality = Qualities.Unknown.value
+                                this.referer = url
+                                this.isM3u8 = true
+                            }
                             callback.invoke(exlink)
                         }
                         if (innerText.contains("playerInstance")) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -521,13 +521,11 @@ open class DrmExtractorLink private constructor(
         url: String,
         referer: String? = null,
         quality: Int? = null,
-        isM3u8: Boolean? = false,
         /** the type of the media, use INFER_TYPE if you want to auto infer the type from the url */
         type: ExtractorLinkType? = INFER_TYPE,
         headers: Map<String, String> = mapOf(),
         /** Used for getExtractorVerifierJob() */
         extractorData: String? = null,
-        isDash: Boolean? = false,
         kid: String? = null,
         key: String? = null,
         uuid: UUID = CLEARKEY_UUID,
@@ -542,10 +540,7 @@ open class DrmExtractorLink private constructor(
         quality = quality ?: Qualities.Unknown.value,
         headers = headers,
         extractorData = extractorData,
-        type = type
-            ?: if (isDash == true) ExtractorLinkType.DASH else if (isM3u8 == true) ExtractorLinkType.M3U8 else inferTypeFromUrl(
-                url
-            ),
+        type = type ?: inferTypeFromUrl(url),
         kid = kid,
         key = key,
         uuid = uuid,
@@ -611,8 +606,8 @@ open class ExtractorLink constructor(
     open var extractorData: String? = null,
     open var type: ExtractorLinkType,
 ) : IDownloadableMinimum {
-    var isM3u8: Boolean = false
-    var isDash: Boolean = false
+    val isM3u8: Boolean get() = type == ExtractorLinkType.M3U8
+    val isDash: Boolean get() = type == ExtractorLinkType.DASH
 
     // Cached video size
     private var videoSize: Long? = null
@@ -651,13 +646,11 @@ open class ExtractorLink constructor(
         url: String,
         referer: String? = null,
         quality: Int? = null,
-        isM3u8: Boolean? = false,
         /** the type of the media, use INFER_TYPE if you want to auto infer the type from the url */
         type: ExtractorLinkType? = INFER_TYPE,
         headers: Map<String, String> = mapOf(),
         /** Used for getExtractorVerifierJob() */
         extractorData: String? = null,
-        isDash: Boolean? = false,
     ) : this(
         source = source,
         name = name,
@@ -666,10 +659,7 @@ open class ExtractorLink constructor(
         quality = quality ?: Qualities.Unknown.value,
         headers = headers,
         extractorData = extractorData,
-        type = type
-            ?: if (isDash == true) ExtractorLinkType.DASH else if (isM3u8 == true) ExtractorLinkType.M3U8 else inferTypeFromUrl(
-                url
-            )
+        type = type ?: inferTypeFromUrl(url)
     )
 
     @Deprecated("Use newExtractorLink", level = DeprecationLevel.ERROR)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -325,12 +325,12 @@ data class ExtractorLinkPlayList(
     override val source: String,
     override val name: String,
     val playlist: List<PlayListItem>,
-    override val referer: String,
-    override val quality: Int,
-    override val headers: Map<String, String> = mapOf(),
+    override var referer: String,
+    override var quality: Int,
+    override var headers: Map<String, String> = mapOf(),
     /** Used for getExtractorVerifierJob() */
-    override val extractorData: String? = null,
-    override val type: ExtractorLinkType,
+    override var extractorData: String? = null,
+    override var type: ExtractorLinkType,
 ) : ExtractorLink(
     source = source,
     name = name,
@@ -435,6 +435,50 @@ val WIDEVINE_UUID = UUID(-0x121074568629b532L, -0x5c37d8232ae2de13L)
  */
 val PLAYREADY_UUID = UUID(-0x65fb0f8667bfbd7aL, -0x546d19a41f77a06bL)
 
+suspend fun newExtractorLink(
+    source: String,
+    name: String,
+    url: String,
+    type: ExtractorLinkType? = null,
+    initializer: suspend ExtractorLink.() -> Unit = { }
+): ExtractorLink {
+
+    @Suppress("DEPRECATION_ERROR")
+    val builder =
+        ExtractorLink(
+            source = source,
+            name = name,
+            url = url,
+            type = type ?: INFER_TYPE
+        )
+
+    builder.initializer()
+    return builder
+}
+
+suspend fun newDrmExtractorLink(
+    source: String,
+    name: String,
+    url: String,
+    type: ExtractorLinkType? = null,
+    uuid: UUID,
+    initializer: suspend DrmExtractorLink.() -> Unit = { }
+): DrmExtractorLink {
+
+    @Suppress("DEPRECATION_ERROR")
+    val builder =
+        DrmExtractorLink(
+            source = source,
+            name = name,
+            url = url,
+            uuid = uuid,
+            type = type ?: INFER_TYPE
+        )
+
+    builder.initializer()
+    return builder
+}
+
 /** Class holds extracted DRM media info to be passed to the player.
  * @property source Name of the media source, appears on player layout.
  * @property name Title of the media, appears on player layout.
@@ -450,16 +494,17 @@ val PLAYREADY_UUID = UUID(-0x65fb0f8667bfbd7aL, -0x546d19a41f77a06bL)
  * @property kty Key type "oct" (octet sequence) by default
  * @property keyRequestParameters Parameters that will used to request the key.
  * */
+@Suppress("DEPRECATION_ERROR")
 open class DrmExtractorLink private constructor(
     override val source: String,
     override val name: String,
     override val url: String,
-    override val referer: String,
-    override val quality: Int,
-    override val headers: Map<String, String> = mapOf(),
+    override var referer: String,
+    override var quality: Int,
+    override var headers: Map<String, String> = mapOf(),
     /** Used for getExtractorVerifierJob() */
-    override val extractorData: String? = null,
-    override val type: ExtractorLinkType,
+    override var extractorData: String? = null,
+    override var type: ExtractorLinkType,
     open var kid: String? = null,
     open var key: String? = null,
     open var uuid: UUID,
@@ -469,6 +514,47 @@ open class DrmExtractorLink private constructor(
 ) : ExtractorLink(
     source, name, url, referer, quality, type, headers, extractorData
 ) {
+    @Deprecated("Use newDrmExtractorLink", level = DeprecationLevel.ERROR)
+    constructor(
+        source: String,
+        name: String,
+        url: String,
+        referer: String? = null,
+        quality: Int? = null,
+        isM3u8: Boolean? = false,
+        /** the type of the media, use INFER_TYPE if you want to auto infer the type from the url */
+        type: ExtractorLinkType? = INFER_TYPE,
+        headers: Map<String, String> = mapOf(),
+        /** Used for getExtractorVerifierJob() */
+        extractorData: String? = null,
+        isDash: Boolean? = false,
+        kid: String? = null,
+        key: String? = null,
+        uuid: UUID = CLEARKEY_UUID,
+        kty: String? = "oct",
+        keyRequestParameters: HashMap<String, String> = hashMapOf(),
+        licenseUrl: String? = null,
+    ) : this(
+        source = source,
+        name = name,
+        url = url,
+        referer = referer ?: "",
+        quality = quality ?: Qualities.Unknown.value,
+        headers = headers,
+        extractorData = extractorData,
+        type = type
+            ?: if (isDash == true) ExtractorLinkType.DASH else if (isM3u8 == true) ExtractorLinkType.M3U8 else inferTypeFromUrl(
+                url
+            ),
+        kid = kid,
+        key = key,
+        uuid = uuid,
+        keyRequestParameters = keyRequestParameters,
+        kty = kty,
+        licenseUrl = licenseUrl,
+    )
+
+    @Deprecated("Use newDrmExtractorLink", level = DeprecationLevel.ERROR)
     constructor(
         source: String,
         name: String,
@@ -518,15 +604,15 @@ open class ExtractorLink constructor(
     open val source: String,
     open val name: String,
     override val url: String,
-    override val referer: String,
-    open val quality: Int,
-    override val headers: Map<String, String> = mapOf(),
+    override var referer: String,
+    open var quality: Int,
+    override var headers: Map<String, String> = mapOf(),
     /** Used for getExtractorVerifierJob() */
-    open val extractorData: String? = null,
-    open val type: ExtractorLinkType,
+    open var extractorData: String? = null,
+    open var type: ExtractorLinkType,
 ) : IDownloadableMinimum {
-    val isM3u8: Boolean get() = type == ExtractorLinkType.M3U8
-    val isDash: Boolean get() = type == ExtractorLinkType.DASH
+    var isM3u8: Boolean = false
+    var isDash: Boolean = false
 
     // Cached video size
     private var videoSize: Long? = null
@@ -558,6 +644,35 @@ open class ExtractorLink constructor(
         return headers
     }
 
+    @Deprecated("Use newExtractorLink", level = DeprecationLevel.ERROR)
+    constructor(
+        source: String,
+        name: String,
+        url: String,
+        referer: String? = null,
+        quality: Int? = null,
+        isM3u8: Boolean? = false,
+        /** the type of the media, use INFER_TYPE if you want to auto infer the type from the url */
+        type: ExtractorLinkType? = INFER_TYPE,
+        headers: Map<String, String> = mapOf(),
+        /** Used for getExtractorVerifierJob() */
+        extractorData: String? = null,
+        isDash: Boolean? = false,
+    ) : this(
+        source = source,
+        name = name,
+        url = url,
+        referer = referer ?: "",
+        quality = quality ?: Qualities.Unknown.value,
+        headers = headers,
+        extractorData = extractorData,
+        type = type
+            ?: if (isDash == true) ExtractorLinkType.DASH else if (isM3u8 == true) ExtractorLinkType.M3U8 else inferTypeFromUrl(
+                url
+            )
+    )
+
+    @Deprecated("Use newExtractorLink", level = DeprecationLevel.ERROR)
     constructor(
         source: String,
         name: String,
@@ -584,6 +699,8 @@ open class ExtractorLink constructor(
      * Old constructor without isDash, allows for backwards compatibility with extensions.
      * Should be removed after all extensions have updated their cloudstream.jar
      **/
+    @Suppress("DEPRECATION_ERROR")
+    @Deprecated("Use newExtractorLink", level = DeprecationLevel.ERROR)
     constructor(
         source: String,
         name: String,
@@ -596,6 +713,7 @@ open class ExtractorLink constructor(
         extractorData: String? = null
     ) : this(source, name, url, referer, quality, isM3u8, headers, extractorData, false)
 
+    @Deprecated("Use newExtractorLink", level = DeprecationLevel.ERROR)
     constructor(
         source: String,
         name: String,
@@ -729,7 +847,7 @@ suspend fun loadExtractor(
         if (compareUrl.startsWith(extractor.mainUrl.replace(schemaStripRegex, ""))) {
             try {
                 extractor.getUrl(currentUrl, referer, subtitleCallback, callback)
-            } catch (e : Exception) {
+            } catch (e: Exception) {
                 logError(e)
                 // Rethrow if we have timed out
                 if (e is CancellationException) {
@@ -750,7 +868,7 @@ suspend fun loadExtractor(
         ) {
             try {
                 extractor.getUrl(currentUrl, referer, subtitleCallback, callback)
-            } catch (e : Exception) {
+            } catch (e: Exception) {
                 logError(e)
                 // Rethrow if we have timed out
                 if (e is CancellationException) {
@@ -1084,7 +1202,7 @@ val extractorApis: MutableList<ExtractorApi> = arrayListOf(
     InternetArchive(),
     VidStack(),
     GDMirrorbot(),
-    )
+)
 
 
 fun getExtractorApiFromName(name: String): ExtractorApi {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/M3u8Helper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/M3u8Helper.kt
@@ -57,10 +57,10 @@ object M3u8Helper2 {
                     source,
                     name = name,
                     stream.streamUrl,
+                    type = ExtractorLinkType.M3U8
                 ) {
                     this.referer = referer
                     this.quality = stream.quality ?: Qualities.Unknown.value
-                    this.isM3u8 = true
                     this.headers = stream.headers
                 }
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/M3u8Helper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/M3u8Helper.kt
@@ -53,15 +53,16 @@ object M3u8Helper2 {
             ), null
         )
             .map { stream ->
-                ExtractorLink(
+                newExtractorLink(
                     source,
                     name = name,
                     stream.streamUrl,
-                    referer,
-                    stream.quality ?: Qualities.Unknown.value,
-                    true,
-                    stream.headers,
-                )
+                ) {
+                    this.referer = referer
+                    this.quality = stream.quality ?: Qualities.Unknown.value
+                    this.isM3u8 = true
+                    this.headers = stream.headers
+                }
             }
     }
 


### PR DESCRIPTION
- Deprecating `ExtractorLink `in favor of `newExtractorLink`.
- Deprecating `DrmExtractorLink `in favor of `newDrmExtractorLink`.
- Porting all internal extractors to `newExtractorLink`.