### PR TITLE
Move app version to BuildConfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,6 @@ android {
         versionCode = 67
         versionName = "4.6.1"
 
-        resValue("string", "app_version", "${defaultConfig.versionName}${versionNameSuffix ?: ""}")
         resValue("string", "commit_hash", getGitCommitHash())
         resValue("bool", "is_prerelease", "false")
 
@@ -78,6 +77,11 @@ android {
             "long",
             "BUILD_DATE",
             "${System.currentTimeMillis()}"
+        )
+        buildConfigField(
+            "String",
+            "APP_VERSION",
+            "\"$versionName\""
         )
         buildConfigField(
             "String",
@@ -129,6 +133,11 @@ android {
                 logger.warn("No prerelease signing config!")
             }
             versionNameSuffix = "-PRE"
+            buildConfigField(
+                "String",
+                "APP_VERSION",
+                "\"${defaultConfig.versionName}$versionNameSuffix\""
+            )
             versionCode = (System.currentTimeMillis() / 60000).toInt()
         }
     }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -246,13 +246,14 @@ class SettingsFragment : BaseFragment<MainSettingsBinding>(
             }
         }
 
-        val appVersion = getString(R.string.app_version)
+        val appVersion = BuildConfig.APP_VERSION
         val commitInfo = getString(R.string.commit_hash)
         val buildTimestamp = SimpleDateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG,
             Locale.getDefault()
         ).apply { timeZone = TimeZone.getTimeZone("UTC")
         }.format(Date(BuildConfig.BUILD_DATE)).replace("UTC", "")
 
+        binding.appVersion.text = appVersion
         binding.buildDate.text = buildTimestamp
         binding.appVersionInfo.setOnLongClickListener {
             clipboardHelper(txt(R.string.extension_version), "$appVersion $commitInfo $buildTimestamp")

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
@@ -9,6 +9,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.lagradost.cloudstream3.AutoDownloadMode
+import com.lagradost.cloudstream3.BuildConfig
 import com.lagradost.cloudstream3.CloudStreamApp
 import com.lagradost.cloudstream3.CommonActivity.showToast
 import com.lagradost.cloudstream3.R
@@ -221,18 +222,21 @@ class SettingsUpdates : BasePreferenceFragmentCompat() {
             return@setOnPreferenceClickListener true
         }
 
-        getPref(R.string.manual_check_update_key)?.setOnPreferenceClickListener {
-            ioSafe {
-                if (activity?.runAutoUpdate(false) == false) {
-                    activity?.runOnUiThread {
-                        showToast(
-                            R.string.no_update_found,
-                            Toast.LENGTH_SHORT
-                        )
+        getPref(R.string.manual_check_update_key)?.let { pref ->
+            pref.summary = BuildConfig.APP_VERSION
+            pref.setOnPreferenceClickListener {
+                ioSafe {
+                    if (activity?.runAutoUpdate(false) == false) {
+                        activity?.runOnUiThread {
+                            showToast(
+                                R.string.no_update_found,
+                                Toast.LENGTH_SHORT
+                            )
+                        }
                     }
                 }
+                return@setOnPreferenceClickListener true
             }
-            return@setOnPreferenceClickListener true
         }
 
         getPref(R.string.auto_download_plugins_key)?.setOnPreferenceClickListener {

--- a/app/src/main/res/layout/main_settings.xml
+++ b/app/src/main/res/layout/main_settings.xml
@@ -115,12 +115,12 @@
                 android:orientation="horizontal">
 
                 <TextView
-                    android:id="@+id/version_info"
+                    android:id="@+id/app_version"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:padding="10dp"
-                    android:text="@string/app_version"
-                    android:textColor="?attr/textColor" />
+                    android:textColor="?attr/textColor"
+                    tools:text="0.0.0" />
 
                 <TextView
                     android:id="@+id/delimiter0"

--- a/app/src/main/res/xml/settings_updates.xml
+++ b/app/src/main/res/xml/settings_updates.xml
@@ -7,8 +7,7 @@
         <Preference
             android:title="@string/check_for_update"
             app:icon="@drawable/ic_baseline_system_update_24"
-            app:key="@string/manual_check_update_key"
-            app:summary="@string/app_version" />
+            app:key="@string/manual_check_update_key" />
         <SwitchPreference
             android:icon="@drawable/ic_baseline_developer_mode_24"
             android:summary="@string/uprereleases_settings_des"


### PR DESCRIPTION
Also, the intent seems to be to be to set the version to `-PRE` when in pre release, which doesn't currently work, but this fixes that. If that isn't the desired behavior that part can be removed though.