### PR TITLE
Build Config Hash and Build time

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,17 @@ android {
             "SIMKL_CLIENT_SECRET",
             "\"" + (System.getenv("SIMKL_CLIENT_SECRET") ?: localProperties["simkl.secret"]) + "\""
         )
+        buildConfigField(
+    "String",
+    "COMMIT_HASH",
+    "\"${getGitCommitHash()}\""
+)
+buildConfigField(
+    "String",
+    "BUILD_TIME",
+    "\"${java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(java.util.Date())}\""
+)
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
This update adds two new BuildConfig fields — COMMIT_HASH and BUILD_TIME — to embed the current Git commit hash and the build timestamp directly into the application at compile time. This enhancement improves traceability, allowing developers and QA teams to easily identify the source and timing of a specific build. It’s especially useful for debugging, crash reporting, and release tracking across CI/CD environments.