### PR TITLE
Add posterHelper for null posters

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/PosterHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/PosterHelper.kt
@@ -32,11 +32,11 @@ fun posterHelper(
 ): String {
     // Check the documentation on the official website.
     val domain    = "https://placehold.co"
-    val txtWidth  = width ?: 2400
-    val txtHeight = height ?: 400
+    val imgWidth  = width ?: 2400
+    val imgHeight = height ?: 400
     val bgColor   = backgroundColor?.removePrefix("#") ?: "EEE"
     val txtColor  = textColor?.removePrefix("#") ?: "31343C"
     val txtFont   = font?.lowercase()?.replace(" ","-") ?: "lato"
 
-    return "$domain/${txtWidth}x${txtHeight}/$bgColor/$txtColor.png?text=$title&font=$txtFont"
+    return "$domain/${imgWidth}x${imgHeight}/$bgColor/$txtColor.png?text=$title&font=$txtFont"
 }


### PR DESCRIPTION
<img width="600" alt="Example poster" src="https://github.com/user-attachments/assets/2608acb7-1824-461e-8080-c8b40d91784e" />


---

Generate placeholder poster URLs for missing posters (custom text/size/color/font). Uses [placehold.co](https://placehold.co/) for image generation.

---
**Example usage**:
<img width="1303" height="211" alt="resim" src="https://github.com/user-attachments/assets/7a1305f7-2e93-421d-927d-492722fe086c" />
**Result**:
<img width="270" height="349" alt="resim" src="https://github.com/user-attachments/assets/1ab24736-d6d1-4552-8262-64d53cf3ca3c" />

