### PR TITLE
Fix broken seeking on some fragmented MP4 files

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -61,6 +61,7 @@ import androidx.media3.exoplayer.text.TextOutput
 import androidx.media3.exoplayer.text.TextRenderer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.trackselection.TrackSelector
+import androidx.media3.extractor.mp4.FragmentedMp4Extractor
 import androidx.media3.ui.SubtitleView
 import androidx.preference.PreferenceManager
 import com.lagradost.cloudstream3.APIHolder.getApiFromNameNull
@@ -1218,6 +1219,7 @@ class CS3IPlayer : IPlayer {
         // Because "Java rules" the media3 team hates to do open classes so we have to copy paste the entire thing to add a custom extractor
         // This includes the updated MKV extractor that enabled seeking in formats where the seek information is at the back of the file
         val extractorFactor = UpdatedDefaultExtractorsFactory()
+            .setFragmentedMp4ExtractorFlags(FragmentedMp4Extractor.FLAG_MERGE_FRAGMENTED_SIDX)
 
         val factory =
             if (cacheFactory == null) DefaultMediaSourceFactory(context, extractorFactor)


### PR DESCRIPTION
Seek doesn't work (only shows duration of a few seconds and seeking then restarts it) on some fragmented MP4 files if they have multiple sidx boxes. Setting this flag merges those and thus will allow seeking. This can be tested using https://github.com/androidx/media/blob/release/libraries/test_data/src/test/assets/media/mp4/sample_fragmented_seekable_multiple_sidx.mp4

*Might* fix #2211 but not certain as I can't confirm without exact file to test against.