### PR TITLE
Add 'Always ask' option for video player selection

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/actions/AlwaysAskAction.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/actions/AlwaysAskAction.kt
@@ -1,0 +1,29 @@
+package com.lagradost.cloudstream3.actions
+
+import android.content.Context
+import com.lagradost.cloudstream3.R
+import com.lagradost.cloudstream3.ui.result.LinkLoadingResult
+import com.lagradost.cloudstream3.ui.result.ResultEpisode
+import com.lagradost.cloudstream3.utils.UiText
+import com.lagradost.cloudstream3.utils.txt
+
+class AlwaysAskAction : VideoClickAction() {
+    override val name = txt(R.string.player_settings_always_ask)
+    override val isPlayer = true
+    
+    override fun shouldShow(context: Context?, video: ResultEpisode?): Boolean {
+        // This action should always be available as a player option
+        return true
+    }
+    
+    override suspend fun runAction(
+        context: Context?,
+        video: ResultEpisode,
+        result: LinkLoadingResult,
+        index: Int?
+    ) {
+        // This is handled specially in ResultViewModel2.kt by detecting the AlwaysAskAction
+        // and showing the player selection dialog instead of executing the action directly
+        throw NotImplementedError("AlwaysAskAction is handled specially by the calling code")
+    }
+}

--- a/app/src/main/java/com/lagradost/cloudstream3/actions/VideoClickAction.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/actions/VideoClickAction.kt
@@ -12,6 +12,7 @@ import com.lagradost.cloudstream3.CommonActivity
 import com.lagradost.cloudstream3.ErrorLoadingException
 import com.lagradost.cloudstream3.MainActivity
 import com.lagradost.cloudstream3.R
+import com.lagradost.cloudstream3.actions.AlwaysAskAction
 import com.lagradost.cloudstream3.actions.temp.CopyClipboardAction
 import com.lagradost.cloudstream3.actions.temp.MpvKtPackage
 import com.lagradost.cloudstream3.actions.temp.MpvKtPreviewPackage
@@ -50,6 +51,8 @@ object VideoClickActionHolder {
         MpvYTDLPackage(),
         MpvKtPackage(),
         MpvKtPreviewPackage(),
+        // Always Ask option
+        AlwaysAskAction(),
         // added by plugins
         // ...
     )

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/EpisodeAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/EpisodeAdapter.kt
@@ -38,6 +38,7 @@ import java.util.Locale
  * @see VideoClickActionHolder
  */
 const val ACTION_PLAY_EPISODE_IN_PLAYER = 1
+const val ACTION_ALWAYS_ASK_PLAYER = 2
 
 const val ACTION_CHROME_CAST_EPISODE = 4
 const val ACTION_CHROME_CAST_MIRROR = 5
@@ -71,6 +72,12 @@ class EpisodeAdapter(
         fun getPlayerAction(context: Context): Int {
             val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
             val playerPref = settingsManager.getString(context.getString(R.string.player_default_key), "")
+            
+            // Check if "Always ask" is selected
+            if (playerPref == context.getString(R.string.player_always_ask_key)) {
+                return ACTION_ALWAYS_ASK_PLAYER
+            }
+            
             return VideoClickActionHolder.uniqueIdToId(playerPref) ?: ACTION_PLAY_EPISODE_IN_PLAYER
         }
     }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/EpisodeAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/EpisodeAdapter.kt
@@ -38,7 +38,6 @@ import java.util.Locale
  * @see VideoClickActionHolder
  */
 const val ACTION_PLAY_EPISODE_IN_PLAYER = 1
-const val ACTION_ALWAYS_ASK_PLAYER = 2
 
 const val ACTION_CHROME_CAST_EPISODE = 4
 const val ACTION_CHROME_CAST_MIRROR = 5
