### PR TITLE
Add tools:targetApi to appease lint

### DIFF
--- a/app/src/main/res/layout/settings_title_top.xml
+++ b/app/src/main/res/layout/settings_title_top.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:background="?attr/primaryGrayBackground"
-        android:id="@+id/settings_top_root"
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/settings_top_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/primaryGrayBackground"
+    android:orientation="vertical">
 
     <include layout="@layout/standard_toolbar" />
 
     <!-- Required ViewGroup for PreferenceFragmentCompat -->
     <FrameLayout
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
-            android:background="?attr/primaryBlackBackground"
-            android:id="@android:id/list_container"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+        android:id="@android:id/list_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/primaryBlackBackground"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:targetApi="n" />
+        <!-- list_container is actually defined by the support library, but lint doesn't know that it exists before API 24. -->
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Part of my work to fix all error level lint issues, in order to eventually enable `failOnError` and ensure better compatability with older API levels and a more consistent reporting of issues.