### PR TITLE
"Play mirror" function on play context window.

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/EpisodeAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/EpisodeAdapter.kt
@@ -38,7 +38,7 @@ import java.util.Locale
  * @see VideoClickActionHolder
  */
 const val ACTION_PLAY_EPISODE_IN_PLAYER = 1
-
+const val ACTION_PLAY_MIRROR = 2
 const val ACTION_CHROME_CAST_EPISODE = 4
 const val ACTION_CHROME_CAST_MIRROR = 5
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -395,6 +395,7 @@
     <string name="episode_action_chromecast_mirror">Chromecast mirror</string>
     <string name="episode_action_cast_mirror">Cast mirror</string>
     <string name="episode_action_play_in_app">Play in app</string>
+    <string name="episode_action_play_mirror">Play mirror</string>"
     <string name="episode_action_play_in_format">Play in %s</string>
     <string name="episode_action_auto_download">Auto download</string>
     <string name="episode_action_download_mirror">Download mirror</string>


### PR DESCRIPTION
Added "Play mirror" function on context window when hold pressing play on any media (play mirror allows you to select a source before loading the media).

Function designed to address issue #1854