### PR TITLE
Odnoklassniki (Minor Fix)

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/OdnoklassnikiExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/OdnoklassnikiExtractor.kt
@@ -10,7 +10,7 @@ import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.AppUtils
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
-import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.getQualityFromName
 import com.lagradost.cloudstream3.utils.newExtractorLink
 
@@ -56,7 +56,7 @@ open class Odnoklassniki : ExtractorApi() {
                     source  = this.name,
                     name    = this.name,
                     url     = videoUrl,
-                    type    = ExtractorLinkType.M3U8
+                    type    = INFER_TYPE
                 ) {
                     this.referer = "$mainUrl/"
                     this.quality = getQualityFromName(quality)


### PR DESCRIPTION
"Changing from ExtractorLinkType.M3U8 to INFER_TYPE resolves the issue with Odnoklassniki videos not playing."