### PR TITLE
Enable resValues in buildFeatures

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,6 +154,7 @@ android {
 
     buildFeatures {
         buildConfig = true
+        resValues = true
     }
 
     namespace = "com.lagradost.cloudstream3"


### PR DESCRIPTION
This will be required in AGP 9, but just to prepare for that, we can do it now. Only the default changed, this should have no effect on older AGP versions.