### PR TITLE
Make constructor for UpdatedMatroskaExtractor private

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/UpdatedMatroskaExtractor.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/UpdatedMatroskaExtractor.kt
@@ -69,7 +69,7 @@ import kotlin.math.min
 
 /** Extracts data from the Matroska and WebM container formats.  */
 @UnstableApi
-class UpdatedMatroskaExtractor internal constructor(
+class UpdatedMatroskaExtractor private constructor(
     private val reader: EbmlReader,
     flags: @Flags Int,
     subtitleParserFactory: SubtitleParser.Factory


### PR DESCRIPTION
`'internal' declaration exposes 'public/*package*/' type 'EbmlReader'. This will become an error in language version 2.4.`