### PR TITLE
Remove "Too short playback" error

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -557,6 +557,7 @@ abstract class MainAPI {
      * */
     open val loadTimeoutMs: Long? = null
 
+
     /**
      * A set of which ids the provider can open with getLoadUrl()
      * If the set contains SyncIdName.Imdb then getLoadUrl() can be started with


### PR DESCRIPTION
Per https://github.com/recloudstream/cloudstream/issues/2218#issuecomment-3537293235 this was added for a certain provider a long time ago, however with some providers such as Invidious, Dailymotion, and Internet Archive, there may often be videos shorter than 20 seconds. This just removes the error entirely as it's no longer necessary and if a certain provider needs to do this, they can handle it a different way.

Fixes #2218 