### PR TITLE
Bump version to 4.6.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,7 +63,7 @@ android {
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = 67
-        versionName = "4.6.0"
+        versionName = "4.6.1"
 
         resValue("string", "app_version", "${defaultConfig.versionName}${versionNameSuffix ?: ""}")
         resValue("string", "commit_hash", getGitCommitHash())


### PR DESCRIPTION
Since we've had a major change with edge to edge, bumping the version could help know if it's related if an issue is created.