### PR TITLE
Use temurin distribution for setup-java action

### DIFF
--- a/.github/workflows/build_to_archive.yml
+++ b/.github/workflows/build_to_archive.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:
+        distribution: temurin
         java-version: 17
-        distribution: adopt
         cache: gradle
 
     - name: Grant execute permission for gradlew

--- a/.github/workflows/generate_dokka.yml
+++ b/.github/workflows/generate_dokka.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
+          distribution: temurin
           java-version: 17
-          distribution: adopt
           cache: gradle
 
       - name: Set up Android SDK

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:
+        distribution: temurin
         java-version: 17
-        distribution: adopt
         cache: gradle
 
     - name: Grant execute permission for gradlew

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,8 +11,8 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:
+        distribution: temurin
         java-version: 17
-        distribution: adopt
         cache: gradle
 
     - name: Grant execute permission for gradlew


### PR DESCRIPTION
Per the note on the README for `actions/setup-java`: "AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` and `adopt-openj9`, to `temurin` and `semeru` respectively, to keep receiving software and security updates."