### PR TITLE
Fix gradient overlay on loading

### DIFF
--- a/app/src/main/res/layout/fragment_result_tv.xml
+++ b/app/src/main/res/layout/fragment_result_tv.xml
@@ -20,6 +20,28 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
     android:layout_height="match_parent"
     android:background="?attr/primaryBlackBackground">
 
+    <FrameLayout
+        android:id="@+id/background_poster_holder"
+        android:layout_width="match_parent"
+        android:layout_height="275dp"
+        android:visibility="visible">
+
+        <com.lagradost.cloudstream3.utils.PercentageCropImageView
+            android:id="@+id/background_poster"
+            android:layout_width="match_parent"
+            android:layout_height="275dp"
+            android:layout_gravity="center"
+            android:alpha="0.8"
+            android:scaleType="matrix"
+            tools:src="@drawable/profile_bg_dark_blue" />
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="120dp"
+            android:layout_gravity="bottom"
+            android:src="@drawable/background_shadow" />
+    </FrameLayout>
+
     <com.facebook.shimmer.ShimmerFrameLayout
         android:id="@+id/result_loading"
         android:layout_width="match_parent"
@@ -77,28 +99,6 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
             <include layout="@layout/loading_episode" />
         </LinearLayout>
     </com.facebook.shimmer.ShimmerFrameLayout>
-
-    <FrameLayout
-        android:id="@+id/background_poster_holder"
-        android:layout_width="match_parent"
-        android:layout_height="275dp"
-        android:visibility="visible">
-
-        <com.lagradost.cloudstream3.utils.PercentageCropImageView
-            android:id="@+id/background_poster"
-            android:layout_width="match_parent"
-            android:layout_height="275dp"
-            android:layout_gravity="center"
-            android:alpha="0.8"
-            android:scaleType="matrix"
-            tools:src="@drawable/profile_bg_dark_blue" />
-
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="120dp"
-            android:layout_gravity="bottom"
-            android:src="@drawable/background_shadow" />
-    </FrameLayout>
 
     <LinearLayout
         android:id="@+id/result_loading_error"


### PR DESCRIPTION
Currently when loading the result page there is a gradient overlay from the poster gradient. 
By reordering the views the issue disappears.

Example of the issue
![file](https://github.com/user-attachments/assets/0d4514d8-7f1f-4344-922e-7965c44f582c)
Notice the difference between episode 1 and episode 2