### PR TITLE
Use hidden password in add account input

### DIFF
--- a/app/src/main/res/layout/add_account_input.xml
+++ b/app/src/main/res/layout/add_account_input.xml
@@ -96,7 +96,7 @@
             android:layout_height="wrap_content"
             android:autofillHints="password"
             android:hint="@string/example_password"
-            android:inputType="textVisiblePassword"
+            android:inputType="textPassword"
             android:nextFocusLeft="@id/apply_btt"
 
             android:nextFocusRight="@id/cancel_btt"


### PR DESCRIPTION
Passwords probably shouldn't be visible by default.

If there is a reason it is though, this can just be closed.