### PR TITLE
Fix entering PiP mode even when we shouldn't

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/CommonActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/CommonActivity.kt
@@ -313,6 +313,8 @@ object CommonActivity {
     }
 
     fun onUserLeaveHint(act: Activity?) {
+        // On Android 12 and later we use setAutoEnterEnabled() instead.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) return
         if (canEnterPipMode && canShowPipMode) {
             act?.enterPIPMode()
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
@@ -55,6 +55,7 @@ import com.lagradost.cloudstream3.utils.EpisodeSkip
 import com.lagradost.cloudstream3.utils.UIHelper
 import com.lagradost.cloudstream3.utils.UIHelper.hideSystemUI
 import com.lagradost.cloudstream3.utils.UIHelper.popCurrentPage
+import com.lagradost.cloudstream3.utils.UIHelper.shouldShowPIPMode
 import java.net.SocketTimeoutException
 
 enum class PlayerResize(@StringRes val nameRes: Int) {
@@ -196,7 +197,7 @@ abstract class AbstractPlayerFragment(
             activity?.let { act ->
                 PlayerPipHelper.updatePIPModeActions(
                     act,
-                    canEnterPipMode,
+                    act.shouldShowPIPMode(canEnterPipMode),
                     player.getAspectRatio()
                 )
             }


### PR DESCRIPTION
Because of `setAutoEnterEnabled(isPlaying)` in `PlayerPipHelper` we need to only set `isPlaying` if we can enter PiP, otherwise it will enter regardless of if `enterPictureInPictureMode` is actually called.

Fixes two issues:
1. PiP mode is activated for trailers
2. The PiP mode setting within CS3 has no affect

From my testing both were fixed with this.

`setAutoEnterEnabled` is also [much smoother](https://developer.android.com/develop/ui/views/picture-in-picture#smoother-transition) for modern devices using gesture navigation then `onUserLeaveHint` with `enterPictureInPictureMode` is as well. So I also added a check so the `onUserLeaveHint` version isn't triggered if using `setAutoEnterEnabled` so we aren't triggering both versions as we are now.

Fixes #1807