### PR TITLE
Migrate `freeCompilerArgs` to new DSL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import org.jetbrains.dokka.gradle.engine.parameters.KotlinPlatform
 import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -272,11 +273,9 @@ tasks.register<Jar>("makeJar") {
 tasks.withType<KotlinJvmCompile> {
     compilerOptions {
         jvmTarget.set(javaTarget)
-        freeCompilerArgs.addAll(
-            "-Xjvm-default=all-compatibility",
-            "-Xannotation-default-target=param-property",
-            "-opt-in=com.lagradost.cloudstream3.Prerelease"
-        )
+        jvmDefault.set(JvmDefaultMode.ENABLE)
+        optIn.add("com.lagradost.cloudstream3.Prerelease")
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
 }
 


### PR DESCRIPTION
`jvmDefault.set(JvmDefaultMode.ENABLE)` is equivalent to `-jvm-default=enable`, which replaces `-Xjvm-default=all-compatibility` in Kotlin 2.2, it doesn't yet warn, but does in Kotlin 2.3.

https://youtrack.jetbrains.com/issue/KT-61649
https://youtrack.jetbrains.com/issue/KT-74590
https://youtrack.jetbrains.com/issue/KT-76353
https://kotlinlang.org/docs/gradle-compiler-options.html#migrate-freecompilerargs