### PR TITLE
Remove `BuildConfig.BETA`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,7 +121,6 @@ android {
         create("prerelease") {
             dimension = "state"
             resValue("bool", "is_prerelease", "true")
-            buildConfigField("boolean", "BETA", "true")
             applicationIdSuffix = ".prerelease"
             if (signingConfigs.names.contains("prerelease")) {
                 signingConfig = signingConfigs.getByName("prerelease")


### PR DESCRIPTION
It's unused, inaccurate (since this would also apply to `DEBUG`), and can be accessed with `BuildConfig.FLAVOR == "prerelease"`, which can differentiate from debug as well.