### PR TITLE
Cleanup InAppUpdater

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
@@ -4,32 +4,34 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.text.TextUtils
 import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.lagradost.cloudstream3.*
+import com.lagradost.cloudstream3.BuildConfig
 import com.lagradost.cloudstream3.CommonActivity.showToast
+import com.lagradost.cloudstream3.MainActivity.Companion.deleteFileOnExit
+import com.lagradost.cloudstream3.R
+import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.mvvm.logError
+import com.lagradost.cloudstream3.services.PackageInstallerService
+import com.lagradost.cloudstream3.utils.AppContextUtils.setDefaultFocus
 import com.lagradost.cloudstream3.utils.AppUtils.parseJson
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+import java.io.IOException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okio.BufferedSink
 import okio.buffer
 import okio.sink
-import java.io.File
-import android.text.TextUtils
-import com.lagradost.cloudstream3.MainActivity.Companion.deleteFileOnExit
-import com.lagradost.cloudstream3.services.PackageInstallerService
-import com.lagradost.cloudstream3.utils.AppContextUtils.setDefaultFocus
-import java.io.BufferedReader
-import java.io.IOException
-import java.io.InputStreamReader
-
 
 class InAppUpdater {
     companion object {
@@ -38,53 +40,51 @@ class InAppUpdater {
 
         private const val LOG_TAG = "InAppUpdater"
 
-        // === IN APP UPDATER ===
-        data class GithubAsset(
+        private data class GithubAsset(
             @JsonProperty("name") val name: String,
-            @JsonProperty("size") val size: Int, // Size bytes
-            @JsonProperty("browser_download_url") val browserDownloadUrl: String, // download link
+            @JsonProperty("size") val size: Int, // Size in bytes
+            @JsonProperty("browser_download_url") val browserDownloadUrl: String,
             @JsonProperty("content_type") val contentType: String, // application/vnd.android.package-archive
         )
 
-        data class GithubRelease(
+        private data class GithubRelease(
             @JsonProperty("tag_name") val tagName: String, // Version code
-            @JsonProperty("body") val body: String, // Desc
+            @JsonProperty("body") val body: String, // Description
             @JsonProperty("assets") val assets: List<GithubAsset>,
-            @JsonProperty("target_commitish") val targetCommitish: String, // branch
+            @JsonProperty("target_commitish") val targetCommitish: String, // Branch
             @JsonProperty("prerelease") val prerelease: Boolean,
-            @JsonProperty("node_id") val nodeId: String //Node Id
+            @JsonProperty("node_id") val nodeId: String,
         )
 
-        data class GithubObject(
-            @JsonProperty("sha") val sha: String, // sha 256 hash
-            @JsonProperty("type") val type: String, // object type
+        private data class GithubObject(
+            @JsonProperty("sha") val sha: String, // SHA-256 hash
+            @JsonProperty("type") val type: String,
             @JsonProperty("url") val url: String,
         )
 
-        data class GithubTag(
+        private data class GithubTag(
             @JsonProperty("object") val githubObject: GithubObject,
         )
 
-        data class Update(
+        private data class Update(
             @JsonProperty("shouldUpdate") val shouldUpdate: Boolean,
             @JsonProperty("updateURL") val updateURL: String?,
             @JsonProperty("updateVersion") val updateVersion: String?,
             @JsonProperty("changelog") val changelog: String?,
-            @JsonProperty("updateNodeId") val updateNodeId: String?
+            @JsonProperty("updateNodeId") val updateNodeId: String?,
         )
 
         private suspend fun Activity.getAppUpdate(): Update {
             return try {
                 val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
-                if (settingsManager.getBoolean(
+                if (
+                    settingsManager.getBoolean(
                         getString(R.string.prerelease_update_key),
                         resources.getBoolean(R.bool.is_prerelease)
                     )
                 ) {
                     getPreReleaseUpdate()
-                } else {
-                    getReleaseUpdate()
-                }
+                } else getReleaseUpdate()
             } catch (e: Exception) {
                 Log.e(LOG_TAG, Log.getStackTraceString(e))
                 Update(false, null, null, null, null)
@@ -94,56 +94,44 @@ class InAppUpdater {
         private suspend fun Activity.getReleaseUpdate(): Update {
             val url = "https://api.github.com/repos/$GITHUB_USER_NAME/$GITHUB_REPO/releases"
             val headers = mapOf("Accept" to "application/vnd.github.v3+json")
-            val response =
-                parseJson<List<GithubRelease>>(
-                    app.get(
-                        url,
-                        headers = headers
-                    ).text
-                )
+            val response = parseJson<List<GithubRelease>>(
+                app.get(url, headers = headers).text
+            )
 
             val versionRegex = Regex("""(.*?((\d+)\.(\d+)\.(\d+))\.apk)""")
             val versionRegexLocal = Regex("""(.*?((\d+)\.(\d+)\.(\d+)).*)""")
-            /*
-            val releases = response.map { it.assets }.flatten()
-                .filter { it.content_type == "application/vnd.android.package-archive" }
-            val found =
-                releases.sortedWith(compareBy {
-                    versionRegex.find(it.name)?.groupValues?.get(2)
-                }).toList().lastOrNull()*/
-            val foundList =
-                response.filter { rel ->
-                    !rel.prerelease
-                }.sortedWith(compareBy { release ->
-                    release.assets.firstOrNull { it.contentType == "application/vnd.android.package-archive" }?.name?.let { it1 ->
-                            versionRegex.find(
-                                it1
-                            )?.groupValues?.let {
-                                it[3].toInt() * 100_000_000 + it[4].toInt() * 10_000 + it[5].toInt()
-                            }
-                        }
-                }).toList()
+            val foundList = response.filter { rel ->
+                !rel.prerelease
+            }.sortedWith(compareBy { release ->
+                release.assets.firstOrNull { it.contentType == "application/vnd.android.package-archive" }?.name?.let { it1 ->
+                    versionRegex.find(
+                        it1
+                    )?.groupValues?.let {
+                        it[3].toInt() * 100_000_000 + it[4].toInt() * 10_000 + it[5].toInt()
+                    }
+                }
+            }).toList()
+
             val found = foundList.lastOrNull()
             val foundAsset = found?.assets?.getOrNull(0)
             val currentVersion = packageName?.let {
-                packageManager.getPackageInfo(
-                    it,
-                    0
-                )
+                packageManager.getPackageInfo(it, 0)
             }
 
             foundAsset?.name?.let { assetName ->
                 val foundVersion = versionRegex.find(assetName)
                 val shouldUpdate =
-                    if (foundAsset.browserDownloadUrl != "" && foundVersion != null) currentVersion?.versionName?.let { versionName ->
-                        versionRegexLocal.find(versionName)?.groupValues?.let {
-                            it[3].toInt() * 100_000_000 + it[4].toInt() * 10_000 + it[5].toInt()
-                        }
-                    }?.compareTo(
-                        foundVersion.groupValues.let {
-                            it[3].toInt() * 100_000_000 + it[4].toInt() * 10_000 + it[5].toInt()
-                        }
-                    )!! < 0 else false
+                    if (foundAsset.browserDownloadUrl != "" && foundVersion != null) {
+                        currentVersion?.versionName?.let { versionName ->
+                            versionRegexLocal.find(versionName)?.groupValues?.let {
+                                it[3].toInt() * 100_000_000 + it[4].toInt() * 10_000 + it[5].toInt()
+                            }
+                        }?.compareTo(
+                            foundVersion.groupValues.let {
+                                it[3].toInt() * 100_000_000 + it[4].toInt() * 10_000 + it[5].toInt()
+                            }
+                        )!! < 0
+                    } else false
                 return if (foundVersion != null) {
                     Update(
                         shouldUpdate,
@@ -152,56 +140,42 @@ class InAppUpdater {
                         found.body,
                         found.nodeId
                     )
-                } else {
-                    Update(false, null, null, null, null)
-                }
+                } else Update(false, null, null, null, null)
             }
+
             return Update(false, null, null, null, null)
         }
 
         private suspend fun Activity.getPreReleaseUpdate(): Update {
-            val tagUrl =
-                "https://api.github.com/repos/$GITHUB_USER_NAME/$GITHUB_REPO/git/ref/tags/pre-release"
+            val tagUrl = "https://api.github.com/repos/$GITHUB_USER_NAME/$GITHUB_REPO/git/ref/tags/pre-release"
             val releaseUrl = "https://api.github.com/repos/$GITHUB_USER_NAME/$GITHUB_REPO/releases"
             val headers = mapOf("Accept" to "application/vnd.github.v3+json")
-            val response =
-                parseJson<List<GithubRelease>>(app.get(releaseUrl, headers = headers).text)
+            val response = parseJson<List<GithubRelease>>(
+                app.get(releaseUrl, headers = headers).text
+            )
 
-            val found =
-                response.lastOrNull { rel ->
-                    rel.prerelease || rel.tagName == "pre-release"
-                }
+            val found = response.lastOrNull { rel ->
+                rel.prerelease || rel.tagName == "pre-release"
+            }
+
             val foundAsset = found?.assets?.filter { it ->
                 it.contentType == "application/vnd.android.package-archive"
             }?.getOrNull(0)
 
-            val tagResponse =
-                parseJson<GithubTag>(app.get(tagUrl, headers = headers).text)
-
-            Log.d(LOG_TAG, "Fetched GitHub tag: ${tagResponse.githubObject.sha.take(7)}")
-
-            val shouldUpdate =
-                (getString(R.string.commit_hash)
-                    .trim { c -> c.isWhitespace() }
-                    .take(7)
-                        !=
-                        tagResponse.githubObject.sha
-                            .trim { c -> c.isWhitespace() }
-                            .take(7))
-
             return if (foundAsset != null) {
+                val tagResponse = parseJson<GithubTag>(app.get(tagUrl, headers = headers).text)
+                val updateCommitHash = tagResponse.githubObject.sha.trim().take(7)
+                Log.d(LOG_TAG, "Fetched GitHub tag: $updateCommitHash")
+
                 Update(
-                    shouldUpdate,
+                    getString(R.string.commit_hash) != updateCommitHash,
                     foundAsset.browserDownloadUrl,
-                    tagResponse.githubObject.sha.take(10),
+                    updateCommitHash,
                     found.body,
                     found.nodeId
                 )
-            } else {
-                Update(false, null, null, null, null)
-            }
+            } else Update(false, null, null, null, null)
         }
-
 
         private val updateLock = Mutex()
 
@@ -214,9 +188,7 @@ class InAppUpdater {
                 // Delete all old updates
                 this.cacheDir.listFiles()?.filter {
                     it.name.startsWith(appUpdateName) && it.extension == appUpdateSuffix
-                }?.forEach {
-                    deleteFileOnExit(it)
-                }
+                }?.forEach { deleteFileOnExit(it) }
 
                 val downloadedFile = File.createTempFile(appUpdateName, ".$appUpdateSuffix")
                 val sink: BufferedSink = downloadedFile.sink().buffer()
@@ -226,8 +198,10 @@ class InAppUpdater {
                     sink.close()
                     openApk(this, Uri.fromFile(downloadedFile))
                 }
+
                 return true
             } catch (e: Exception) {
+                logError(e)
                 return false
             }
         }
@@ -255,23 +229,20 @@ class InAppUpdater {
 
         /**
          * @param checkAutoUpdate if the update check was launched automatically
-         **/
+         */
         suspend fun Activity.runAutoUpdate(checkAutoUpdate: Boolean = true): Boolean {
             val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
-
             if (!checkAutoUpdate || settingsManager.getBoolean(
                     getString(R.string.auto_update_key),
                     true
                 )
             ) {
                 val update = getAppUpdate()
-                if (
-                    update.shouldUpdate &&
-                        update.updateURL != null) {
-
+                if (update.shouldUpdate && update.updateURL != null) {
                     // Check if update should be skipped
-                    val updateNodeId =
-                        settingsManager.getString(getString(R.string.skip_update_key), "")
+                    val updateNodeId = settingsManager.getString(
+                        getString(R.string.skip_update_key), ""
+                    )
 
                     // Skips the update if its an automatic update and the update is skipped
                     // This allows updating manually
@@ -282,10 +253,7 @@ class InAppUpdater {
                     runOnUiThread {
                         try {
                             val currentVersion = packageName?.let {
-                                packageManager.getPackageInfo(
-                                    it,
-                                    0
-                                )
+                                packageManager.getPackageInfo(it, 0)
                             }
 
                             val builder = AlertDialog.Builder(this, R.style.AlertDialogCustom)
@@ -302,8 +270,6 @@ class InAppUpdater {
                             } // Sanitized because it looks cluttered
 
                             builder.setMessage(sanitizedChangelog)
-
-                            val context = this
                             builder.apply {
                                 setPositiveButton(R.string.update) { _, _ ->
                                     // Forcefully start any delayed installations
@@ -312,42 +278,45 @@ class InAppUpdater {
                                     showToast(R.string.download_started, Toast.LENGTH_LONG)
 
                                     // Check if the setting hasn't been changed
-                                    if (settingsManager.getInt(
+                                    if (
+                                        settingsManager.getInt(
                                             getString(R.string.apk_installer_key),
                                             -1
                                         ) == -1
                                     ) {
-                                        if (isMiUi()) // Set to legacy if using miui
-                                            settingsManager.edit()
-                                                .putInt(getString(R.string.apk_installer_key), 1)
-                                                .apply()
+                                        // Set to legacy installer if using MIUI
+                                        if (isMiUi()) {
+                                            settingsManager.edit {
+                                                putInt(getString(R.string.apk_installer_key), 1)
+                                            }
+                                        }
                                     }
 
-                                    val currentInstaller =
-                                        settingsManager.getInt(
-                                            getString(R.string.apk_installer_key),
-                                            0
-                                        )
+                                    val currentInstaller = settingsManager.getInt(
+                                        getString(R.string.apk_installer_key),
+                                        0
+                                    )
 
                                     when (currentInstaller) {
                                         // New method
                                         0 -> {
                                             val intent = PackageInstallerService.Companion.getIntent(
-                                                context,
+                                                this@runAutoUpdate,
                                                 update.updateURL
                                             )
-                                            ContextCompat.startForegroundService(context, intent)
+                                            ContextCompat.startForegroundService(this@runAutoUpdate, intent)
                                         }
                                         // Legacy
                                         1 -> {
                                             ioSafe {
-                                                if (!downloadUpdate(update.updateURL))
+                                                if (!downloadUpdate(update.updateURL)) {
                                                     runOnUiThread {
                                                         showToast(
                                                             R.string.download_failed,
                                                             Toast.LENGTH_LONG
                                                         )
                                                     }
+                                                }
                                             }
                                         }
                                     }
@@ -357,10 +326,12 @@ class InAppUpdater {
 
                                 if (checkAutoUpdate) {
                                     setNeutralButton(R.string.skip_update) { _, _ ->
-                                        settingsManager.edit().putString(
-                                            getString(R.string.skip_update_key),
-                                            update.updateNodeId ?: ""
-                                        ).apply()
+                                        settingsManager.edit {
+                                            putString(
+                                                getString(R.string.skip_update_key),
+                                                update.updateNodeId ?: ""
+                                            )
+                                        }
                                     }
                                 }
                             }
@@ -386,7 +357,7 @@ class InAppUpdater {
                 BufferedReader(InputStreamReader(p.inputStream), 1024).use {
                     it.readLine()
                 }
-            } catch (ex: IOException) {
+            } catch (_: IOException) {
                 null
             }
         }


### PR DESCRIPTION
The only functional change here is that the commit in the updater dialog was normalized to what it is everywhere else, meaning it is 7 not 10 characters now.

I also have another patch prepared to convert this entire class to an actual object rather than just a class with only a companion object but since that touches every single line due to indentation changes, I decided to split it in order to make it easier to review.