### PR TITLE
No gradle cache on prerelease for now

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'adopt'
-        cache: gradle
+        # cache: gradle
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
I have a way to fix it but for now let's just remove it.