### PR TITLE
Dual subtitles: long‑press selection

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1250,6 +1250,30 @@ class GeneratorPlayer : FullScreenPlayer() {
                     }
                 }
 
+                // Long-press on group: quick set secondary. On "No subtitles" clears secondary
+                subtitleList.setOnItemLongClickListener { _, _, which, _ ->
+                    if (which == 0) {
+                        player.setSecondarySubtitles(null)
+                        showToast(ctx.getString(R.string.no_subtitles) + " (secondary)", Toast.LENGTH_SHORT)
+                        return@setOnItemLongClickListener true
+                    }
+                    val groupIndex = which - 1
+                    val secondary = subtitlesGroupedList
+                        .getOrNull(groupIndex)?.value
+                        ?.firstOrNull()
+                    if (secondary != null) {
+                        player.setSecondarySubtitles(secondary)
+                        showToast(
+                            ctx.getString(R.string.player_loaded_subtitles, secondary.name) +
+                                    " (secondary)",
+                            Toast.LENGTH_SHORT
+                        )
+                        true
+                    } else {
+                        false
+                    }
+                }
+
                 subtitleOptionList.setOnItemClickListener { _, _, which, _ ->
                     if (which >= (subtitlesGroupedList.getOrNull(subtitleGroupIndex - 1)?.value?.size
                             ?: -1)
@@ -1259,6 +1283,23 @@ class GeneratorPlayer : FullScreenPlayer() {
                     } else {
                         subtitleOptionIndex = which
                         subtitleOptionList.setItemChecked(which, true)
+                    }
+                }
+
+                subtitleOptionList.setOnItemLongClickListener { _, _, which, _ ->
+                    val secondary = subtitlesGroupedList
+                        .getOrNull(subtitleGroupIndex - 1)?.value
+                        ?.getOrNull(which)
+                    if (secondary != null) {
+                        player.setSecondarySubtitles(secondary)
+                        showToast(
+                            ctx.getString(R.string.player_loaded_subtitles, secondary.name) +
+                                    " (secondary)",
+                            Toast.LENGTH_SHORT
+                        )
+                        true
+                    } else {
+                        false
                     }
                 }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
@@ -271,6 +271,9 @@ interface IPlayer {
     fun setPreferredSubtitles(subtitle: SubtitleData?): Boolean // returns true if the player requires a reload, null for nothing
     fun getCurrentPreferredSubtitle(): SubtitleData?
 
+    /** Set a secondary subtitle (rendered in a separate overlay view). */
+    fun setSecondarySubtitles(subtitle: SubtitleData?)
+
     fun handleEvent(event: CSPlayerEvent, source: PlayerEventSource = PlayerEventSource.UI)
 
     fun onStop()


### PR DESCRIPTION


- Adds dual subtitles via long‑press (long‑press “No subtitles” to clear).
- Renders secondary at the top; primary remains at the bottom.
- Keeps secondary in sync with a lightweight periodic update.
- Fixes 403 on subtitle fetch by merging video headers (incl. referer) with subtitle headers.
- Stops the updater on release.