### PR TITLE
Suppress an UnspecifiedRegisterReceiverFlag lint issue

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/AbstractPlayerFragment.kt
@@ -221,11 +221,16 @@ abstract class AbstractPlayerFragment(
                         )
                     }
                 }
+
                 val filter = IntentFilter()
                 filter.addAction(ACTION_MEDIA_CONTROL)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     activity?.registerReceiver(pipReceiver, filter, Context.RECEIVER_EXPORTED)
-                } else activity?.registerReceiver(pipReceiver, filter)
+                } else {
+                    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+                    activity?.registerReceiver(pipReceiver, filter)
+                }
+
                 val isPlaying = player.getIsPlaying()
                 val isPlayingValue =
                     if (isPlaying) CSPlayerLoading.IsPlaying else CSPlayerLoading.IsPaused


### PR DESCRIPTION
Part of my work to fix all error level lint issues, in order to eventually enable `failOnError` and ensure better compatability with older API levels and a more consistent reporting of issues.