### PR TITLE
Fix no poster showing wrong poster

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchResultBuilder.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchResultBuilder.kt
@@ -128,7 +128,7 @@ object SearchResultBuilder {
         cardText?.text = card.name
         cardText?.isVisible = showTitle
         cardView.isVisible = true
-        if (card.posterUrl != null) {
+        if (!card.posterUrl.isNullOrEmpty()) {
             cardView.loadImage(card.posterUrl, card.posterHeaders) {
                 error { getImageFromDrawable(itemView.context, R.drawable.default_cover) }
             }


### PR DESCRIPTION
This fixes a long time bug where items with no poster would use the wrong poster from some random item with a poster. This happened in all search fragments, and home fragment, and this seems to fix it in all places I've noticed it.