### PR TITLE
Disable MissingTranslation lint

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,6 +150,7 @@ android {
     lint {
         abortOnError = false
         checkReleaseBuilds = false
+        disable.add("MissingTranslation")
     }
 
     buildFeatures {


### PR DESCRIPTION
Translations are handled by weblate, so we don't really care about missing translations here.