### PR TITLE
Remove backwards compatible constructors that have been deprecated for over a year

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -2136,20 +2136,7 @@ data class NextAiring(
     val episode: Int,
     val unixTime: Long,
     val season: Int? = null,
-) {
-    /**
-     * Secondary constructor for backwards compatibility without season.
-     *  TODO Remove this constructor after there is a new stable release and extensions are updated to support season.
-     */
-    constructor(
-        episode: Int,
-        unixTime: Long,
-    ) : this(
-        episode,
-        unixTime,
-        null
-    )
-}
+)
 
 /** Data class holds season info.
  * @param season To be mapped with episode season, not shown in UI if displaySeason is defined
@@ -2221,59 +2208,7 @@ constructor(
     override var backgroundPosterUrl: String? = null,
     override var contentRating: String? = null,
     override var uniqueUrl: String = url
-) : LoadResponse {
-    /**
-     * Secondary constructor for backwards compatibility without contentRating.
-     * Remove this constructor after there is a new stable release and extensions are updated to support contentRating.
-     */
-    @Suppress("DEPRECATION_ERROR")
-    @Deprecated(
-        "Use newTorrentLoadResponse method with contentRating included",
-        level = DeprecationLevel.ERROR
-    )
-    constructor(
-        name: String,
-        url: String,
-        apiName: String,
-        magnet: String?,
-        torrent: String?,
-        plot: String?,
-        type: TvType = TvType.Torrent,
-        posterUrl: String? = null,
-        year: Int? = null,
-        rating: Int? = null,
-        tags: List<String>? = null,
-        duration: Int? = null,
-        trailers: MutableList<TrailerData> = mutableListOf(),
-        recommendations: List<SearchResponse>? = null,
-        actors: List<ActorData>? = null,
-        comingSoon: Boolean = false,
-        syncData: MutableMap<String, String> = mutableMapOf(),
-        posterHeaders: Map<String, String>? = null,
-        backgroundPosterUrl: String? = null,
-    ) : this(
-        name,
-        url,
-        apiName,
-        magnet,
-        torrent,
-        plot,
-        type,
-        posterUrl,
-        year,
-        Score.fromOld(rating),
-        tags,
-        duration,
-        trailers,
-        recommendations,
-        actors,
-        comingSoon,
-        syncData,
-        posterHeaders,
-        backgroundPosterUrl,
-        null
-    )
-}
+) : LoadResponse
 
 suspend fun MainAPI.newTorrentLoadResponse(
     name: String,
@@ -2359,68 +2294,6 @@ constructor(
             }
         } + episode
     }
