### PR TITLE
Add Android TV channel preview support with deep linking & batch insertion for optimization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("org.jetbrains.dokka")
-    id("kotlin-parcelize")
+
 }
 
 val javaTarget = JvmTarget.fromTarget(libs.versions.jvmTarget.get())
@@ -159,8 +159,6 @@ dependencies {
     androidTestImplementation(libs.espresso.core)
 
     // Android Core & Lifecycle
-    implementation("androidx.tvprovider:tvprovider:1.0.0")
-    implementation("com.google.code.gson:gson:2.10.1")
     implementation(libs.core.ktx)
     implementation(libs.appcompat)
     implementation(libs.bundles.navigationKtx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("org.jetbrains.dokka")
+    id("kotlin-parcelize")
 }
 
 val javaTarget = JvmTarget.fromTarget(libs.versions.jvmTarget.get())
@@ -158,6 +159,8 @@ dependencies {
     androidTestImplementation(libs.espresso.core)
 
     // Android Core & Lifecycle
+    implementation("androidx.tvprovider:tvprovider:1.0.0")
+    implementation("com.google.code.gson:gson:2.10.1")
     implementation(libs.core.ktx)
     implementation(libs.appcompat)
     implementation(libs.bundles.navigationKtx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" /> <!-- We can use this directly as CS3 is not on Play Store -->
     <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA" />  <!-- We can use to read the tv channel list -->
-    <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />  <!-- We can use this to write programs into the channel -->
     <!-- Required for OpenInAppAction and getting arbitrary Aniyomi packages  -->
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,15 +18,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" /> <!-- We can use this directly as CS3 is not on Play Store -->
-
-    <!--    start-->
-    <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA" />
-    <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
-    <uses-permission android:name="com.android.providers.tv.permission.WRITE_PREVIEW_DATA" />
-    <uses-permission android:name="com.android.providers.tv.permission.ACCESS_ALL_EPG_DATA" />
-    <uses-permission android:name="android.permission.READ_TV_LISTINGS" />
-    <!--    end-->
-
+    <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA" />  <!-- We can use to read the tv channel list -->
+    <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />  <!-- We can use this to write programs into the channel -->
     <!-- Required for OpenInAppAction and getting arbitrary Aniyomi packages  -->
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,14 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" /> <!-- We can use this directly as CS3 is not on Play Store -->
 
+    <!--    start-->
+    <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA" />
+    <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
+    <uses-permission android:name="com.android.providers.tv.permission.WRITE_PREVIEW_DATA" />
+    <uses-permission android:name="com.android.providers.tv.permission.ACCESS_ALL_EPG_DATA" />
+    <uses-permission android:name="android.permission.READ_TV_LISTINGS" />
+    <!--    end-->
+
     <!-- Required for OpenInAppAction and getting arbitrary Aniyomi packages  -->
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -76,6 +76,7 @@ import com.lagradost.cloudstream3.ui.account.AccountViewModel
 import com.lagradost.cloudstream3.utils.TvChannelUtils
 
 
+private const val TAG = "HomeFragment"
 
 class HomeFragment : Fragment() {
     companion object {
@@ -518,47 +519,47 @@ class HomeFragment : Fragment() {
 
 
 
-    private fun addMovies(cards: List<SearchResponse>) {
+     fun addMovies(cards: List<SearchResponse>) {
         val ctx = context ?: run {
-            Log.e("HomeFragment", "Context is null, aborting addMovies")
+            Log.e(TAG, "Context is null, aborting addMovies")
             return
         }
 
         try {
-            val existingId = TvChannelUtils().getChannelId(ctx, getString(R.string.app_name))
+            val existingId = TvChannelUtils.getChannelId(ctx, getString(R.string.app_name))
             if (existingId != null) {
-                Log.d("HomeFragment", "Channel ID: $existingId")
+                Log.d(TAG, "Channel ID: $existingId")
 
-                val programCards = cards.map { it.toImpl() }
+                val programCards = cards
 
-                TvChannelUtils().addPrograms(
+                TvChannelUtils.addPrograms(
                     context = ctx,
                     channelId = existingId,
                     items = programCards
                 )
             } else {
-                Log.d("HomeFragment", "Channel does not exist")
+                Log.d(TAG, "Channel does not exist")
             }
         } catch (e: Exception) {
-            Log.e("HomeFragment", "Error adding movies: $e")
+            Log.e(TAG, "Error adding movies: $e")
         }
     }
     private fun deleteAll() {
         val ctx = context ?: run {
-            Log.e("HomeFragment", "Context is null, aborting deleteAll")
+            Log.e(TAG, "Context is null, aborting deleteAll")
             return
         }
 
         try {
-            val existingId = TvChannelUtils().getChannelId(ctx, getString(R.string.app_name))
+            val existingId = TvChannelUtils.getChannelId(ctx, getString(R.string.app_name))
             if (existingId != null) {
-                Log.d("HomeFragment", "Channel ID: $existingId")
-                TvChannelUtils().deleteStoredPrograms(ctx)
+                Log.d(TAG, "Channel ID: $existingId")
+                TvChannelUtils.deleteStoredPrograms(ctx)
             } else {
-                Log.d("HomeFragment", "Channel does not exist")
+                Log.d(TAG, "Channel does not exist")
             }
         } catch (e: Exception) {
-            Log.e("HomeFragment", "Error deleting programs: ${e.message}")
+            Log.e(TAG, "Error deleting programs: ${e.message}")
         }
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -490,35 +490,6 @@ class HomeFragment : Fragment() {
     private val homeViewModel: HomeViewModel by activityViewModels()
     private val accountViewModel: AccountViewModel by activityViewModels()
 
-
-    data class SearchResponseImpl(
-        override val name: String,
-        override val url: String,
-        override val apiName: String,
-        override var type: TvType? = null,
-        override var posterUrl: String? = null,
-        override var posterHeaders: Map<String, String>? = null,
-        override var id: Int? = null,
-        override var quality: SearchQuality? = null,
-        override var score: Score? = null
-    ) : SearchResponse
-    fun SearchResponse.toImpl(): SearchResponseImpl {
-        return SearchResponseImpl(
-            name = name,
-            url = url,
-            apiName = apiName,
-            type = type,
-            posterUrl = posterUrl,
-            posterHeaders = posterHeaders,
-            id = id,
-            quality = quality,
-            score = score
-        )
-    }
-
-
-
-
      fun addMovies(cards: List<SearchResponse>) {
         val ctx = context ?: run {
             Log.e(TAG, "Context is null, aborting addMovies")

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/AppContextUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/AppContextUtils.kt
@@ -104,15 +104,8 @@ import androidx.tvprovider.media.tv.PreviewProgram
 import androidx.tvprovider.media.tv.TvContractCompat
 import com.lagradost.cloudstream3.SearchResponse
 import android.content.ContentUris
-import com.lagradost.cloudstream3.utils.DataStore.getStoredProgramIds
-import com.lagradost.cloudstream3.utils.DataStore.removeProgramId
-import com.lagradost.cloudstream3.utils.DataStore.saveProgramId
 import android.content.Intent
-import android.os.Parcelable
-import com.google.gson.Gson
-import com.lagradost.cloudstream3.MainActivity
-import com.lagradost.cloudstream3.ui.home.HomeFragment
-import kotlinx.parcelize.Parcelize
+
 
 
 
@@ -173,98 +166,6 @@ object AppContextUtils {
         }
     }
     /** Get channel ID by name */
-    fun getChannelId(context: Context, channelName: String): Long? {
-        return try {
-            context.contentResolver.query(
-                TvContractCompat.Channels.CONTENT_URI,
-                arrayOf(
-                    TvContractCompat.Channels._ID,
-                    TvContractCompat.Channels.COLUMN_DISPLAY_NAME
-                ),
-                null,
-                null,
-                null
-            )?.use { cursor ->
-                while (cursor.moveToNext()) {
-                    val id = cursor.getLong(
-                        cursor.getColumnIndexOrThrow(TvContractCompat.Channels._ID)
-                    )
-                    val name = cursor.getString(
-                        cursor.getColumnIndexOrThrow(TvContractCompat.Channels.COLUMN_DISPLAY_NAME)
-                    )
-                    if (name == channelName) return id
-                }
-                null
-            }
-        } catch (e: Exception) {
-            Log.e("TvChannelUtils", "Query failed: ${e.message}", e)
-            null
-        }
-    }
-
-    /** Insert programs into a channel */
-
-    fun addPrograms(context: Context, channelId: Long, items: List<HomeFragment.SearchResponseImpl>) {
-        for (item in items) {
-            try {
-                val intent = Intent(context, MainActivity::class.java).apply {
-                    action = Intent.ACTION_VIEW
-                    putExtra("OPEN_PROGRAM_DETAIL", true)
-                    val json = Gson().toJson(item)
-                    putExtra("PROGRAM_CARD_JSON", json)
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                }
-
-                val program = PreviewProgram.Builder()
-                    .setChannelId(channelId)
-                    .setTitle(item.name)
-                    .setDescription(item.apiName)
-                    .setType(TvContractCompat.PreviewPrograms.TYPE_CLIP)
-                    .setPosterArtUri(Uri.parse(item.posterUrl ?: ""))
-                    .setIntentUri(Uri.parse(intent.toUri(Intent.URI_INTENT_SCHEME)))
-                    .setPosterArtAspectRatio(TvContractCompat.PreviewPrograms.ASPECT_RATIO_2_3)
-                    .build()
-
-                val uri = context.contentResolver.insert(
-                    TvContractCompat.PreviewPrograms.CONTENT_URI,
-                    program.toContentValues()
-                )
-
-                if (uri != null) {
-                    val programId = ContentUris.parseId(uri)
-                    context.saveProgramId(programId)
-                    Log.d("TvChannelUtils", "Inserted program ${item.name}, ID=$programId")
-                } else {
-                    Log.e("TvChannelUtils", "Insert failed for ${item.name}")
-                }
-
-            } catch (error: Exception) {
-                Log.e("TvChannelUtils", "Error inserting ${item.name}: $error")
-            }
-        }
-    }
-
-    fun deleteStoredPrograms(context: Context) {
-        val programIds = context.getStoredProgramIds()
-
-        for (id in programIds) {
-            val uri = ContentUris.withAppendedId(TvContractCompat.PreviewPrograms.CONTENT_URI, id)
-            try {
-                val rowsDeleted = context.contentResolver.delete(uri, null, null)
-                if (rowsDeleted > 0) {
-                    Log.d("ProgramDelete", "Deleted program ID: $id")
-                    context.removeProgramId(id) // Remove from persistent list
-                } else {
-                    Log.w("ProgramDelete", "No program found for ID: $id")
-                }
-            } catch (e: Exception) {
-                Log.e("ProgramDelete", "Failed to delete program ID: $id", e)
-            }
-        }
-
-        Log.d("ProgramDelete", "Finished deleting stored programs")
-    }
-
     @SuppressLint("RestrictedApi")
     private fun buildWatchNextProgramUri(
         context: Context,

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/DataStore.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/DataStore.kt
@@ -20,7 +20,7 @@ const val DOWNLOAD_EPISODE_CACHE = "download_episode_cache"
 const val VIDEO_PLAYER_BRIGHTNESS = "video_player_alpha_key"
 const val USER_SELECTED_HOMEPAGE_API = "home_api_used"
 const val USER_PROVIDER_API = "user_custom_sites"
-
+const val PROGRAM_ID_LIST_KEY = "persistent_program_ids"
 const val PREFERENCES_NAME = "rebuild_preference"
 
 // TODO degelgate by value for get & set
@@ -93,6 +93,20 @@ object DataStore {
 
     fun Context.getSharedPrefs(): SharedPreferences {
         return getPreferences(this)
+    }
+
+    fun Context.saveProgramId(programId: Long) {
+        val existing: List<Long> = getKey(PROGRAM_ID_LIST_KEY) ?: emptyList()
+        val updated = existing + programId
+        setKey(PROGRAM_ID_LIST_KEY, updated)
+    }
+    fun Context.getStoredProgramIds(): List<Long> {
+        return getKey(PROGRAM_ID_LIST_KEY) ?: emptyList()
+    }
+    fun Context.removeProgramId(programId: Long) {
+        val existing: List<Long> = getKey(PROGRAM_ID_LIST_KEY) ?: emptyList()
+        val updated = existing.filter { it != programId }
+        setKey(PROGRAM_ID_LIST_KEY, updated)
     }
 
     fun getFolderName(folder: String, path: String): String {

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/DataStore.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/DataStore.kt
@@ -20,7 +20,6 @@ const val DOWNLOAD_EPISODE_CACHE = "download_episode_cache"
 const val VIDEO_PLAYER_BRIGHTNESS = "video_player_alpha_key"
 const val USER_SELECTED_HOMEPAGE_API = "home_api_used"
 const val USER_PROVIDER_API = "user_custom_sites"
-const val PROGRAM_ID_LIST_KEY = "persistent_program_ids"
 const val PREFERENCES_NAME = "rebuild_preference"
 
 // TODO degelgate by value for get & set
@@ -95,19 +94,6 @@ object DataStore {
         return getPreferences(this)
     }
 
-    fun Context.saveProgramId(programId: Long) {
-        val existing: List<Long> = getKey(PROGRAM_ID_LIST_KEY) ?: emptyList()
-        val updated = existing + programId
-        setKey(PROGRAM_ID_LIST_KEY, updated)
-    }
-    fun Context.getStoredProgramIds(): List<Long> {
-        return getKey(PROGRAM_ID_LIST_KEY) ?: emptyList()
-    }
-    fun Context.removeProgramId(programId: Long) {
-        val existing: List<Long> = getKey(PROGRAM_ID_LIST_KEY) ?: emptyList()
-        val updated = existing.filter { it != programId }
-        setKey(PROGRAM_ID_LIST_KEY, updated)
-    }
 
     fun getFolderName(folder: String, path: String): String {
         return "${folder}/${path}"

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/TvChannelUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/TvChannelUtils.kt
@@ -98,10 +98,7 @@ object TvChannelUtils {
                 if (!safePosterUrl.isNullOrBlank() && safePosterUrl.startsWith("http")) {
                     builder.setPosterArtUri(Uri.parse(safePosterUrl))
 
-                } else {
-
                 }
-
                 val program = builder.build()
 
                 val uri = context.contentResolver.insert(


### PR DESCRIPTION
Description:
This PR introduces a new Android TV Preview Channel integration that adds programs directly to the home screen and enables seamless navigation to the app’s detailed page when a program is clicked.

Changes include:

Created a CardData model annotated with https://github.com/parcelize to make program data Parcelable.

Updated TvChannelUtils.addProgram() to attach an IntentUri containing the full CardData.

Modified MainActivity to handle the incoming preview-program intent, extract the CardData, and invoke AppContextUtils.loadSearchResult() to display the detailed page.

Ensured existing channel creation and program addition utilities persist program IDs and handle cleanup correctly.

This feature enhances user engagement by allowing Android TV users to discover and launch specific content directly from the home screen’s recommendation channel.

This feature brings CloudStream closer to native Android TV behavior, allowing users to discover and launch content directly from the home screen. It improves visibility, engagement, and streamlines navigation.