### PR TITLE
Rename fixPadding to fixLayout and expand usage

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/BaseFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/BaseFragment.kt
@@ -17,7 +17,6 @@ import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.ui.settings.SettingsFragment.Companion.setSystemBarsPadding
 import com.lagradost.cloudstream3.utils.txt
-import com.lagradost.cloudstream3.utils.UIHelper.fixSystemBarsPadding
 
 /**
  * A base Fragment class that simplifies ViewBinding usage and handles view inflation safely.
@@ -75,7 +74,7 @@ private interface BaseFragmentHelper<T : ViewBinding> {
      * Subclasses should use [onBindingCreated] instead of overriding this method directly.
      */
     fun onViewReady(view: View, savedInstanceState: Bundle?) {
-        fixPadding(view)
+        fixLayout(view)
         binding?.let { onBindingCreated(it, savedInstanceState) }
     }
 
@@ -110,16 +109,16 @@ private interface BaseFragmentHelper<T : ViewBinding> {
     fun pickLayout(): Int? = null
 
     /**
-     * Apply padding adjustments for system bars to the root view.
+     * Ensures the layout of the root view is correctly adjusted for the current configuration.
      *
-     * `fixPadding` should be idempotent in respect to the configuration, as the function may be
-     * called many times on the same view in case of configuration change like device orientation.
+     * This may include applying padding for system bars, adjusting insets, or performing other
+     * layout updates. `fixLayout` should remain idempotent, as it can be called multiple
+     * times on the same view, such as during configuration changes (e.g. device rotation) or when
+     * the view is recreated.
      *
      * @param view The root view to adjust.
      */
-    fun fixPadding(view: View) {
-        fixSystemBarsPadding(view)
-    }
+    fun fixLayout(view: View) {}
 }
 
 abstract class BaseFragment<T : ViewBinding>(
@@ -145,7 +144,7 @@ abstract class BaseFragment<T : ViewBinding>(
      */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        view?.let { fixPadding(it) }
+        view?.let { fixLayout(it) }
     }
 
     /** Cleans up the binding reference when the view is destroyed to avoid memory leaks. */
@@ -200,7 +199,7 @@ abstract class BaseDialogFragment<T : ViewBinding>(
     /** @see [BaseFragment.onConfigurationChanged] for documentation. */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        view?.let { fixPadding(it) }
+        view?.let { fixLayout(it) }
     }
 
     /** Cleans up the binding reference when the view is destroyed to avoid memory leaks. */
@@ -229,7 +228,7 @@ abstract class BaseBottomSheetDialogFragment<T : ViewBinding>(
     /** @see [BaseFragment.onConfigurationChanged] for documentation. */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        view?.let { fixPadding(it) }
+        view?.let { fixLayout(it) }
     }
 
     /** Cleans up the binding reference when the view is destroyed to avoid memory leaks. */

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/EasterEggMonkeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/EasterEggMonkeFragment.kt
@@ -46,10 +46,6 @@ class EasterEggMonkeFragment : BaseFragment<FragmentEasterEggMonkeBinding>(
     private val activeMonkeys = mutableListOf<ImageView>()
     private var spawningJob: Job? = null
 
-    override fun fixPadding(view: View) {
-        // Don't need any padding here
-    }
-
     override fun onBindingCreated(binding: FragmentEasterEggMonkeBinding) {
         activity?.hideSystemUI()
         spawningJob = lifecycleScope.launch {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/WebviewFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/WebviewFragment.kt
@@ -1,7 +1,6 @@
 package com.lagradost.cloudstream3.ui
 
 import android.os.Bundle
-import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -19,10 +18,6 @@ import com.lagradost.cloudstream3.utils.AppContextUtils.loadRepository
 class WebviewFragment : BaseFragment<FragmentWebviewBinding>(
     BaseFragment.BindingCreator.Inflate(FragmentWebviewBinding::inflate)
 ) {
-
-    override fun fixPadding(view: View) {
-        // Don't need any padding here
-    }
 
     override fun onBindingCreated(binding: FragmentWebviewBinding) {
         val url = arguments?.getString(WEBVIEW_URL) ?: "".also {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadChildFragment.kt
@@ -27,6 +27,7 @@ import com.lagradost.cloudstream3.utils.UIHelper.setAppBarNoScrollFlagsOnTV
 class DownloadChildFragment : BaseFragment<FragmentChildDownloadsBinding>(
     BaseFragment.BindingCreator.Inflate(FragmentChildDownloadsBinding::inflate)
 ) {
+
     private val downloadViewModel: DownloadViewModel by activityViewModels()
 
     companion object {
@@ -43,7 +44,7 @@ class DownloadChildFragment : BaseFragment<FragmentChildDownloadsBinding>(
         super.onDestroyView()
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(
             view,
             padBottom = isLandscape(),

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadFragment.kt
@@ -56,6 +56,7 @@ const val DOWNLOAD_NAVIGATE_TO = "downloadpage"
 class DownloadFragment : BaseFragment<FragmentDownloadsBinding>(
     BaseFragment.BindingCreator.Inflate(FragmentDownloadsBinding::inflate)
 ) {
+
     private val downloadViewModel: DownloadViewModel by activityViewModels()
 
     private fun View.setLayoutWidth(weight: Long) {
@@ -72,7 +73,7 @@ class DownloadFragment : BaseFragment<FragmentDownloadsBinding>(
         super.onDestroyView()
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(
             view,
             padBottom = isLandscape(),

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -5,7 +5,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -568,13 +567,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
         super.onDestroyView()
     }
 
-    private fun fixGrid() {
-        activity?.getSpanCount()?.let {
-            currentSpan = it
-        }
-        configEvent.invoke(currentSpan)
-    }
-
     private val apiChangeClickListener = View.OnClickListener { view ->
         view.context.selectHomepage(currentApiName) { api ->
             homeViewModel.loadAndCancel(api, forceReload = true, fromUI = true)
@@ -586,11 +578,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
         view.popupMenuNoIconsAndNoStringRes(validAPIs.mapIndexed { index, api -> Pair(index, api.name) }) {
             homeViewModel.loadAndCancel(validAPIs[itemId].name)
         }*/
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        fixGrid()
     }
 
     private var currentApiName: String? = null
@@ -621,20 +608,22 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
         }
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(
             view,
             padTop = false,
             padBottom = isLandscape(),
             padLeft = isLayout(TV or EMULATOR)
         )
+
+        // Fix grid
+        currentSpan = view.context.getSpanCount()
+        configEvent.invoke(currentSpan)
     }
 
     @SuppressLint("SetTextI18n")
     override fun onBindingCreated(binding: FragmentHomeBinding) {
-        fixGrid()
         context?.let { HomeChildItemAdapter.updatePosterSize(it) }
-
         binding.apply {
             //homeChangeApiLoading.setOnClickListener(apiChangeClickListener)
             //homeChangeApiLoading.setOnClickListener(apiChangeClickListener)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/LibraryFragment.kt
@@ -114,7 +114,7 @@ class LibraryFragment : BaseFragment<FragmentLibraryBinding>(
         } else binding.libraryRandom.isGone = true
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(
             view,
             padBottom = isLandscape(),
@@ -329,7 +329,7 @@ class LibraryFragment : BaseFragment<FragmentLibraryBinding>(
 
         val startLoading = Runnable {
             binding.apply {
-                gridview.numColumns = context?.getSpanCount() ?: 3
+                gridview.numColumns = root.context.getSpanCount()
                 gridview.adapter =
                     context?.let { LoadingPosterAdapter(it, 6 * 3) }
                 libraryLoadingOverlay.isVisible = true

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/ViewpagerAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/ViewpagerAdapter.kt
@@ -76,8 +76,7 @@ class ViewpagerAdapter(
 
         binding.pageRecyclerview.tag = position
         binding.pageRecyclerview.apply {
-            spanCount =
-                binding.root.context.getSpanCount() ?: 3
+            spanCount = binding.root.context.getSpanCount()
             if (adapter == null) { //  || rebind
                 // Only add the items after it has been attached since the items rely on ItemWidth
                 // Which is only determined after the recyclerview is attached.

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/quicksearch/QuickSearchFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/quicksearch/QuickSearchFragment.kt
@@ -2,7 +2,6 @@ package com.lagradost.cloudstream3.ui.quicksearch
 
 import android.app.Activity
 import android.content.Context
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -42,6 +41,7 @@ import com.lagradost.cloudstream3.utils.AppContextUtils.filterSearchResultByFilm
 import com.lagradost.cloudstream3.utils.AppContextUtils.isRecyclerScrollable
 import com.lagradost.cloudstream3.utils.AppContextUtils.ownShow
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
+import com.lagradost.cloudstream3.utils.UIHelper.fixSystemBarsPadding
 import com.lagradost.cloudstream3.utils.UIHelper.getSpanCount
 import com.lagradost.cloudstream3.utils.UIHelper.hideKeyboard
 import com.lagradost.cloudstream3.utils.UIHelper.navigate
@@ -92,6 +92,15 @@ class QuickSearchFragment : BaseFragment<QuickSearchBinding>(
 
     private var bottomSheetDialog: BottomSheetDialog? = null
 
+    override fun fixLayout(view: View) {
+        fixSystemBarsPadding(view)
+
+        // Fix grid
+        HomeFragment.currentSpan = view.context.getSpanCount()
+        binding?.quickSearchAutofitResults?.spanCount = HomeFragment.currentSpan
+        HomeFragment.configEvent.invoke(HomeFragment.currentSpan)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -124,21 +133,7 @@ class QuickSearchFragment : BaseFragment<QuickSearchBinding>(
         return false
     }
 
-    private fun fixGrid() {
-        activity?.getSpanCount()?.let {
-            HomeFragment.currentSpan = it
-        }
-        binding?.quickSearchAutofitResults?.spanCount = HomeFragment.currentSpan
-        HomeFragment.configEvent.invoke(HomeFragment.currentSpan)
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        fixGrid()
-    }
-
     override fun onBindingCreated(binding: QuickSearchBinding) {
-        fixGrid()
         arguments?.getStringArray(PROVIDER_KEY)?.let {
             providers = it.toSet()
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
@@ -247,7 +247,7 @@ class ResultFragmentTv : BaseFragment<FragmentResultTvBinding>(
         }
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(view, padTop = false)
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
@@ -3,7 +3,6 @@ package com.lagradost.cloudstream3.ui.search
 import android.app.Activity
 import android.content.Intent
 import android.content.DialogInterface
-import android.content.res.Configuration
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
 import android.os.Bundle
@@ -135,20 +134,6 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 
-    private fun fixGrid() {
-        activity?.getSpanCount()?.let {
-            currentSpan = it
-        }
-        binding?.searchAutofitResults?.spanCount = currentSpan
-        currentSpan = currentSpan
-        HomeFragment.configEvent.invoke(currentSpan)
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        fixGrid()
-    }
-
     override fun onDestroyView() {
         hideKeyboard()
         bottomSheetDialog?.ownHide()
@@ -225,21 +210,24 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(
         }
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(
             view,
             padBottom = isLandscape(),
             padLeft = isLayout(TV or EMULATOR)
         )
+
+        // Fix grid
+        currentSpan = view.context.getSpanCount()
+        binding?.searchAutofitResults?.spanCount = currentSpan
+        HomeFragment.configEvent.invoke(currentSpan)
     }
 
     override fun onBindingCreated(
         binding: FragmentSearchBinding,
         savedInstanceState: Bundle?
     ) {
-        fixGrid()
         reloadRepos()
-
         binding.apply {
             val adapter =
                 SearchAdapter(

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -167,7 +167,7 @@ class SettingsFragment : BaseFragment<MainSettingsBinding>(
         }
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(
             view,
             padBottom = isLandscape(),

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/ExtensionsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/ExtensionsFragment.kt
@@ -68,7 +68,7 @@ class ExtensionsFragment : BaseFragment<FragmentExtensionsBinding>(
         extensionViewModel.loadRepositories()
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         setSystemBarsPadding()
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginDetailsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginDetailsFragment.kt
@@ -45,7 +45,7 @@ class PluginDetailsFragment(val data: PluginViewData) : BaseBottomSheetDialogFra
         }
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(
             view,
             padBottom = isLandscape(),

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/PluginsFragment.kt
@@ -41,7 +41,7 @@ class PluginsFragment : BaseFragment<FragmentPluginsBinding>(
         super.onDestroyView()
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         setSystemBarsPadding()
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/testing/TestFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/testing/TestFragment.kt
@@ -20,7 +20,7 @@ class TestFragment : BaseFragment<FragmentTestingBinding>(
 
     private val testViewModel: TestViewModel by activityViewModels()
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         setSystemBarsPadding()
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentExtensions.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentExtensions.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3.ui.setup
 
 import android.os.Bundle
+import android.view.View
 import androidx.core.view.isVisible
 import androidx.navigation.fragment.findNavController
 import com.lagradost.cloudstream3.APIHolder.apis
@@ -14,6 +15,7 @@ import com.lagradost.cloudstream3.ui.BaseFragment
 import com.lagradost.cloudstream3.ui.settings.extensions.PluginsViewModel
 import com.lagradost.cloudstream3.ui.settings.extensions.RepoAdapter
 import com.lagradost.cloudstream3.utils.Coroutines.main
+import com.lagradost.cloudstream3.utils.UIHelper.fixSystemBarsPadding
 
 class SetupFragmentExtensions : BaseFragment<FragmentSetupExtensionsBinding>(
     BaseFragment.BindingCreator.Inflate(FragmentSetupExtensionsBinding::inflate)
@@ -39,6 +41,10 @@ class SetupFragmentExtensions : BaseFragment<FragmentSetupExtensionsBinding>(
     override fun onStop() {
         super.onStop()
         afterRepositoryLoadedEvent -= ::setRepositories
+    }
+
+    override fun fixLayout(view: View) {
+        fixSystemBarsPadding(view)
     }
 
     private fun setRepositories(success: Boolean = true) {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentLanguage.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentLanguage.kt
@@ -1,5 +1,6 @@
 package com.lagradost.cloudstream3.ui.setup
 
+import android.view.View
 import android.widget.AbsListView
 import android.widget.ArrayAdapter
 import androidx.core.content.ContextCompat
@@ -16,12 +17,18 @@ import com.lagradost.cloudstream3.ui.BaseFragment
 import com.lagradost.cloudstream3.ui.settings.appLanguages
 import com.lagradost.cloudstream3.ui.settings.getCurrentLocale
 import com.lagradost.cloudstream3.ui.settings.nameNextToFlagEmoji
+import com.lagradost.cloudstream3.utils.UIHelper.fixSystemBarsPadding
 
 const val HAS_DONE_SETUP_KEY = "HAS_DONE_SETUP"
 
 class SetupFragmentLanguage : BaseFragment<FragmentSetupLanguageBinding>(
     BaseFragment.BindingCreator.Inflate(FragmentSetupLanguageBinding::inflate)
 ) {
+
+    override fun fixLayout(view: View) {
+        fixSystemBarsPadding(view)
+    }
+
     override fun onBindingCreated(binding: FragmentSetupLanguageBinding) {
         // We don't want a crash for all users
         safe {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentLayout.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentLayout.kt
@@ -1,5 +1,6 @@
 package com.lagradost.cloudstream3.ui.setup
 
+import android.view.View
 import android.widget.AbsListView
 import android.widget.ArrayAdapter
 import androidx.navigation.fragment.findNavController
@@ -9,10 +10,16 @@ import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.databinding.FragmentSetupLayoutBinding
 import com.lagradost.cloudstream3.mvvm.safe
 import com.lagradost.cloudstream3.ui.BaseFragment
+import com.lagradost.cloudstream3.utils.UIHelper.fixSystemBarsPadding
 
 class SetupFragmentLayout : BaseFragment<FragmentSetupLayoutBinding>(
     BaseFragment.BindingCreator.Inflate(FragmentSetupLayoutBinding::inflate)
 ) {
+
+    override fun fixLayout(view: View) {
+        fixSystemBarsPadding(view)
+    }
+
     override fun onBindingCreated(binding: FragmentSetupLayoutBinding) {
         safe {
             val ctx = context ?: return@safe

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentMedia.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentMedia.kt
@@ -1,5 +1,6 @@
 package com.lagradost.cloudstream3.ui.setup
 
+import android.view.View
 import android.widget.AbsListView
 import android.widget.ArrayAdapter
 import androidx.core.util.forEach
@@ -11,10 +12,16 @@ import com.lagradost.cloudstream3.databinding.FragmentSetupMediaBinding
 import com.lagradost.cloudstream3.mvvm.safe
 import com.lagradost.cloudstream3.ui.BaseFragment
 import com.lagradost.cloudstream3.utils.DataStoreHelper
+import com.lagradost.cloudstream3.utils.UIHelper.fixSystemBarsPadding
 
 class SetupFragmentMedia : BaseFragment<FragmentSetupMediaBinding>(
     BaseFragment.BindingCreator.Inflate(FragmentSetupMediaBinding::inflate)
 ) {
+
+    override fun fixLayout(view: View) {
+        fixSystemBarsPadding(view)
+    }
+
     override fun onBindingCreated(binding: FragmentSetupMediaBinding) {
         safe {
             val ctx = context ?: return@safe

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentProviderLanguage.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/setup/SetupFragmentProviderLanguage.kt
@@ -1,5 +1,6 @@
 package com.lagradost.cloudstream3.ui.setup
 
+import android.view.View
 import android.widget.AbsListView
 import android.widget.ArrayAdapter
 import androidx.core.util.forEach
@@ -13,10 +14,16 @@ import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.ui.BaseFragment
 import com.lagradost.cloudstream3.utils.AppContextUtils.getApiProviderLangSettings
 import com.lagradost.cloudstream3.utils.SubtitleHelper.getNameNextToFlagEmoji
+import com.lagradost.cloudstream3.utils.UIHelper.fixSystemBarsPadding
 
 class SetupFragmentProviderLanguage : BaseFragment<FragmentSetupProviderLanguagesBinding>(
     BaseFragment.BindingCreator.Inflate(FragmentSetupProviderLanguagesBinding::inflate)
 ) {
+
+    override fun fixLayout(view: View) {
+        fixSystemBarsPadding(view)
+    }
+
     override fun onBindingCreated(binding: FragmentSetupProviderLanguagesBinding) {
         safe {
             val ctx = context ?: return@safe

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/ChromecastSubtitlesFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/ChromecastSubtitlesFragment.kt
@@ -151,7 +151,7 @@ class ChromecastSubtitlesFragment : BaseFragment<ChromecastSubtitleSettingsBindi
         onColorSelectedEvent -= ::onColorSelected
     }
 
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(
             view,
             padBottom = isLandscape(),

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/SubtitlesFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/SubtitlesFragment.kt
@@ -370,7 +370,7 @@ class SubtitlesFragment : BaseDialogFragment<SubtitleSettingsBinding>(
     }
 
     var systemBarsAddPadding = isLayout(TV or EMULATOR)
-    override fun fixPadding(view: View) {
+    override fun fixLayout(view: View) {
         fixSystemBarsPadding(
             view,
             padBottom = systemBarsAddPadding || isLandscape(),

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
@@ -202,17 +202,15 @@ object UIHelper {
         listView.requestLayout()
     }
 
-    fun Context?.getSpanCount(): Int? {
+    fun Context.getSpanCount(): Int {
         val compactView = false
         val spanCountLandscape = if (compactView) 2 else 6
         val spanCountPortrait = if (compactView) 1 else 3
-        val orientation = this?.resources?.configuration?.orientation ?: return null
+        val orientation = resources.configuration.orientation
 
         return if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
             spanCountLandscape
-        } else {
-            spanCountPortrait
-        }
+        } else spanCountPortrait
     }
 
     fun Fragment.hideKeyboard() {


### PR DESCRIPTION
This renames it to `fixLayout()` so that it can be used and still make sense for things beyond just `fixSystemBarsPadding()`. It merges `fixGrid()` into it in fragments that have that running both in `onBindingCreated()` and `onConfigurationChanged()`, and removes any default handling for padding so that if we don't want padding we don't have an empty override, and always override the method when we do want padding. Eventually I was thinking of requiring it be overridden still with errors when its not, unless a simple var is overridden like `override val needsPadding = false` to prevent potential bugs where this is accidentally forgotten on some fragment that needs it as well.