### PR TITLE
Use internal modifier rather than method name

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -88,7 +88,7 @@ import com.lagradost.cloudstream3.mvvm.observe
 import com.lagradost.cloudstream3.mvvm.observeNullable
 import com.lagradost.cloudstream3.network.initClient
 import com.lagradost.cloudstream3.plugins.PluginManager
-import com.lagradost.cloudstream3.plugins.PluginManager.___DO_NOT_CALL_FROM_A_PLUGIN_loadAllOnlinePlugins
+import com.lagradost.cloudstream3.plugins.PluginManager.loadAllOnlinePlugins
 import com.lagradost.cloudstream3.plugins.PluginManager.loadSinglePlugin
 import com.lagradost.cloudstream3.receivers.VideoDownloadRestartReceiver
 import com.lagradost.cloudstream3.services.SubscriptionWorkManager
@@ -265,8 +265,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
         /**
          * @return true if the str has launched an app task (be it successful or not)
          * @param isWebview does not handle providers and opening download page if true. Can still add repos and login.
-         * */
-        @Suppress("DEPRECATION_ERROR")
+         */
         fun handleAppIntentUrl(
             activity: FragmentActivity?,
             str: String?,
@@ -318,7 +317,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                         // https://github.com/recloudstream/gradle/blob/master/src/main/kotlin/com/lagradost/cloudstream3/gradle/tasks/DeployWithAdbTask.kt#L46
                         if (str == "$APP_STRING:") {
                             ioSafe {
-                                PluginManager.___DO_NOT_CALL_FROM_A_PLUGIN_hotReloadAllLocalPlugins(
+                                PluginManager.hotReloadAllLocalPlugins(
                                     activity
                                 )
                             }
@@ -1157,7 +1156,6 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
         }
     }
 
-    @Suppress("DEPRECATION_ERROR")
     override fun onCreate(savedInstanceState: Bundle?) {
         app.initClient(this)
         val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
@@ -1340,11 +1338,11 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                             true
                         )
                     ) {
-                        PluginManager.___DO_NOT_CALL_FROM_A_PLUGIN_updateAllOnlinePluginsAndLoadThem(
+                        PluginManager.updateAllOnlinePluginsAndLoadThem(
                             this@MainActivity
                         )
                     } else {
-                        ___DO_NOT_CALL_FROM_A_PLUGIN_loadAllOnlinePlugins(this@MainActivity)
+                        loadAllOnlinePlugins(this@MainActivity)
                     }
 
                     //Automatically download not existing plugins, using mode specified.
@@ -1355,7 +1353,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                         )
                     ) ?: AutoDownloadMode.Disable
                     if (autoDownloadPlugin != AutoDownloadMode.Disable) {
-                        PluginManager.___DO_NOT_CALL_FROM_A_PLUGIN_downloadNotExistingPluginsAndLoad(
+                        PluginManager.downloadNotExistingPluginsAndLoad(
                             this@MainActivity,
                             autoDownloadPlugin
                         )
@@ -1363,7 +1361,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                 }
 
                 ioSafe {
-                    PluginManager.___DO_NOT_CALL_FROM_A_PLUGIN_loadAllLocalPlugins(
+                    PluginManager.loadAllLocalPlugins(
                         this@MainActivity,
                         false
                     )

--- a/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
@@ -258,18 +258,12 @@ object PluginManager {
      * DO NOT USE THIS IN A PLUGIN! It may case an infinite recursive loop lagging or crashing everyone's devices.
      * If you use it from a plugin, do not expect a stable jvmName, SO DO NOT USE IT!
      */
-    @Suppress("FunctionName", "DEPRECATION_ERROR")
-    @Deprecated(
-        "Calling this function from a plugin will lead to crashes, use loadPlugin and unloadPlugin",
-        replaceWith = ReplaceWith("loadPlugin"),
-        level = DeprecationLevel.ERROR
-    )
     @Throws
-    suspend fun ___DO_NOT_CALL_FROM_A_PLUGIN_updateAllOnlinePluginsAndLoadThem(activity: Activity) {
+    internal suspend fun updateAllOnlinePluginsAndLoadThem(activity: Activity) {
         assertNonRecursiveCallstack()
 
         // Load all plugins as fast as possible!
-        ___DO_NOT_CALL_FROM_A_PLUGIN_loadAllOnlinePlugins(activity)
+        loadAllOnlinePlugins(activity)
         afterPluginsLoadedEvent.invoke(false)
 
         val urls = (getKey<Array<RepositoryData>>(REPOSITORIES_KEY)
@@ -339,14 +333,8 @@ object PluginManager {
      * DO NOT USE THIS IN A PLUGIN! It may case an infinite recursive loop lagging or crashing everyone's devices.
      * If you use it from a plugin, do not expect a stable jvmName, SO DO NOT USE IT!
      */
-    @Suppress("FunctionName", "DEPRECATION_ERROR")
-    @Deprecated(
-        "Calling this function from a plugin will lead to crashes, use loadPlugin and unloadPlugin",
-        replaceWith = ReplaceWith("loadPlugin"),
-        level = DeprecationLevel.ERROR
-    )
     @Throws
-    suspend fun ___DO_NOT_CALL_FROM_A_PLUGIN_downloadNotExistingPluginsAndLoad(
+    internal suspend fun downloadNotExistingPluginsAndLoad(
         activity: Activity,
         mode: AutoDownloadMode
     ) {
@@ -453,14 +441,8 @@ object PluginManager {
      * DO NOT USE THIS IN A PLUGIN! It may case an infinite recursive loop lagging or crashing everyone's devices.
      * If you use it from a plugin, do not expect a stable jvmName, SO DO NOT USE IT!
      */
-    @Suppress("FunctionName", "DEPRECATION_ERROR")
-    @Deprecated(
-        "Calling this function from a plugin will lead to crashes, use loadPlugin and unloadPlugin",
-        replaceWith = ReplaceWith("loadPlugin"),
-        level = DeprecationLevel.ERROR
-    )
     @Throws
-    suspend fun ___DO_NOT_CALL_FROM_A_PLUGIN_loadAllOnlinePlugins(context: Context) {
+    internal suspend fun loadAllOnlinePlugins(context: Context) {
         assertNonRecursiveCallstack()
 
         // Load all plugins as fast as possible!
@@ -479,14 +461,8 @@ object PluginManager {
      * DO NOT USE THIS IN A PLUGIN! It may case an infinite recursive loop lagging or crashing everyone's devices.
      * If you use it from a plugin, do not expect a stable jvmName, SO DO NOT USE IT!
      */
-    @Suppress("FunctionName", "DEPRECATION_ERROR")
     @Throws
-    @Deprecated(
-        "Calling this function from a plugin will lead to crashes, use loadPlugin and unloadPlugin",
-        replaceWith = ReplaceWith("loadPlugin"),
-        level = DeprecationLevel.ERROR
-    )
-    suspend fun ___DO_NOT_CALL_FROM_A_PLUGIN_hotReloadAllLocalPlugins(activity: FragmentActivity?) {
+    internal suspend fun hotReloadAllLocalPlugins(activity: FragmentActivity?) {
         assertNonRecursiveCallstack()
 
         Log.d(TAG, "Reloading all local plugins!")
@@ -494,7 +470,7 @@ object PluginManager {
         getPluginsLocal().forEach {
             unloadPlugin(it.filePath)
         }
-        ___DO_NOT_CALL_FROM_A_PLUGIN_loadAllLocalPlugins(activity, true)
+        loadAllLocalPlugins(activity, true)
     }
 
     /**
@@ -504,14 +480,8 @@ object PluginManager {
      * DO NOT USE THIS IN A PLUGIN! It may case an infinite recursive loop lagging or crashing everyone's devices.
      * If you use it from a plugin, do not expect a stable jvmName, SO DO NOT USE IT!
      */
-    @Suppress("FunctionName", "DEPRECATION_ERROR")
-    @Deprecated(
-        "Calling this function from a plugin will lead to crashes, use loadPlugin and unloadPlugin",
-        replaceWith = ReplaceWith("loadPlugin"),
-        level = DeprecationLevel.ERROR
-    )
     @Throws
-    suspend fun ___DO_NOT_CALL_FROM_A_PLUGIN_loadAllLocalPlugins(context: Context, forceReload: Boolean) {
+    internal suspend fun loadAllLocalPlugins(context: Context, forceReload: Boolean) {
         assertNonRecursiveCallstack()
 
         val dir = File(LOCAL_PLUGINS_PATH)
@@ -808,19 +778,13 @@ object PluginManager {
      * DO NOT USE THIS IN A PLUGIN! It may case an infinite recursive loop lagging or crashing everyone's devices.
      * If you use it from a plugin, do not expect a stable jvmName, SO DO NOT USE IT!
      */
-    @Suppress("FunctionName", "DEPRECATION_ERROR")
     @Throws
-    @Deprecated(
-        "Calling this function from a plugin will lead to crashes, use loadPlugin and unloadPlugin",
-        replaceWith = ReplaceWith("loadPlugin"),
-        level = DeprecationLevel.ERROR
-    )
-    suspend fun ___DO_NOT_CALL_FROM_A_PLUGIN_manuallyReloadAndUpdatePlugins(activity: Activity) {
+    internal suspend fun manuallyReloadAndUpdatePlugins(activity: Activity) {
         assertNonRecursiveCallstack()
 
         showToast(activity.getString(R.string.starting_plugin_update_manually), Toast.LENGTH_LONG)
 
-        ___DO_NOT_CALL_FROM_A_PLUGIN_loadAllOnlinePlugins(activity)
+        loadAllOnlinePlugins(activity)
         afterPluginsLoadedEvent.invoke(false)
 
         val urls = (getKey<Array<RepositoryData>>(REPOSITORIES_KEY)

--- a/app/src/main/java/com/lagradost/cloudstream3/services/SubscriptionWorkManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/services/SubscriptionWorkManager.kt
@@ -97,7 +97,7 @@ class SubscriptionWorkManager(val context: Context, workerParams: WorkerParamete
                 .build()
         )
     }
-    @Suppress("DEPRECATION_ERROR")
+
     override suspend fun doWork(): Result {
         try {
 //        println("Update subscriptions!")
@@ -128,8 +128,8 @@ class SubscriptionWorkManager(val context: Context, workerParams: WorkerParamete
             updateProgress(max, progress, true)
 
             // We need all plugins loaded.
-            PluginManager.___DO_NOT_CALL_FROM_A_PLUGIN_loadAllOnlinePlugins(context)
-            PluginManager.___DO_NOT_CALL_FROM_A_PLUGIN_loadAllLocalPlugins(context, false)
+            PluginManager.loadAllOnlinePlugins(context)
+            PluginManager.loadAllLocalPlugins(context, false)
 
             subscriptions.amap { savedData ->
                 try {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
@@ -65,7 +65,6 @@ class SettingsUpdates : BasePreferenceFragmentCompat() {
         }
     }
 
-    @Suppress("DEPRECATION_ERROR")
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         hideKeyboard()
         setPreferencesFromResource(R.xml.settings_updates, rootKey)
@@ -257,7 +256,7 @@ class SettingsUpdates : BasePreferenceFragmentCompat() {
 
         getPref(R.string.manual_update_plugins_key)?.setOnPreferenceClickListener {
             ioSafe {
-                PluginManager.___DO_NOT_CALL_FROM_A_PLUGIN_manuallyReloadAndUpdatePlugins(activity ?: return@ioSafe)
+                PluginManager.manuallyReloadAndUpdatePlugins(activity ?: return@ioSafe)
             }
             return@setOnPreferenceClickListener true // Return true for the listener
         }


### PR DESCRIPTION
This means it can't be used in plugins, only the same gradle module. I'm unsure if this is wanted but thought I'd just put it out there. If you don't want it do feel free to just close this.

It doesn't seem like any plugin at all actually does use them anyway.

Also we shouldn't use `@Suppress("DEPRECATION_ERROR")` on entire large methods or we may suppress to much.