### PR TITLE
Fix: match packed JavaScript with space

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -797,7 +797,7 @@ fun getQualityFromName(qualityName: String?): Int {
     }?.value ?: match.toIntOrNull() ?: Qualities.Unknown.value
 }
 
-private val packedRegex = Regex("""eval\(function\(p,a,c,k,e,.*\)\)""")
+private val packedRegex = Regex("""eval\(function\(p,\s*a,\s*c,\s*k,\s*e,.*\)""")
 fun getPacked(string: String): String? {
     return packedRegex.find(string)?.value
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/JsUnpacker.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/JsUnpacker.kt
@@ -15,7 +15,7 @@ class JsUnpacker(packedJS: String?) {
      */
     fun detect(): Boolean {
         val js = packedJS!!.replace(" ", "")
-        val p = Pattern.compile("eval\\(function\\(p,a,c,k,e,[rd]")
+        val p = Pattern.compile("""eval\(function\(p,\s*a,\s*c,\s*k,\s*e,.*\)""")
         val m = p.matcher(js)
         return m.find()
     }


### PR DESCRIPTION
Match packed JavaScript with spaces as in:
- `function(p, a, c, k, e, d)`
- `function(p,a,c,   k,  e,  r)`
...