### PR TITLE
Remove usage of deprecated unsafeCheckOpNoThrow

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
@@ -495,22 +495,13 @@ object UIHelper {
     fun Context.hasPIPPermission(): Boolean {
         val appOps =
             getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            appOps.unsafeCheckOpNoThrow(
-                AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
-                android.os.Process.myUid(),
-                packageName
-            ) == AppOpsManager.MODE_ALLOWED
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            @Suppress("DEPRECATION")
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             appOps.checkOpNoThrow(
                 AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
                 android.os.Process.myUid(),
                 packageName
             ) == AppOpsManager.MODE_ALLOWED
-        } else {
-            return true
-        }
+        } else true
     }
 
     fun hideKeyboard(view: View?) {


### PR DESCRIPTION
Seems that checkOpNoThrow was deprecated so we switched to unsafeCheckOpNoThrow, however now it seems it went back and deprecated unsafeCheckOpNoThrow which is now just a wrapper around checkOpNoThrow which is now undeprecated. I'm kinda lost at what happened there.