### PR TITLE
Fix one more build issue on future version of Kotlin

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/AStreamHub.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/AStreamHub.kt
@@ -15,11 +15,10 @@ open class AStreamHub : ExtractorApi() {
 
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink> {
         val sources = mutableListOf<ExtractorLink>()
-        app.get(url).document.selectFirst("body > script")?.let { script ->
-            val text = script.html()
-            Log.i("Dev", "text => $text")
-            if (text.isNotBlank()) {
-                val m3link = "(?<=file:)(.*)(?=,)".toRegex().find(text)
+        app.get(url).document.selectFirst("body > script")?.data()?.let { script ->
+            Log.i("Dev", "script => $script")
+            if (script.isNotBlank()) {
+                val m3link = "(?<=file:)(.*)(?=,)".toRegex().find(script)
                     ?.groupValues?.get(0)?.trim()?.trim('"') ?: ""
                 Log.i("Dev", "m3link => $m3link")
                 if (m3link.isNotBlank()) {
@@ -39,5 +38,4 @@ open class AStreamHub : ExtractorApi() {
         }
         return sources
     }
-
 }


### PR DESCRIPTION
It's a warning on Kotlin 2.3 and will be an error in 2.4:

`Type annotation class 'Nullable' of the inferred type is inaccessible. Check the module classpath for missing or conflicting dependencies. This will become an error in language version 2.4.`