### PR TITLE
Remove onConfigurationChanged from ResultFragmentPhone

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Intent
 import android.content.res.ColorStateList
-import android.content.res.Configuration
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
@@ -322,11 +321,6 @@ open class ResultFragmentPhone : FullScreenPlayer() {
     private fun updateUI(id: Int?) {
         syncModel.updateUserData()
         viewModel.reloadEpisodes()
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        view?.let { fixSystemBarsPadding(it) }
     }
 
     @SuppressLint("SetTextI18n")


### PR DESCRIPTION
I just realized we don't need this one here. Because `fixSystemBarsPadding` is not orientation dependent here since there are no nav views. So rerunning on configuration change is unnecessary in this case. That was my bad here.