### PR TITLE
Revert "Hide PIP settings option on TV"

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
@@ -43,8 +43,7 @@ class SettingsPlayer : PreferenceFragmentCompat() {
                 R.string.pref_category_gestures_key,
                 R.string.rotate_video_key,
                 R.string.auto_rotate_video_key,
-                R.string.speedup_key,
-                R.string.pip_enabled_key
+                R.string.speedup_key
             ),
             TV or EMULATOR
         )


### PR DESCRIPTION
Reverts recloudstream/cloudstream#1829 as PiP is possible on some TV devices?