### PR TITLE
Refactor PluginManager: store plugins in private files dir

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
@@ -532,7 +532,7 @@ object PluginManager {
             // Clean up all existing plugins since the local plugins folder doesn't exist
             // This is required since the user might stop using local plugins but still have old
             // plugins lying around taking up space.
-            // These cannot be deleted without manually by the user without root access
+            // These cannot be deleted manually by the user without root access
             pluginDirectory.listFiles()?.forEach { it.delete() }
 
             // Since there are no local plugins, we can consider them loaded


### PR DESCRIPTION
This pull request updates the plugin storage directory to the app's private files directory, ensuring a clean state before loading plugins, and improving error handling when the plugins folder does not exist.

**Plugin directory management improvements:**

* Changed the plugin storage directory from the external files directory to the app's private files directory (`context.filesDir`) to avoid `SecurityException` when loading dex files.
* Cleaned up all non-existing plugins in the plugins directory by comparing them with the local plugins directory before loading new plugins to prevent stale plugins from persisting.
* If local plugin folder (in Internal Storage) does not exist, then do not create it and remove all local plugins currently installed.

**Error handling and plugin loading logic:**

* Improved handling when the local plugins folder does not exist by logging a message and marking plugins as loaded, instead of attempting to create the directory and logging a warning.
* Ensured that all local plugins are fully refreshed by removing the local plugins key before loading.

**Related Issues**

- Fixes #2076 