### PR TITLE
Fix chapter skipping

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -124,6 +124,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
     protected var isShowing = false
     private var uiShowingBeforeGesture = false
     protected var isLocked = false
+    protected var timestampShowState = false
 
     protected var hasEpisodes = false
         private set
@@ -1583,7 +1584,12 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
             when (keyCode) {
                 KeyEvent.KEYCODE_DPAD_CENTER -> {
                     if (!isShowing) {
-                        if (!isLocked) player.handleEvent(CSPlayerEvent.PlayPauseToggle)
+                        // If UI is not shown make click instantly skip to next chapter even if locked
+                        if (timestampShowState) {
+                            player.handleEvent(CSPlayerEvent.SkipCurrentChapter)
+                        } else if (!isLocked) {
+                            player.handleEvent(CSPlayerEvent.PlayPauseToggle)
+                        }
                         onClickChange()
                         return true
                     }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1880,8 +1880,6 @@ class GeneratorPlayer : FullScreenPlayer() {
         super.onDestroyView()
     }
 
-    var timestampShowState = false
-
     var skipAnimator: ValueAnimator? = null
     var skipIndex = 0
 


### PR DESCRIPTION
On TV the skip chapter button was not instantly clickable even if focused due to the click overrides. 
This keeps the previous focus and ensures that it is "clickable".