### PR TITLE
Download selection fix + sub del fix + Del dialog fix

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/VideoDownloadManager.kt
@@ -1628,7 +1628,7 @@ object VideoDownloadManager {
      * Turns a string to an UniFile. Used for stored string paths such as settings.
      * Should only be used to get a download path.
      * */
-    private fun basePathToFile(context: Context, path: String?): SafeFile? {
+    fun basePathToFile(context: Context, path: String?): SafeFile? {
         return when {
             path.isNullOrBlank() -> getDefaultDir(context)
             path.startsWith("content://") -> SafeFile.fromUri(context, path.toUri())


### PR DESCRIPTION
After some discussion with @Luna712 I decided to fix some minor issues with the old code.

1. Now subtitles are deleted properly using the correct SafeFile api
2. Now delete sections on episodes + movies act way more consistent as the state of "isSelectingItemsRightNow" is now coupled with the type (eg, null = not in selection, empty = no items selected, {a,b,c} = selected a, b and c). I also cleaned up the code around that part too. 
3. Fixed a minor issue with the delete dialog to prevent "delete null?" by reordering the when stmt.   

Yall are free to test it out, but I will probs merge it soon. 