### PR TITLE
fix: make YouTube subtitles nullable

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YoutubeExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YoutubeExtractor.kt
@@ -160,7 +160,7 @@ open class YoutubeExtractor : ExtractorApi() {
                 subtitleCallback.invoke(
                     newSubtitleFile(
                         lang =caption.name.simpleText,
-                        url  ="${caption.baseUrl}&fmt=ttml"
+                        url  ="${caption.baseUrl}&fmt=ttml" // The default format is not supported
                     ) { headers = HEADERS })
             }
         }


### PR DESCRIPTION
Some videos, such as livestreams, do not provide subtitle tracks.