### PR TITLE
Feat: Zoom

### DIFF
--- a/app/src/main/res/drawable/video_outline.xml
+++ b/app/src/main/res/drawable/video_outline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke android:color="#C0FFFFFF" android:width="30dp"/>
+</shape>

--- a/app/src/main/res/layout/player_custom_layout.xml
+++ b/app/src/main/res/layout/player_custom_layout.xml
@@ -7,6 +7,14 @@
     android:orientation="vertical"
     tools:orientation="vertical">
 
+    <ImageView
+        android:visibility="gone"
+        android:id="@+id/video_outline"
+        android:src="@drawable/video_outline"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    </ImageView>
+
 
     <!--
         <LinearLayout android:layout_width="match_parent"

--- a/app/src/main/res/layout/player_custom_layout_tv.xml
+++ b/app/src/main/res/layout/player_custom_layout_tv.xml
@@ -8,6 +8,14 @@
     android:tag="television"
     tools:orientation="vertical">
 
+    <ImageView
+        android:visibility="gone"
+        android:id="@+id/video_outline"
+        android:src="@drawable/video_outline"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    </ImageView>
+
 
     <FrameLayout
         android:id="@+id/piphide"

--- a/app/src/main/res/layout/trailer_custom_layout.xml
+++ b/app/src/main/res/layout/trailer_custom_layout.xml
@@ -7,6 +7,14 @@
     android:orientation="vertical"
     tools:orientation="vertical">
 
+    <ImageView
+        android:visibility="gone"
+        android:id="@+id/video_outline"
+        android:src="@drawable/video_outline"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    </ImageView>
+
 
     <TextView
         android:id="@+id/player_time_text"


### PR DESCRIPTION
This is an updated patch of #1907 as zoom is a very cool feature. The main difference is how I did the transform as the old pull request did not feel right https://github.com/recloudstream/cloudstream/pull/1907#issuecomment-3289688607. The main reason it felt incorrect was that the zooming was done around the center of the screen, instead of the center of the pinch. I honestly did not want to reinvent the postScale function using pure math, so I just used the matrix operations and then extracted translation+scale. 

I also fixed some issues with black borders https://github.com/recloudstream/cloudstream/pull/1907#issuecomment-3314604831 and added an outline like youtube.

It should work fine on all horizontal videos, but I have noticed some weird behavior on vertical videos. It is also a bit wonky when zooming in when in the resize option "Zoom" as it instantly zooms out. 