### PR TITLE
Remove minor outdated APIs

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -1949,24 +1949,6 @@ interface LoadResponse {
             this.addSimklId(SimklSyncServices.Imdb, id)
         }
 
-        @Deprecated(
-            "Outdated API due to misspelling",
-            replaceWith = ReplaceWith("addTraktId(id)"),
-            level = DeprecationLevel.ERROR
-        )
-        fun LoadResponse.addTrackId(id: String?) {
-            this.addTraktId(id)
-        }
-
-        @Deprecated(
-            "Outdated API due to missing capitalization",
-            replaceWith = ReplaceWith("addKitsuId(id)"),
-            level = DeprecationLevel.ERROR
-        )
-        fun LoadResponse.addkitsuId(id: String?) {
-            this.addKitsuId(id)
-        }
-
         @Suppress("UNUSED_PARAMETER")
         fun LoadResponse.addTraktId(id: String?) {
             // TODO add Trakt sync


### PR DESCRIPTION
* Deprecated for awhile
* Extremely easy to fix (IDE can do it automatically)
* Not even really implemented or functional methods
* Extensions that do still use them are likely broken in other ways at this point due to being mostly unmaintained in that case