### PR TITLE
Removes check for available devices before displaying chromecast button

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
@@ -559,12 +559,7 @@ open class ResultFragmentPhone : FullScreenPlayer() {
                             CastContext.getSharedInstance(act.applicationContext) {
                                 it.run()
                             }.addOnCompleteListener {
-                                isGone = if (it.isSuccessful) {
-                                    it.result.castState == CastState.NO_DEVICES_AVAILABLE
-                                } else {
-                                    true
-                                }
-
+                                isGone = !it.isSuccessful
                             }
                             // this shit leaks for some reason
                             //castContext.addCastStateListener { state ->


### PR DESCRIPTION
Once the button is selected, the chrome cast service will search for devices and notify the user if none have been found.

Addresses the disappearing button in issue #2311 