### PR TITLE
Add newExtractorLink usage in ByseSX Extractor

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/ByseSX.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/ByseSX.kt
@@ -11,8 +11,6 @@ import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.newExtractorLink
-
-import com.lagradost.cloudstream3.utils.M3u8Helper
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import javax.crypto.Cipher
@@ -134,6 +132,7 @@ open class ByseSX : ExtractorApi() {
             }
         )
     }
+}
 
 data class DetailsRoot(
     val id: Long,


### PR DESCRIPTION
The current method used in the extractor ends up creating duplicates.

Ex:
<img width="1920" height="1080" alt="20260104_22h42m50s_grim" src="https://github.com/user-attachments/assets/6f2d3959-9ad4-45ec-86ed-3931dd941150" />

If we use newExtractorLink in this way, the extractor will only create one option with multiple resolutions.