### PR TITLE
Improved TV Back Button UX (extension content -> extension selection Bttn -> home nav Bttn -> exit dialog)

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -922,8 +922,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                     binding?.homeChangeApi?.requestFocus()
                 }
             }
-            // Case 2: Focus is on plugin selector -> Move to home navigation
-            currentFocus.id == R.id.home_change_api -> {
+            // Case 2: Focus is on plugin selector or nearby buttons -> Move to home navigation
+            currentFocus.id == R.id.home_change_api ||
+            currentFocus.id == R.id.home_preview_reload_provider ||
+            currentFocus.id == R.id.home_preview_search_button -> {
                 activity?.findViewById<View>(R.id.navigation_home)?.requestFocus()
             }
             // Case 3: Any other location -> Use default back behavior


### PR DESCRIPTION
# Pull Request: Improved TV Back Button Navigation

## Summary

This PR implements a custom back button navigation flow for Android TV interface in `HomeFragment`, improving the user experience by providing logical focus transitions instead of immediately showing the exit dialog. The Back button transitions focus from and to the following items:

extension content -> extension selection Button -> home button -> exit dialog

the Phone interface remains unaffected by this change.

## Problem

Previously, when navigating plugin content on Android TV, pressing the back button would immediately show the "exit app" dialog regardless of the current focus position. This created a poor user experience as users couldn't easily navigate back to the plugin selector or home navigation without dismissing the dialog.

## Solution

Implemented a three-step back button navigation sequence specifically for TV interface:

1. **First Back Press** (when focus is on plugin content): Focuses the plugin selector button and Scrolls to top. In that order to avoid race conditions.
2. **Second Back Press** (when focus is on plugin selector): Moves focus to the Home icon in the navigation bar
3. **Third Back Press** (when focus is on navigation bar): Shows the standard exit app dialog (default behavior)

## Changes Made

### Modified Files

- `app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt`


### Implementation Details

#### 1. Added Back Press Callback Registration

In `onBindingCreated()`:

```kotlin
(activity as? ComponentActivity)?.attachBackPressedCallback("HomeFragment_BackPress") {
    handleTvBackPress(this)
}
```


#### 2. Created Custom Back Press Handler

New method `handleTvBackPress()` that:

- Only activates on TV layout (`isLayout(TV)`)
- Detects current focus position by traversing view hierarchy
- Implements the three-step navigation logic
- Falls back to default behavior for mobile devices and edge cases


#### 3. Added Callback Cleanup

In `onDestroyView()`:

```kotlin
(activity as? ComponentActivity)?.detachBackPressedCallback("HomeFragment_BackPress")
```


### Key Features

- ✅ **TV-only**: Uses `isLayout(TV)` check to ensure mobile interface is unaffected
- ✅ **Safe**: Falls back to default behavior when conditions aren't met
- ✅ **Memory-safe**: Properly detaches callback on view destruction
- ✅ **Focus-aware**: Traverses view hierarchy to detect if focus is within content RecyclerView


## Testing

- ✅ Compiles successfully
- ✅ Tested on Android TV - navigation works as expected
- ✅ Mobile interface confirmed unaffected (uses default back button behavior)


## Technical Notes

Uses Cloudstream's existing `BackPressedCallbackHelper` system to hook into the back press dispatcher, ensuring compatibility with the app's architecture.

## Related Issues

Resolves user-reported navigation issues on TV interface where back button behavior was unintuitive for plugin content browsing.


