### PR TITLE
feat: Add Quad9 Secured DNS Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/kotlin,java,android,androidstudio,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=kotlin,java,android,androidstudio,visualstudiocode
 
+### Gemini ###
+GEMINI.md
+
 ### Android ###
 # Gradle files
 .gradle/

--- a/app/src/main/java/com/lagradost/cloudstream3/network/DohProviders.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/network/DohProviders.kt
@@ -105,3 +105,12 @@ fun OkHttpClient.Builder.addCanadianShieldDns() = (
                 "149.112.122.10",
             )
         ))
+
+fun OkHttpClient.Builder.addQuad9SecureDns() = (
+    addGenericDns(
+        "https://dns11.quad9.net/dns-query",
+        listOf(
+            "9.9.9.11",
+            "149.112.112.11",
+        )
+    ))

--- a/app/src/main/java/com/lagradost/cloudstream3/network/DohProviders.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/network/DohProviders.kt
@@ -106,11 +106,11 @@ fun OkHttpClient.Builder.addCanadianShieldDns() = (
             )
         ))
 
-fun OkHttpClient.Builder.addQuad9SecureDns() = (
+fun OkHttpClient.Builder.addQuad9SecureDns() =
     addGenericDns(
         "https://dns11.quad9.net/dns-query",
         listOf(
             "9.9.9.11",
             "149.112.112.11",
         )
-    ))
+    )

--- a/app/src/main/java/com/lagradost/cloudstream3/network/RequestsHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/network/RequestsHelper.kt
@@ -45,6 +45,7 @@ fun buildDefaultClient(context: Context): OkHttpClient {
                 6 -> addQuad9Dns()
                 7 -> addDnsSbDns()
                 8 -> addCanadianShieldDns()
+                9 -> addQuad9SecureDns()
             }
         }
         // Needs to be build as otherwise the other builders will change this object

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -24,6 +24,7 @@
         <item>Quad9</item>
         <item>DNS.SB</item>
         <item>Canadian Shield</item>
+        <item>Quad9 Secured</item>
     </array>
     <array name="dns_pref_values">
         <item>0</item>
@@ -35,6 +36,7 @@
         <item>6</item>
         <item>7</item>
         <item>8</item>
+        <item>9</item>
     </array>
 
     <array name="apk_installer_pref">


### PR DESCRIPTION
This PR adds support for the Quad9 Secure DNS provider, giving users a powerful new option to enhance their privacy and security.
Quad9 blocks malicious domains and ensures the integrity of DNS responses by validating them with DNSSEC. This helps protect users from malware, phishing, and other online threats.
