### PR TITLE
Clear home page adapter pools when reloading

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
@@ -501,6 +501,9 @@ class HomeViewModel : ViewModel() {
                 return@ioSafe
             }
 
+            HomeChildItemAdapter.sharedPool.clear()
+            ParentItemAdapter.sharedPool.clear()
+
             val api = getApiFromNameNull(preferredApiName)
             if (preferredApiName == noneApi.name) {
                 // just set to random


### PR DESCRIPTION
Sometimes old posters and items from a previous selected API remains shown after swirching in some items in the RecyclerViews. I could only ever reproduce this when switching accounts, but to be safe I think we should clear when reloading at all.