### PR TITLE
Add plot and score to `DownloadHeaderCached`

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultViewModel2.kt
@@ -716,6 +716,8 @@ class ResultViewModel2 : ViewModel() {
             currentHeaderName: String,
             currentType: TvType,
             currentPoster: String?,
+            currentPlot: String?,
+            currentScore: Score?,
             apiName: String,
             parentId: Int,
             url: String,
@@ -749,6 +751,8 @@ class ResultViewModel2 : ViewModel() {
                         type = currentType,
                         name = currentHeaderName,
                         poster = currentPoster,
+                        plot = currentPlot,
+                        score = currentScore,
                         id = parentId,
                         cacheTime = System.currentTimeMillis(),
                     )
@@ -808,13 +812,15 @@ class ResultViewModel2 : ViewModel() {
             }
         }
 
-        suspend fun downloadEpisode(
+        private suspend fun downloadEpisode(
             activity: Activity?,
             episode: ResultEpisode,
             currentIsMovie: Boolean,
             currentHeaderName: String,
             currentType: TvType,
             currentPoster: String?,
+            currentPlot: String?,
+            currentScore: Score?,
             apiName: String,
             parentId: Int,
             url: String,
@@ -859,6 +865,8 @@ class ResultViewModel2 : ViewModel() {
                     currentHeaderName,
                     currentType,
                     currentPoster,
+                    currentPlot,
+                    currentScore,
                     apiName,
                     parentId,
                     url,
@@ -1617,9 +1625,11 @@ class ResultViewModel2 : ViewModel() {
                     response.name,
                     response.type,
                     response.posterUrl,
+                    response.plot,
+                    response.score,
                     response.apiName,
                     response.getId(),
-                    response.url
+                    response.url,
                 )
             }
 
@@ -1638,6 +1648,8 @@ class ResultViewModel2 : ViewModel() {
                             response.name,
                             response.type,
                             response.posterUrl,
+                            response.plot,
+                            response.score,
                             response.apiName,
                             response.getId(),
                             response.url,
@@ -2813,6 +2825,8 @@ class ResultViewModel2 : ViewModel() {
                             type = loadResponse.type,
                             name = loadResponse.name,
                             poster = loadResponse.posterUrl,
+                            plot = loadResponse.plot,
+                            score = loadResponse.score,
                             id = mainId,
                             cacheTime = System.currentTimeMillis(),
                         )

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadHelper.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.utils
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.Score
 import com.lagradost.cloudstream3.TvType
+
 object VideoDownloadHelper {
     abstract class DownloadCached(
         @JsonProperty("id") open val id: Int,
@@ -40,6 +41,8 @@ object VideoDownloadHelper {
         @JsonProperty("type") val type: TvType,
         @JsonProperty("name") val name: String,
         @JsonProperty("poster") val poster: String?,
+        @JsonProperty("plot") val plot: String?,
+        @JsonProperty("score") val score: Score?,
         @JsonProperty("cacheTime") val cacheTime: Long,
         override val id: Int,
     ): DownloadCached(id)


### PR DESCRIPTION
In preparation for adding more details to download items, and to be the same as what `DownloadEpisodeCached` has.