### PR TITLE
Add quick scroll-to-top functionality via long press on Home button

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/artifacts/library_jvm_1_0_0.xml
+++ b/.idea/artifacts/library_jvm_1_0_0.xml
@@ -1,0 +1,6 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="library-jvm-1.0.0">
+    <output-path>$PROJECT_DIR$/library/build/libs</output-path>
+    <root id="archive" name="library-jvm-1.0.0.jar" />
+  </artifact>
+</component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="2.1.10" />
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -106,6 +106,7 @@ import com.lagradost.cloudstream3.ui.WatchType
 import com.lagradost.cloudstream3.ui.account.AccountHelper.showAccountSelectLinear
 import com.lagradost.cloudstream3.ui.download.DOWNLOAD_NAVIGATE_TO
 import com.lagradost.cloudstream3.ui.home.HomeViewModel
+import com.lagradost.cloudstream3.ui.home.HomeFragment
 import com.lagradost.cloudstream3.ui.library.LibraryViewModel
 import com.lagradost.cloudstream3.ui.player.BasicLink
 import com.lagradost.cloudstream3.ui.player.GeneratorPlayer
@@ -716,6 +717,38 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
         } catch (e: IllegalArgumentException) {
             Log.e("NavigationError", "Failed to navigate: ${e.message}")
             false
+        }
+    }
+
+    private fun handleHomeLongClick() {
+        // Navigate to home if not already there and scroll to top
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as? NavHostFragment
+        val navController = navHostFragment?.navController
+        
+        if (navController?.currentDestination?.id != R.id.navigation_home) {
+            // Navigate to home first
+            navController?.navigate(R.id.navigation_home)
+        }
+        
+        // Scroll to top - find the home fragment and call scrollToTop
+        ioSafe {
+            // Give some time for navigation to complete if needed
+            Thread.sleep(100)
+            runOnUiThread {
+                val fragments = supportFragmentManager.fragments
+                for (fragment in fragments) {
+                    if (fragment is NavHostFragment) {
+                        val childFragments = fragment.childFragmentManager.fragments
+                        for (childFragment in childFragments) {
+                            if (childFragment is HomeFragment) {
+                                childFragment.scrollToTop()
+                                break
+                            }
+                        }
+                        break
+                    }
+                }
+            }
         }
     }
 
@@ -1630,6 +1663,39 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                     navController
                 )
             }
+            
+            // Long click listener for Home button
+            // Note: Material BottomNavigationView doesn't have native long click support
+            // This is a workaround to add long click functionality
+            try {
+                post {
+                    val homeMenuItem = menu.findItem(R.id.navigation_home)
+                    if (homeMenuItem != null) {
+                        // Try to find the home navigation item view
+                        for (i in 0 until childCount) {
+                            val child = getChildAt(i)
+                            if (child is ViewGroup) {
+                                for (j in 0 until child.childCount) {
+                                    val menuItemView = child.getChildAt(j)
+                                    // Check if this is the home menu item
+                                    if (menuItemView.tag == homeMenuItem || 
+                                        (menuItemView as? View)?.id == R.id.navigation_home ||
+                                        menuItemView.contentDescription?.toString()?.contains("Home", ignoreCase = true) == true) {
+                                        menuItemView.setOnLongClickListener {
+                                            handleHomeLongClick()
+                                            true
+                                        }
+                                        break
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                // Fallback: if long click setup fails, just log it
+                Log.w("MainActivity", "Failed to set up long click for home button", e)
+            }
         }
 
         binding?.navRailView?.apply {
@@ -1647,6 +1713,39 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                     item,
                     navController
                 )
+            }
+            
+            // Long click listener for Home button
+            // Note: Material NavigationRailView doesn't have native long click support
+            // This is a workaround to add long click functionality
+            try {
+                post {
+                    val homeMenuItem = menu.findItem(R.id.navigation_home)
+                    if (homeMenuItem != null) {
+                        // Try to find the home navigation item view
+                        for (i in 0 until childCount) {
+                            val child = getChildAt(i)
+                            if (child is ViewGroup) {
+                                for (j in 0 until child.childCount) {
+                                    val menuItemView = child.getChildAt(j)
+                                    // Check if this is the home menu item
+                                    if (menuItemView.tag == homeMenuItem || 
+                                        (menuItemView as? View)?.id == R.id.navigation_home ||
+                                        menuItemView.contentDescription?.toString()?.contains("Home", ignoreCase = true) == true) {
+                                        menuItemView.setOnLongClickListener {
+                                            handleHomeLongClick()
+                                            true
+                                        }
+                                        break
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                // Fallback: if long click setup fails, just log it
+                Log.w("MainActivity", "Failed to set up long click for home button", e)
             }
 
             fun noFocus(view: View) {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -430,6 +430,9 @@ class HomeFragment : Fragment() {
 
     var binding: FragmentHomeBinding? = null
 
+    fun scrollToTop() {
+        binding?.homeMasterRecycler?.smoothScrollToPosition(0)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
When users scroll down extensively on long pages, returning to the top can be inconvenient. With this update, users can now quickly return to the top of the main page by long-pressing the Home button, improving overall navigation and user experience.