### PR TITLE
Don't create backup on first install

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1201,6 +1201,8 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
             val lastAppAutoBackup: String = getKey("VERSION_NAME") ?: ""
             if (appVer != lastAppAutoBackup) {
                 setKey("VERSION_NAME", BuildConfig.VERSION_NAME)
+                if (lastAppAutoBackup.isEmpty()) return@safe
+
                 safe {
                     backup(this)
                 }


### PR DESCRIPTION
There is no reason to create a mostly empty backup when the app is first installed.

TODO: make this whole check use commit to make this work for pre when the actual version is changed, but I want to wait until #2285 is merged to do that.