### PR TITLE
Fix crash on Android 5

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -1875,7 +1875,6 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
         }
 
         playerBinding?.apply {
-
             if (isLayout(TV or EMULATOR)) {
                 mapOf(
                     playerGoBack to playerGoBackText,
@@ -1990,8 +1989,10 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
                 return@setOnTouchListener handleMotionEvent(callView, event)
             }
 
-            playerControlsScroll.setOnScrollChangeListener { _, _, _, _, _ ->
-                autoHide()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                playerControlsScroll.setOnScrollChangeListener { _, _, _, _, _ ->
+                    autoHide()
+                }
             }
 
             exoProgress.setOnTouchListener { _, event ->


### PR DESCRIPTION
I just realized I hadn't done a PR to fix this issue yet but this issue is why I've been working on fixing all error level lint issues so that we can enable `failOnError` which would have prevented this.