### PR TITLE
Fix setting summary

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
@@ -250,20 +250,20 @@ class SettingsPlayer : BasePreferenceFragmentCompat() {
         getPref(R.string.video_buffer_clear_key)?.let { pref ->
             val cacheDir = context?.cacheDir ?: return@let
 
-            fun updateSummery() {
+            fun updateSummary() {
                 try {
-                    pref.summary = formatShortFileSize(view?.context, getFolderSize(cacheDir))
+                    pref.summary = formatShortFileSize(pref.context, getFolderSize(cacheDir))
                 } catch (e: Exception) {
                     logError(e)
                 }
             }
 
-            updateSummery()
+            updateSummary()
 
             pref.setOnPreferenceClickListener {
                 try {
                     cacheDir.deleteRecursively()
-                    updateSummery()
+                    updateSummary()
                 } catch (e: Exception) {
                     logError(e)
                 }


### PR DESCRIPTION
Currently it only works after it is clicked, this fixes it to show the initial summary for bytes before clearing. I guess due to how the context is being accessed from view doesn't work initially, until clicked? I'm actually not certain why this works but it does for me.