### PR TITLE
Don't remove trailing newlines in fix locales

### DIFF
--- a/.github/locales.py
+++ b/.github/locales.py
@@ -1,7 +1,6 @@
 import re
 import glob
 import requests
-import os
 import lxml.etree as ET  # builtin library doesn't preserve comments
 
 
@@ -62,8 +61,5 @@ for file in glob.glob(f"{XML_NAME}*/strings.xml"):
         with open(file, 'wb') as fp:
             fp.write(b'<?xml version="1.0" encoding="utf-8"?>\n')
             tree.write(fp, encoding="utf-8", method="xml", pretty_print=True, xml_declaration=False)
-            # Remove trailing new line to be consistent with weblate
-            fp.seek(-1, os.SEEK_END)
-            fp.truncate()
     except ET.ParseError as ex:
         print(f"[{file}] {ex}")


### PR DESCRIPTION
It seems that weblate actually does add newlines so "to be consistent" we shouldn't remove them. I'm not 100% sure if this just changed at some point or if we do actually want to remove them still.