### PR TITLE
Upgrade to minSdk 23

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -181,9 +181,8 @@ dependencies {
     implementation(libs.core.ktx)
     implementation(libs.activity.ktx)
     implementation(libs.appcompat)
-    implementation(libs.bundles.navigationKtx)
-    implementation(libs.lifecycle.livedata.ktx)
-    implementation(libs.lifecycle.viewmodel.ktx)
+    implementation(libs.bundles.lifecycle)
+    implementation(libs.bundles.navigation)
 
     // Design & UI
     implementation(libs.preference.ktx)
@@ -192,20 +191,19 @@ dependencies {
     implementation(libs.swiperefreshlayout)
 
     // Coil Image Loading
-    implementation(libs.coil)
-    implementation(libs.coil.network.okhttp)
+    implementation(libs.bundles.coil)
 
     // Media 3 (ExoPlayer)
     implementation(libs.bundles.media3)
     implementation(libs.video)
 
+    // FFmpeg Decoding
+    implementation(libs.bundles.nextlib)
+
     // PlayBack
     implementation(libs.colorpicker) // Subtitle Color Picker
     implementation(libs.newpipeextractor) // For Trailers
     implementation(libs.juniversalchardet) // Subtitle Decoding
-
-    // FFmpeg Decoding
-    implementation(libs.bundles.nextlibMedia3)
 
     // UI Stuff
     implementation(libs.shimmer) // Shimmering Effect (Loading Skeleton)
@@ -230,7 +228,6 @@ dependencies {
     implementation(libs.torrentserver)
 
     // Downloading & Networking
-    implementation(libs.work.runtime)
     implementation(libs.work.runtime.ktx)
     implementation(libs.nicehttp) // HTTP Lib
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,8 +24,7 @@ junitVersion = "1.3.0"
 juniversalchardet = "2.5.0"
 kotlinGradlePlugin = "2.2.21"
 kotlinxCoroutinesCore = "1.10.2"
-lifecycleLivedataKtx = "2.9.4"
-lifecycleViewmodelKtx = "2.9.4"
+lifecycleKtx = "2.9.4"
 material = "1.14.0-alpha06"
 media3 = "1.8.0"
 navigationKtx = "2.9.6"
@@ -45,7 +44,6 @@ tmdbJava = "2.13.0"
 torrentserver = "7861970e038b35cd8c6918384e49caf26903e09e"
 tvprovider = "1.1.0"
 video = "1.0.0"
-workRuntime = "2.10.5"
 workRuntimeKtx = "2.10.5"
 
 jvmTarget = "1.8"
@@ -77,8 +75,8 @@ junit = { module = "junit:junit", version.ref = "junit" }
 junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junitKtx" }
 juniversalchardet = { module = "com.github.albfernandez:juniversalchardet", version.ref = "juniversalchardet" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleLivedataKtx" }
-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
+lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleKtx" }
+lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleKtx" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 media3-cast = { module = "androidx.media3:media3-cast", version.ref = "media3" }
 media3-common = { module = "androidx.media3:media3-common", version.ref = "media3" }
@@ -110,7 +108,6 @@ tmdb-java = { module = "com.uwetrottmann.tmdb2:tmdb-java", version.ref = "tmdbJa
 torrentserver = { module = "com.github.recloudstream:torrentserver", version.ref = "torrentserver" }
 tvprovider = { module = "androidx.tvprovider:tvprovider", version.ref = "tvprovider" }
 video = { module = "com.google.android.mediahome:video", version.ref = "video" }
-work-runtime = { module = "androidx.work:work-runtime", version.ref = "workRuntime" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 
 [plugins]
@@ -123,6 +120,8 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm" , version.ref = "kotlinGradlePlug
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlinGradlePlugin" }
 
 [bundles]
+coil = ["coil", "coil-network-okhttp"]
+lifecycle = ["lifecycle-livedata-ktx", "lifecycle-viewmodel-ktx"]
 media3 = ["media3-cast", "media3-common", "media3-container", "media3-datasource-cronet", "media3-datasource-okhttp", "media3-exoplayer", "media3-exoplayer-dash", "media3-exoplayer-hls", "media3-session", "media3-ui"]
-navigationKtx = ["navigation-fragment-ktx", "navigation-ui-ktx"]
-nextlibMedia3 = ["nextlib-media3ext", "nextlib-mediainfo"]
+navigation = ["navigation-fragment-ktx", "navigation-ui-ktx"]
+nextlib = ["nextlib-media3ext", "nextlib-mediainfo"]


### PR DESCRIPTION
Most major packages, including all androidx packages are now being upgraded to minSdk 23. This means we also need to upgrade now otherwise we will be stuck unable to continue upgrading at all. Additionally, there really isnt a need to keep supporting API 21 and API 22 (Both are only Android 5).

I understand there is hesitation, this is not immediately urgent anyway, but I am just putting out there. For the ease of confirming that is actually necessary, I have attached references here for releases and other things about the change. So far only `work` has a stable release with the change, however others will follow soon. This is also not an exhaustive list.

References:
* https://issuetracker.google.com/issues/380448311
* https://developer.android.com/jetpack/androidx/versions#version-table
* https://developer.android.com/jetpack/androidx/releases/activity#1.12.0-alpha06
* https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0-alpha02
* https://developer.android.com/jetpack/androidx/releases/media3#1.9.0-alpha01
* https://developer.android.com/jetpack/androidx/releases/work#2.11.0
* https://developer.android.com/jetpack/androidx/releases/biometric#1.4.0-alpha05


I have also only bumped the minSdk and set `useLegacyPackaging` here, and not removed any backwards compatible code for pre 23, that is because it will be done in a follow-up after this is determined whether we will do it and that doesn't any issues.

`useLegacyPackaging` was set because starting when targeting minSdk 23, it doesn't compress things by default causing the total base APK size to nearly double. The change was to improve app loading speed because when an app is loaded, it decompresses, but the trade was larger app size in return for faster start time. To maintain the same behavior I set that here. If we ever decide we want to utilize the new behavior we can remove it.

In my personal opinion (perhaps a bit less popular of an opinion), CloudStream3 should follow to use the same minSdk as androidx, if another package doesn't support it, we just don't upgrade unless we absolutely have to then we can figure out an alternative, but androidx packages (in particular media3 comes to mind which has already bumped to minSdk 23) often have very good bug fixes and are also needed for future targetSdk, which we can't just simply never bump.

I'm mostly creating this just to document a lot of this, its still up to whether or not this is merged and we go that route. But it has been asked in the past for a very good reason to bump minSdk and I believe being required to for core dependent packages is a fairly good reason to do so, which is why I am creating with documentation and references, etc...