### PR TITLE
feat: add nathanfromsubject mirror of voe

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Voe.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Voe.kt
@@ -24,6 +24,10 @@ class Urochsunloath : Voe() {
     override var mainUrl = "https://urochsunloath.com"
 }
 
+class NathanFromSubject : Voe() {
+    override val mainUrl = "https://nathanfromsubject.com"
+}
+
 class Yipsu : Voe() {
     override val name = "Yipsu"
     override var mainUrl = "https://yip.su"

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -146,6 +146,7 @@ import com.lagradost.cloudstream3.extractors.Mvidoo
 import com.lagradost.cloudstream3.extractors.Mwish
 import com.lagradost.cloudstream3.extractors.MwvnVizcloudInfo
 import com.lagradost.cloudstream3.extractors.MyCloud
+import com.lagradost.cloudstream3.extractors.NathanFromSubject
 import com.lagradost.cloudstream3.extractors.Nekostream
 import com.lagradost.cloudstream3.extractors.Nekowish
 import com.lagradost.cloudstream3.extractors.Neonime7n
@@ -1166,6 +1167,7 @@ val extractorApis: MutableList<ExtractorApi> = arrayListOf(
     Vidguardto3(),
     Simpulumlamerop(),
     Urochsunloath(),
+    NathanFromSubject(),
     Yipsu(),
     MetaGnathTuggers(),
     Geodailymotion(),


### PR DESCRIPTION
https://nathanfromsubject.com is a new mirror of Voe.sx and primarily used by Voe now.