### PR TITLE
Fix compiling library with debug flag

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -56,7 +56,7 @@ buildkonfig {
     exposeObjectWithName = "BuildConfig"
 
     defaultConfigs {
-        val isDebug = kotlin.runCatching { extra.get("isDebug") }.getOrNull() == true
+        val isDebug = kotlin.runCatching { project.extra.get("isDebug") }.getOrNull() == true
         if (isDebug) {
             logger.quiet("Compiling library with debug flag")
         } else {


### PR DESCRIPTION
I'm not even sure if this is necessary for the library to even have a debug flag as no one noticed anything different, but at current it never works to compile as debug and always uses release.