### PR TITLE
SubtitleHelper: add IETF BCP 47 and OpenSubtitles

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1681,7 +1681,7 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         sortSubs(subtitles).firstOrNull { sub ->
             val t = sub.name.replace(Regex("[^A-Za-z]"), " ").trim()
-            (settings) && t == lang || t.startsWith(lang) || t == langCode
+            settings && t == lang || t.startsWith(lang) || t == langCode
         }?.let { sub ->
             return sub
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/SubtitlesFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/SubtitlesFragment.kt
@@ -672,7 +672,7 @@ class SubtitlesFragment : DialogFragment() {
             subsAutoSelectLanguage.setFocusableInTv()
             subsAutoSelectLanguage.setOnClickListener { textView ->
                 val langMap = arrayListOf(
-                    SubtitleHelper.Language639(
+                    SubtitleHelper.LanguageMetadata(
                         textView.context.getString(R.string.none),
                         textView.context.getString(R.string.none),
                         "",


### PR DESCRIPTION
* Add IETF BCP 48 tag

* Unify generation of emoji flag + language name

* A lot of manual work to:
  - include OpenSubtitles inconsistent codes
  - remove extinct and with < 1 mi speakers languages
  - include flag emoji to ~100 languages