### PR TITLE
Make fixSystemBarsPadding not accept a null View

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1262,19 +1262,21 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
             null
         }
 
-        fixSystemBarsPadding(
-            binding?.navView,
-            heightResId = R.dimen.nav_view_height,
-            padTop = false,
-            overlayCutout = false
-        )
+        binding?.apply {
+            fixSystemBarsPadding(
+                navView,
+                heightResId = R.dimen.nav_view_height,
+                padTop = false,
+                overlayCutout = false
+            )
 
-        fixSystemBarsPadding(
-            binding?.navRailView,
-            widthResId = R.dimen.nav_rail_view_width,
-            padRight = false,
-            padTop = false
-        )
+            fixSystemBarsPadding(
+                navRailView,
+                widthResId = R.dimen.nav_rail_view_width,
+                padRight = false,
+                padTop = false
+            )
+        }
 
         // overscan
         val padding = settingsManager.getInt(getString(R.string.overscan_key), 0).toPx

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
@@ -326,7 +326,7 @@ open class ResultFragmentPhone : FullScreenPlayer() {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        fixSystemBarsPadding(binding?.root)
+        view?.let { fixSystemBarsPadding(it) }
     }
 
     @SuppressLint("SetTextI18n")
@@ -334,7 +334,7 @@ open class ResultFragmentPhone : FullScreenPlayer() {
         super.onViewCreated(view, savedInstanceState)
 
         // ===== setup =====
-        fixSystemBarsPadding(binding?.root)
+        fixSystemBarsPadding(view)
         val storedData = getStoredData() ?: return
         activity?.window?.decorView?.clearFocus()
         activity?.loadCache()

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -143,11 +143,13 @@ class SettingsFragment : BaseFragment<MainSettingsBinding>(
         }
 
         fun Fragment.setSystemBarsPadding() {
-            fixSystemBarsPadding(
-                view,
-                padLeft = isLayout(TV or EMULATOR),
-                padBottom = isLandscape()
-            )
+            view?.let {
+                fixSystemBarsPadding(
+                    it,
+                    padLeft = isLayout(TV or EMULATOR),
+                    padBottom = isLandscape()
+                )
+            }
         }
 
         fun getFolderSize(dir: File): Long {

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
@@ -423,7 +423,7 @@ object UIHelper {
     }
 
     fun fixSystemBarsPadding(
-        v: View?,
+        v: View,
         @DimenRes heightResId: Int? = null,
         @DimenRes widthResId: Int? = null,
         padTop: Boolean = true,
@@ -432,8 +432,6 @@ object UIHelper {
         padRight: Boolean = true,
         overlayCutout: Boolean = true
     ) {
-        if (v == null) return
-
         // edge-to-edge is very buggy on earlier versions so we just
         // handle the status bar here instead.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {


### PR DESCRIPTION
Now that we use `BaseFragment` which uses this never being null, only a few null usages left, which we just make sure aren't null here. Being explicit and not accepting null makes it easier to know what type is being passed and debug any potential issues as well which is why I wrote `BaseFragment` to not accept nullable for `fixPadding`.