### PR TITLE
feat: add streamup extractor api

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamup.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamup.kt
@@ -1,0 +1,44 @@
+package com.lagradost.cloudstream3.extractors
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.lagradost.cloudstream3.SubtitleFile
+import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.utils.ExtractorApi
+import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
+
+open class Streamup() : ExtractorApi() {
+    override val name: String = "Streamup"
+    override val mainUrl: String = "https://strmup.to"
+    override val requiresReferer: Boolean = false
+
+    override suspend fun getUrl(
+        url: String,
+        referer: String?,
+        subtitleCallback: (SubtitleFile) -> Unit,
+        callback: (ExtractorLink) -> Unit
+    ) {
+        val fileCode = url.substringAfterLast("/")
+        val fileInfo = app.get("$mainUrl/ajax/stream?filecode=$fileCode")
+            .parsed<StreamUpFileInfo>()
+
+        callback.invoke(
+            newExtractorLink(
+                source = name,
+                name = name,
+                url = fileInfo.streamingUrl,
+                type = ExtractorLinkType.M3U8
+            )
+        )
+    }
+
+    private data class StreamUpFileInfo(
+        val title: String,
+        val thumbnail: String,
+        @JsonProperty("streaming_url")
+        val streamingUrl: String,
+        // subtitles seems to always be empty
+        // val subtitles: List<Any>
+    )
+}

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -220,6 +220,7 @@ import com.lagradost.cloudstream3.extractors.Streamlare
 import com.lagradost.cloudstream3.extractors.StreamoUpload
 import com.lagradost.cloudstream3.extractors.Streamplay
 import com.lagradost.cloudstream3.extractors.Streamsss
+import com.lagradost.cloudstream3.extractors.Streamup
 import com.lagradost.cloudstream3.extractors.Streamwish2
 import com.lagradost.cloudstream3.extractors.Strwish
 import com.lagradost.cloudstream3.extractors.Strwish2
@@ -1105,6 +1106,7 @@ val extractorApis: MutableList<ExtractorApi> = arrayListOf(
     MoviehabNet(),
     Jeniusplay(),
     StreamoUpload(),
+    Streamup(),
 
     GamoVideo(),
     Gdriveplayerapi(),


### PR DESCRIPTION
- this extractor can be tested with the FilmPalast extension from https://github.com/Bnyro/GermanProviders
- I'm not sure if the API provides subtitles, but as far as I can see they're already included in the m3u8 anyways