### PR TITLE
Add toggle for showing/hiding cast panel

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentPhone.kt
@@ -834,8 +834,11 @@ open class ResultFragmentPhone : FullScreenPlayer() {
                     resultComingSoon.isVisible = d.comingSoon
                     resultDataHolder.isGone = d.comingSoon
 
-                    resultCastItems.isGone = d.actors.isNullOrEmpty()
-                    (resultCastItems.adapter as? ActorAdaptor)?.submitList(d.actors)
+                    val prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(root.context)
+                    val showCast = prefs.getBoolean(root.context.getString(R.string.show_cast_in_details_key), true)
+
+                    resultCastItems.isGone = !showCast || d.actors.isNullOrEmpty()
+                    (resultCastItems.adapter as? ActorAdaptor)?.submitList(if (showCast) d.actors else emptyList())
 
                     if (d.contentRatingText == null) {
                         // If there is no rating to display, we don't want an empty gap

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
@@ -925,10 +925,11 @@ class ResultFragmentTv : BaseFragment<FragmentResultTvBinding>(
                         resultTvComingSoon.isVisible = d.comingSoon
 
                         populateChips(resultTag, d.tags)
-                        resultCastItems.isGone = d.actors.isNullOrEmpty()
-                        (resultCastItems.adapter as? ActorAdaptor)?.submitList(
-                            d.actors
-                        )
+                        val prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(root.context)
+                        val showCast = prefs.getBoolean(root.context.getString(R.string.show_cast_in_details_key), true)
+
+                        resultCastItems.isGone = !showCast || d.actors.isNullOrEmpty()
+                        (resultCastItems.adapter as? ActorAdaptor)?.submitList(if (showCast) d.actors else emptyList())
 
                         if (d.contentRatingText == null) {
                             // If there is no rating to display, we don't want an empty gap

--- a/app/src/main/res/drawable/ic_baseline_people_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_people_24.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:strokeColor="@android:color/white"
+        android:strokeWidth="1.2"
+        android:pathData="M12,2c5.52,0 10,4.48 10,10s-4.48,10 -10,10S2,17.52 2,12 6.48,2 12,2z"/>
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,11.5c1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3 1.34,3 3,3z M12,13c-2.33,0 -7,1.17 -7,3.5 0,1.2 0.7,2.3 2,3.1 1.4,0.9 3.2,1.4 5,1.4s3.6,-0.5 5,-1.4c1.3,-0.8 2,-1.9 2,-3.1C19,14.17 14.33,13 12,13z"/>
+</vector>

--- a/app/src/main/res/values/donottranslate-strings.xml
+++ b/app/src/main/res/values/donottranslate-strings.xml
@@ -41,6 +41,7 @@
     <string name="show_fillers_key">show_fillers_key</string>
     <string name="show_trailers_key">show_trailers_key</string>
     <string name="show_kitsu_posters_key">show_kitsu_posters_key</string>
+    <string name="show_cast_in_details_key">show_cast_in_details_key</string>
     <string name="random_button_key">random_button_key</string>
     <string name="provider_lang_key">provider_lang_key</string>
     <string name="dns_key">dns_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,7 @@
     <string name="show_fillers_settings">Show filler episode for anime</string>
     <string name="show_trailers_settings">Show trailers</string>
     <string name="kitsu_settings">Show posters from Kitsu</string>
+    <string name="show_cast_in_details">Show cast panel</string>
     <string name="pref_filter_search_quality">Hide selected video quality in search results</string>
     <string name="automatic_plugin_updates">Automatic plugin updates</string>
     <string name="automatic_plugin_download">Automatically download plugins</string>

--- a/app/src/main/res/xml/settings_ui.xml
+++ b/app/src/main/res/xml/settings_ui.xml
@@ -75,6 +75,11 @@
             android:key="@string/show_kitsu_posters_key"
             android:title="@string/kitsu_settings" />
         <SwitchPreference
+            android:defaultValue="true"
+            android:icon="@drawable/ic_baseline_people_24"
+            android:key="@string/show_cast_in_details_key"
+            android:title="@string/show_cast_in_details" />    
+        <SwitchPreference
             android:defaultValue="false"
             android:icon="@drawable/ic_baseline_skip_next_24"
             android:key="@string/show_fillers_key"


### PR DESCRIPTION
Adds a setting to show or hide the cast panel in movie/series details.

![Screenshot_2026-01-29-14-20-41-263_com lagradost cloudstream3 prerelease debug-edit](https://github.com/user-attachments/assets/53ca8023-c04e-4a11-bcbd-78e9f5c1e067)