@@ -72,11 +71,6 @@ class EpisodeAdapter(
         fun getPlayerAction(context: Context): Int {
             val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
             val playerPref = settingsManager.getString(context.getString(R.string.player_default_key), "")
-            
-            // Check if "Always ask" is selected
-            if (playerPref == context.getString(R.string.player_always_ask_key)) {
-                return ACTION_ALWAYS_ASK_PLAYER
-            }
             
             return VideoClickActionHolder.uniqueIdToId(playerPref) ?: ACTION_PLAY_EPISODE_IN_PLAYER
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -1636,6 +1636,33 @@ class ResultViewModel2 : ViewModel() {
                 }
             }
 
+            ACTION_ALWAYS_ASK_PLAYER -> {
+                activity?.let { ctx ->
+                    // Show player selection dialog
+                    val players = VideoClickActionHolder.getPlayers(ctx)
+                    val options = mutableListOf<Pair<UiText, Int>>()
+                    
+                    // Add internal player option
+                    options.add(txt(R.string.episode_action_play_in_app) to ACTION_PLAY_EPISODE_IN_PLAYER)
+                    
+                    // Add external player options 
+                    options.addAll(players.map { player ->
+                        player.name to (VideoClickActionHolder.uniqueIdToId(player.uniqueId()) ?: ACTION_PLAY_EPISODE_IN_PLAYER)
+                    })
+
+                    postPopup(
+                        txt(R.string.player_pref),
+                        options
+                    ) { selectedAction ->
+                        if (selectedAction != null) {
+                            handleEpisodeClickEvent(
+                                click.copy(action = selectedAction)
+                            )
+                        }
+                    }
+                }
+            }
+
             ACTION_MARK_AS_WATCHED -> {
                 val isWatched =
                     getVideoWatchState(click.data.id) == VideoWatchState.Watched

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -24,6 +24,7 @@ import com.lagradost.cloudstream3.LoadResponse.Companion.getAniListId
 import com.lagradost.cloudstream3.LoadResponse.Companion.getMalId
 import com.lagradost.cloudstream3.LoadResponse.Companion.isMovie
 import com.lagradost.cloudstream3.LoadResponse.Companion.readIdFromString
+import com.lagradost.cloudstream3.actions.AlwaysAskAction
 import com.lagradost.cloudstream3.actions.VideoClickActionHolder
 import com.lagradost.cloudstream3.metaproviders.SyncRedirector
 import com.lagradost.cloudstream3.mvvm.*
@@ -1636,33 +1637,6 @@ class ResultViewModel2 : ViewModel() {
                 }
             }
 
-            ACTION_ALWAYS_ASK_PLAYER -> {
-                activity?.let { ctx ->
-                    // Show player selection dialog
-                    val players = VideoClickActionHolder.getPlayers(ctx)
-                    val options = mutableListOf<Pair<UiText, Int>>()
-                    
-                    // Add internal player option
-                    options.add(txt(R.string.episode_action_play_in_app) to ACTION_PLAY_EPISODE_IN_PLAYER)
-                    
-                    // Add external player options 
-                    options.addAll(players.map { player ->
-                        player.name to (VideoClickActionHolder.uniqueIdToId(player.uniqueId()) ?: ACTION_PLAY_EPISODE_IN_PLAYER)
-                    })
-
-                    postPopup(
-                        txt(R.string.player_pref),
-                        options
-                    ) { selectedAction ->
-                        if (selectedAction != null) {
-                            handleEpisodeClickEvent(
-                                click.copy(action = selectedAction)
-                            )
-                        }
-                    }
-                }
-            }
-
             ACTION_MARK_AS_WATCHED -> {
                 val isWatched =
                     getVideoWatchState(click.data.id) == VideoWatchState.Watched
@@ -1679,6 +1653,35 @@ class ResultViewModel2 : ViewModel() {
 
             else -> {
                 val action = VideoClickActionHolder.getActionById(click.action) ?: return
+
+                // Special handling for AlwaysAskAction - show player selection dialog
+                if (action is AlwaysAskAction) {
+                    activity?.let { ctx ->
+                        // Show player selection dialog
+                        val players = VideoClickActionHolder.getPlayers(ctx)
+                        val options = mutableListOf<Pair<UiText, Int>>()
+                        
+                        // Add internal player option
+                        options.add(txt(R.string.episode_action_play_in_app) to ACTION_PLAY_EPISODE_IN_PLAYER)
+                        
+                        // Add external player options 
+                        options.addAll(players.filter { it !is AlwaysAskAction }.map { player ->
+                            player.name to (VideoClickActionHolder.uniqueIdToId(player.uniqueId()) ?: ACTION_PLAY_EPISODE_IN_PLAYER)
+                        })
+
+                        postPopup(
+                            txt(R.string.player_pref),
+                            options
+                        ) { selectedAction ->
+                            if (selectedAction != null) {
+                                handleEpisodeClickEvent(
+                                    click.copy(action = selectedAction)
+                                )
+                            }
+                        }
+                    }
+                    return
+                }
 
                 activity?.setKey("last_click_action", action.uniqueId())
                 if (action.oneSource) {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
@@ -179,10 +179,12 @@ class SettingsPlayer : PreferenceFragmentCompat() {
             val prefNames = buildList {
                 add(getString(R.string.player_settings_play_in_app))
                 addAll(players.map { it.name.asStringNull(activity) ?: it.javaClass.simpleName })
+                add(getString(R.string.player_settings_always_ask))
             }
             val prefValues = buildList {
                 add("")
                 addAll(players.map { it.uniqueId() })
+                add(getString(R.string.player_always_ask_key))
             }
             val current = settingsManager.getString(getString(R.string.player_default_key), "") ?: ""
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
@@ -179,12 +179,10 @@ class SettingsPlayer : PreferenceFragmentCompat() {
             val prefNames = buildList {
                 add(getString(R.string.player_settings_play_in_app))
                 addAll(players.map { it.name.asStringNull(activity) ?: it.javaClass.simpleName })
-                add(getString(R.string.player_settings_always_ask))
             }
             val prefValues = buildList {
                 add("")
                 addAll(players.map { it.uniqueId() })
-                add(getString(R.string.player_always_ask_key))
             }
             val current = settingsManager.getString(getString(R.string.player_default_key), "") ?: ""
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,6 @@
     <string name="quality_pref_key" translatable="false">quality_pref_key</string>
     <string name="quality_pref_mobile_data_key" translatable="false">quality_pref_mobile_data_key</string>
     <string name="player_default_key" translatable="false">player_default_key</string>
-    <string name="player_always_ask_key" translatable="false">always_ask</string>
     <string name="prefer_limit_title_key" translatable="false">prefer_limit_title_key</string>
     <string name="prefer_limit_title_rez_key" translatable="false">prefer_limit_title_rez_key</string>
     <string name="apk_installer_key" translatable="false">apk_installer_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="quality_pref_key" translatable="false">quality_pref_key</string>
     <string name="quality_pref_mobile_data_key" translatable="false">quality_pref_mobile_data_key</string>
     <string name="player_default_key" translatable="false">player_default_key</string>
+    <string name="player_always_ask_key" translatable="false">always_ask</string>
     <string name="prefer_limit_title_key" translatable="false">prefer_limit_title_key</string>
     <string name="prefer_limit_title_rez_key" translatable="false">prefer_limit_title_rez_key</string>
     <string name="apk_installer_key" translatable="false">apk_installer_key</string>
@@ -673,6 +674,7 @@
     <string name="hls_playlist">HLS Playlist</string>
     <string name="player_pref">Preferred video player</string>
     <string name="player_settings_play_in_app">Internal player</string>
+    <string name="player_settings_always_ask">Always ask</string>
     <string name="player_settings_select_cast_device">Select cast device</string>
     <string name="app_not_found_error">App not found</string>
     <string name="all_languages_preference">All Languages</string>


### PR DESCRIPTION
Introduces an 'Always ask' option in player settings, allowing users to choose a player each time an video is played. Updates the settings UI, string resources, and episode handling logic to support this feature.


Purpose: I got issues in some mp4 files in which a audioDecoder error occurs in internal player . For that sake i used to switch to vlc in settings. But some Dash files that requires cookies didnt work in vlc but worked in internal player. Its been a headache between switching players in settings for each media everytime. So i made a "Always Ask" In prefered video player which allows users to selecte player while they play video on the go..

This could be a temp solution for the issue [#1721 ](https://github.com/recloudstream/cloudstream/issues/1721)