### PR TITLE
Add explicit dependsOn for copyJar

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -48,9 +48,7 @@ jobs:
         echo "key_pwd=$KEY_PWD" >> $GITHUB_OUTPUT
 
     - name: Run Gradle
-      run: |
-        ./gradlew assemblePrerelease build androidSourcesJar
-        ./gradlew makeJar # for classes.jar, has to be done after assemblePrerelease
+      run: ./gradlew assemblePrerelease build androidSourcesJar makeJar
       env:
         SIGNING_KEY_ALIAS: "key0"
         SIGNING_KEY_PASSWORD: ${{ steps.fetch_keystore.outputs.key_pwd }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -241,6 +241,7 @@ tasks.register<Jar>("androidSourcesJar") {
 }
 
 tasks.register<Copy>("copyJar") {
+    dependsOn("build", ":library:jvmJar")
     from(
         "build/intermediates/compile_app_classes_jar/prereleaseDebug/bundlePrereleaseDebugClassesToCompileJar",
         "../library/build/libs"


### PR DESCRIPTION
So we don't care about tbe run order of the tasks, it can just do it properly itself no matter what order it's ran in.