### PR TITLE
Revert "Allow to enter PIP mode if buffering"

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
@@ -192,7 +192,7 @@ abstract class AbstractPlayerFragment(
             }
         }
 
-        canEnterPipMode = (isPlayingRightNow || isBuffering) && hasPipModeSupport
+        canEnterPipMode = isPlayingRightNow && hasPipModeSupport
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             activity?.let { act ->
                 PlayerPipHelper.updatePIPModeActions(


### PR DESCRIPTION
Reverts recloudstream/cloudstream#2199

I can't reproduce any issues with it but it seems to cause some issues where PIP is entered after exiting the player while its still loading then going to another app. Not sure why or why I can't reproduce but we can just revert this for now.