### PR TITLE
Cleanup UnstableApi usage

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/WebviewFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/WebviewFragment.kt
@@ -6,9 +6,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.annotation.OptIn
 import androidx.fragment.app.FragmentActivity
-import androidx.media3.common.util.UnstableApi
 import androidx.navigation.fragment.findNavController
 import com.lagradost.cloudstream3.MainActivity
 import com.lagradost.cloudstream3.USER_AGENT
@@ -28,7 +26,6 @@ class WebviewFragment : BaseFragment<FragmentWebviewBinding>(
         }
 
         binding.webView.webViewClient = object : WebViewClient() {
-            @OptIn(UnstableApi::class)
             override fun shouldOverrideUrlLoading(
                 view: WebView?,
                 request: WebResourceRequest?
@@ -43,6 +40,7 @@ class WebviewFragment : BaseFragment<FragmentWebviewBinding>(
                 return super.shouldOverrideUrlLoading(view, request)
             }
         }
+
         binding.webView.apply {
             WebViewResolver.webViewUserAgent = settings.userAgentString
 
@@ -53,7 +51,6 @@ class WebviewFragment : BaseFragment<FragmentWebviewBinding>(
 
             loadUrl(url)
         }
-
     }
 
     companion object {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
@@ -20,11 +20,13 @@ import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.annotation.LayoutRes
+import androidx.annotation.OptIn
 import androidx.annotation.StringRes
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.media3.common.PlaybackException
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession
 import androidx.media3.ui.AspectRatioFrameLayout
@@ -74,6 +76,7 @@ const val NEXT_WATCH_EPISODE_PERCENTAGE = 90
 // when the player should sync the progress of "watched", TODO MAKE SETTING
 const val UPDATE_SYNC_PROGRESS_PERCENTAGE = 80
 
+@OptIn(UnstableApi::class)
 abstract class AbstractPlayerFragment(
     var player: IPlayer = CS3IPlayer()
 ) : Fragment() {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CustomSubtitleDecoderFactory.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CustomSubtitleDecoderFactory.kt
@@ -35,8 +35,8 @@ import java.nio.charset.Charset
 /**
  * @param fallbackFormat used to create a decoder based on mimetype if the subtitle string is not
  * enough to identify the subtitle format.
- **/
-@UnstableApi
+ */
+@OptIn(UnstableApi::class)
 class CustomDecoder(private val fallbackFormat: Format?) : SubtitleParser {
     companion object {
         fun updateForcedEncoding(context: Context) {
@@ -392,7 +392,7 @@ class CustomSubtitleDecoderFactory : SubtitleDecoderFactory {
     /**
      * Decoders created here persists across reset()
      * Do not save state in the decoder which you want to reset (e.g subtitle offset)
-     **/
+     */
     override fun createDecoder(format: Format): SubtitleDecoder {
         val parser = CustomDecoder(format)
         // Allow garbage collection if player releases the decoder
@@ -404,8 +404,8 @@ class CustomSubtitleDecoderFactory : SubtitleDecoderFactory {
     }
 }
 
-@OptIn(UnstableApi::class)
 /** We need to convert the newer SubtitleParser to an older SubtitleDecoder */
+@OptIn(UnstableApi::class)
 class DelegatingSubtitleDecoder(name: String, private val parser: SubtitleParser) :
     SimpleSubtitleDecoder(name) {
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -103,6 +103,7 @@ const val DOUBLE_TAB_PAUSE_PERCENTAGE = 0.15        // in both directions
 private const val SUBTITLE_DELAY_BUNDLE_KEY = "subtitle_delay"
 
 // All the UI Logic for the player
+@OptIn(UnstableApi::class)
 open class FullScreenPlayer : AbstractPlayerFragment() {
     private var isVerticalOrientation: Boolean = false
     protected open var lockRotation = true
@@ -274,7 +275,6 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
     private fun animateLayoutChangesForSubtitles() =
         // Post here as bottomPlayerBar is gone the first frame => bottomPlayerBar.height = 0
         playerBinding?.bottomPlayerBar?.post {
-            @OptIn(UnstableApi::class)
             val sView = subView ?: return@post
             val sStyle = CustomDecoder.style
             val binding = playerBinding ?: return@post
@@ -378,7 +378,6 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
         }
     }
 
-    @OptIn(UnstableApi::class)
     override fun subtitlesChanged() {
         val tracks = player.getVideoTracks()
         val isBuiltinSubtitles = tracks.currentTextTracks.all { track ->
@@ -1526,7 +1525,6 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
 
     private var loudnessEnhancer: LoudnessEnhancer? = null
 
-    @OptIn(UnstableApi::class)
     private fun handleVolumeAdjustment(
         delta: Float,
         fromButton: Boolean,

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -132,7 +132,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
-@UnstableApi
+@OptIn(UnstableApi::class)
 class GeneratorPlayer : FullScreenPlayer() {
     companion object {
         const val NOTIFICATION_ID = 2326
@@ -266,12 +266,8 @@ class GeneratorPlayer : FullScreenPlayer() {
         return PendingIntent.getBroadcast(context, instanceId, intent, pendingFlags)
     }
 
-    @OptIn(UnstableApi::class)
-    @UnstableApi
     private var cachedPlayerNotificationManager: PlayerNotificationManager? = null
 
-    @OptIn(UnstableApi::class)
-    @UnstableApi
     private fun getMediaNotification(context: Context): PlayerNotificationManager {
         val cache = cachedPlayerNotificationManager
         if (cache != null) return cache
@@ -876,7 +872,6 @@ class GeneratorPlayer : FullScreenPlayer() {
         //dialog.subtitles_search_year?.setText(currentTempMeta.year)
     }
 
-    @OptIn(UnstableApi::class)
     private fun openSubPicker() {
         try {
             subsPathPicker.launch(

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/ChromecastSubtitlesFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/ChromecastSubtitlesFragment.kt
@@ -10,7 +10,9 @@ import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
+import androidx.annotation.OptIn
 import androidx.media3.common.text.Cue
+import androidx.media3.common.util.UnstableApi
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.android.gms.cast.TextTrackStyle.EDGE_TYPE_DEPRESSED
 import com.google.android.gms.cast.TextTrackStyle.EDGE_TYPE_DROP_SHADOW
@@ -49,7 +51,7 @@ data class SaveChromeCaptionStyle(
     @JsonProperty("fontScale") var fontScale: Float = 1.05f,
     @JsonProperty("windowColor") var windowColor: Int = Color.TRANSPARENT,
 )
-@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 class ChromecastSubtitlesFragment : BaseFragment<ChromecastSubtitleSettingsBinding>(
     BaseFragment.BindingCreator.Inflate(ChromecastSubtitleSettingsBinding::inflate)
 ) {
@@ -330,6 +332,12 @@ class ChromecastSubtitlesFragment : BaseFragment<ChromecastSubtitleSettingsBindi
             //it.context.fromSaveToStyle(state)
             activity?.popCurrentPage()
         }
+
+        setSubtitleCues(binding)
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun setSubtitleCues(binding: ChromecastSubtitleSettingsBinding) {
         binding.subtitleText.apply {
             setCues(
                 listOf(

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/SubtitlesFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/subtitles/SubtitlesFragment.kt
@@ -60,10 +60,11 @@ const val SUBTITLE_KEY = "subtitle_settings"
 const val SUBTITLE_AUTO_SELECT_KEY = "subs_auto_select"
 const val SUBTITLE_DOWNLOAD_KEY = "subs_auto_download"
 
-data class SaveCaptionStyle @OptIn(UnstableApi::class) constructor(
+data class SaveCaptionStyle(
     @JsonProperty("foregroundColor") var foregroundColor: Int,
     @JsonProperty("backgroundColor") var backgroundColor: Int,
     @JsonProperty("windowColor") var windowColor: Int,
+    @OptIn(UnstableApi::class)
     @JsonProperty("edgeType") var edgeType: @CaptionStyleCompat.EdgeType Int,
     @JsonProperty("edgeColor") var edgeColor: Int,
     @FontRes
@@ -91,7 +92,7 @@ data class SaveCaptionStyle @OptIn(UnstableApi::class) constructor(
 
 const val DEF_SUBS_ELEVATION = 20
 
-@OptIn(androidx.media3.common.util.UnstableApi::class)
+@OptIn(UnstableApi::class)
 class SubtitlesFragment : BaseDialogFragment<SubtitleSettingsBinding>(
     BaseFragment.BindingCreator.Inflate(SubtitleSettingsBinding::inflate)
 ) {


### PR DESCRIPTION
* Remove `@UnstableApi` from GeneratorPlayer and use OptIn instead.
* Remove `@OptIn` from WebviewFragment as it was unnecessary.
* Move `@OptIn` in SaveCaptionStyle to the actual single line we need to OptIn.
* Split `setCues` logic to a new method in ChromcastSubtitlesFragment and only add `@OptIn` to that method as it's only necessary there.
* Add some missing `@OptIn` annotations to fix all remaining `UnsafeOptInUsageError` lint errors.