-
-    /**
-     * Secondary constructor for backwards compatibility without contentRating.
-     * Remove this constructor after there is a new stable release and extensions are updated to support contentRating.
-     */
-    @Suppress("DEPRECATION_ERROR")
-    @Deprecated(
-        "Use newAnimeLoadResponse method with contentRating included",
-        level = DeprecationLevel.ERROR
-    )
-    constructor(
-        engName: String? = null,
-        japName: String? = null,
-        name: String,
-        url: String,
-        apiName: String,
-        type: TvType,
-        posterUrl: String? = null,
-        year: Int? = null,
-        episodes: MutableMap<DubStatus, List<Episode>> = mutableMapOf(),
-        showStatus: ShowStatus? = null,
-        plot: String? = null,
-        tags: List<String>? = null,
-        synonyms: List<String>? = null,
-        rating: Int? = null,
-        duration: Int? = null,
-        trailers: MutableList<TrailerData> = mutableListOf(),
-        recommendations: List<SearchResponse>? = null,
-        actors: List<ActorData>? = null,
-        comingSoon: Boolean = false,
-        syncData: MutableMap<String, String> = mutableMapOf(),
-        posterHeaders: Map<String, String>? = null,
-        nextAiring: NextAiring? = null,
-        seasonNames: List<SeasonData>? = null,
-        backgroundPosterUrl: String? = null,
-    ) : this(
-        engName,
-        japName,
-        name,
-        url,
-        apiName,
-        type,
-        posterUrl,
-        year,
-        episodes,
-        showStatus,
-        plot,
-        tags,
-        synonyms,
-        Score.fromOld(rating),
-        duration,
-        trailers,
-        recommendations,
-        actors,
-        comingSoon,
-        syncData,
-        posterHeaders,
-        nextAiring,
-        seasonNames,
-        backgroundPosterUrl,
-        null
-    )
 }
 
 /**
@@ -2480,57 +2353,7 @@ constructor(
     override var backgroundPosterUrl: String? = null,
     override var contentRating: String? = null,
     override var uniqueUrl: String = url
-) : LoadResponse {
-    /**
-     * Secondary constructor for backwards compatibility without contentRating.
-     * Remove this constructor after there is a new stable release and extensions are updated to support contentRating.
-     */
-    @Suppress("DEPRECATION_ERROR")
-    @Deprecated(
-        "Use newLiveStreamLoadResponse method with contentRating included",
-        level = DeprecationLevel.ERROR
-    )
-    constructor(
-        name: String,
-        url: String,
-        apiName: String,
-        dataUrl: String,
-        posterUrl: String? = null,
-        year: Int? = null,
-        plot: String? = null,
-        type: TvType = TvType.Live,
-        rating: Int? = null,
-        tags: List<String>? = null,
-        duration: Int? = null,
-        trailers: MutableList<TrailerData> = mutableListOf(),
-        recommendations: List<SearchResponse>? = null,
-        actors: List<ActorData>? = null,
-        comingSoon: Boolean = false,
-        syncData: MutableMap<String, String> = mutableMapOf(),
-        posterHeaders: Map<String, String>? = null,
-        backgroundPosterUrl: String? = null,
-    ) : this(
-        name,
-        url,
-        apiName,
-        dataUrl,
-        posterUrl,
-        year,
-        plot,
-        type,
-        Score.fromOld(rating),
-        tags,
-        duration,
-        trailers,
-        recommendations,
-        actors,
-        comingSoon,
-        syncData,
-        posterHeaders,
-        backgroundPosterUrl,
-        null
-    )
-}
+) : LoadResponse
 
 suspend fun MainAPI.newLiveStreamLoadResponse(
     name: String,
@@ -2578,57 +2401,7 @@ constructor(
     override var backgroundPosterUrl: String? = null,
     override var contentRating: String? = null,
     override var uniqueUrl: String = url
-) : LoadResponse {
-    /**
-     * Secondary constructor for backwards compatibility without contentRating.
-     * Remove this constructor after there is a new stable release and extensions are updated to support contentRating.
-     */
-    @Suppress("DEPRECATION_ERROR")
-    @Deprecated(
-        "Use newMovieLoadResponse method with contentRating included",
-        level = DeprecationLevel.ERROR
-    )
-    constructor(
-        name: String,
-        url: String,
-        apiName: String,
-        type: TvType,
-        dataUrl: String,
-        posterUrl: String? = null,
-        year: Int? = null,
-        plot: String? = null,
-        rating: Int? = null,
-        tags: List<String>? = null,
-        duration: Int? = null,
-        trailers: MutableList<TrailerData> = mutableListOf(),
-        recommendations: List<SearchResponse>? = null,
-        actors: List<ActorData>? = null,
-        comingSoon: Boolean = false,
-        syncData: MutableMap<String, String> = mutableMapOf(),
-        posterHeaders: Map<String, String>? = null,
-        backgroundPosterUrl: String? = null,
-    ) : this(
-        name,
-        url,
-        apiName,
-        type,
-        dataUrl,
-        posterUrl,
-        year,
-        plot,
-        Score.fromOld(rating),
-        tags,
-        duration,
-        trailers,
-        recommendations,
-        actors,
-        comingSoon,
-        syncData,
-        posterHeaders,
-        backgroundPosterUrl,
-        null
-    )
-}
+) : LoadResponse
 
 suspend fun <T> MainAPI.newMovieLoadResponse(
     name: String,
@@ -2714,25 +2487,6 @@ constructor(
             this.score = Score.from(value, 100)
         }
         get() = score?.toInt(100)
-
-    /**
-     * Secondary constructor for backwards compatibility without runTime.
-     *  TODO Remove this constructor after there is a new stable release and extensions are updated to support runTime.
-     */
-    @Suppress("DEPRECATION_ERROR")
-    @Deprecated("Use newEpisode method", level = DeprecationLevel.ERROR)
-    constructor(
-        data: String,
-        name: String? = null,
-        season: Int? = null,
-        episode: Int? = null,
-        posterUrl: String? = null,
-        rating: Int? = null,
-        description: String? = null,
-        date: Long? = null,
-    ) : this(
-        data, name, season, episode, posterUrl, Score.fromOld(rating), description, date, null
-    )
 }
 
 fun Episode.addDate(date: String?, format: String = "yyyy-MM-dd") {
@@ -2848,62 +2602,6 @@ constructor(
             episodeSeason in 1..<season
         } + episode
     }
-
-    /**
-     * Secondary constructor for backwards compatibility without contentRating.
-     * Remove this constructor after there is a new stable release and extensions are updated to support contentRating.
-     */
-    @Suppress("DEPRECATION_ERROR")
-    @Deprecated(
-        "Use newTvSeriesLoadResponse method with contentRating included",
-        level = DeprecationLevel.ERROR
-    )
-    constructor(
-        name: String,
-        url: String,
-        apiName: String,
-        type: TvType,
-        episodes: List<Episode>,
-        posterUrl: String? = null,
-        year: Int? = null,
-        plot: String? = null,
-        showStatus: ShowStatus? = null,
-        rating: Int? = null,
-        tags: List<String>? = null,
-        duration: Int? = null,
-        trailers: MutableList<TrailerData> = mutableListOf(),
-        recommendations: List<SearchResponse>? = null,
-        actors: List<ActorData>? = null,
-        comingSoon: Boolean = false,
-        syncData: MutableMap<String, String> = mutableMapOf(),
-        posterHeaders: Map<String, String>? = null,
-        nextAiring: NextAiring? = null,
-        seasonNames: List<SeasonData>? = null,
-        backgroundPosterUrl: String? = null,
-    ) : this(
-        name,
-        url,
-        apiName,
-        type,
-        episodes,
-        posterUrl,
-        year,
-        plot,
-        showStatus,
-        Score.fromOld(rating),
-        tags,
-        duration,
-        trailers,
-        recommendations,
-        actors,
-        comingSoon,
-        syncData,
-        posterHeaders,
-        nextAiring,
-        seasonNames,
-        backgroundPosterUrl,
-        null
-    )
 }
 
 suspend fun MainAPI.newTvSeriesLoadResponse(


### PR DESCRIPTION
Now that we more or less force using the new* methods, removing some of these makes it much easier to maintain as well. This only removes those from over a year ago, most are from nearly 2 years ago.