### PR TITLE
remove check icon in tvtype chips

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -102,6 +102,7 @@
         <item name="android:fontFamily">@font/google_sans</item>
         <item name="android:tag">@string/tv_no_focus_tag</item>
         <item name="chipMinTouchTargetSize">0dp</item>
+        <item name="checkedIconVisible">false</item>
     </style>
 
     <style name="RoundProgressbar">


### PR DESCRIPTION
check icon causes unnecessary flicker while selecting we should remove that