### PR TITLE
Reset player hide delay when scrolling controls

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -943,7 +943,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
             if (!isCurrentTouchValid && isShowing && index == currentTapIndex && player.getIsPlaying()) {
                 onClickChange()
             }
-        }, 2000)
+        }, 3000)
     }
 
     // this is used because you don't want to hide UI when double tap seeking
@@ -1987,6 +1987,10 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
             // it is !not! a bug that you cant touch the right side, it does not register inputs on navbar or status bar
             playerHolder.setOnTouchListener { callView, event ->
                 return@setOnTouchListener handleMotionEvent(callView, event)
+            }
+
+            playerControlsScroll.setOnScrollChangeListener { _, _, _, _, _ ->
+                autoHide()
             }
 
             exoProgress.setOnTouchListener { _, event ->

--- a/app/src/main/res/layout/player_custom_layout.xml
+++ b/app/src/main/res/layout/player_custom_layout.xml
@@ -711,6 +711,7 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <HorizontalScrollView
+                    android:id="@+id/player_controls_scroll"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center">

--- a/app/src/main/res/layout/player_custom_layout_tv.xml
+++ b/app/src/main/res/layout/player_custom_layout_tv.xml
@@ -852,6 +852,7 @@
 
 
                 <HorizontalScrollView
+                    android:id="@+id/player_controls_scroll"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center">

--- a/app/src/main/res/layout/trailer_custom_layout.xml
+++ b/app/src/main/res/layout/trailer_custom_layout.xml
@@ -698,6 +698,7 @@
 
 
             <HorizontalScrollView
+                android:id="@+id/player_controls_scroll"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"


### PR DESCRIPTION
This also increases the delay time just a bit as before it seems it is to fast once scroll finishes if you don't think fast enough, however, I can remove that part if it isn't wanted.

Fixes #2173

Could also probably close #1755