### PR TITLE
Use assemblePrereleaseRelease for building prerelease

### DIFF
--- a/.github/workflows/build_to_archive.yml
+++ b/.github/workflows/build_to_archive.yml
@@ -61,13 +61,14 @@ jobs:
         cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
     - name: Run Gradle
-      run: ./gradlew assemblePrerelease
+      run: ./gradlew assemblePrereleaseRelease
       env:
         SIGNING_KEY_ALIAS: "key0"
         SIGNING_KEY_PASSWORD: ${{ steps.fetch_keystore.outputs.key_pwd }}
         SIGNING_STORE_PASSWORD: ${{ steps.fetch_keystore.outputs.key_pwd }}
         SIMKL_CLIENT_ID: ${{ secrets.SIMKL_CLIENT_ID }}
         SIMKL_CLIENT_SECRET: ${{ secrets.SIMKL_CLIENT_SECRET }}
+        MDL_API_KEY: ${{ secrets.MDL_API_KEY }}
 
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -52,7 +52,7 @@ jobs:
         cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
     - name: Run Gradle
-      run: ./gradlew assemblePrerelease build androidSourcesJar makeJar
+      run: ./gradlew assemblePrereleaseRelease androidSourcesJar makeJar
       env:
         SIGNING_KEY_ALIAS: "key0"
         SIGNING_KEY_PASSWORD: ${{ steps.fetch_keystore.outputs.key_pwd }}


### PR DESCRIPTION
It's more explicit that way.

This also adds missing `MDL_API_KEY` to archive build, which seems was missed.

Additionally, this also removes running `build` manually, it's unnecessary now (since #2261). In the future, we can also probably remove `androidSourcesJar` and `sources.jar` from releases, ever since the library split it really hasn't been useful as we don't even include library sources in it, so we don't actually need it (unless it is still needed for some usage I'm not clear on, which is very possible). But for now, we can leave it. I also plans to have `makeJar` auto run with the release build type to auto include for all releases, including stable so we can have `classes.jar` for stable releases as well (though it would still need included in release artifacts still). We can also create a new workflow triggered by `workflow_dispatch` for manually triggering to streamline creating stable releases and auto include this as well. Those are just some things I'm planning for the future (if even wanted), but this is just a start for that.