### PR TITLE
Readd gradle cache on prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'adopt'
-        # cache: gradle
+        cache: gradle
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
Now that all packages are up-to-date we should be able to readd this without any problem.