### PR TITLE
feat(ui): improve appearance of video player info

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -444,12 +444,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
                 start()
             }
         }
-        playerBinding?.playerVideoTitleRez?.let {
-            ObjectAnimator.ofFloat(it, "translationY", titleMove).apply {
-                duration = 200
-                start()
-            }
-        }
+
         playerBinding?.playerVideoInfo?.let {
             ObjectAnimator.ofFloat(it, "translationY", titleMove).apply {
                 duration = 200
@@ -1005,7 +1000,6 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
             // video_bar.startAnimation(fadeAnimation)
 
             // TITLE
-            playerVideoTitleRez.startAnimation(fadeAnimation)
             playerVideoInfo.startAnimation(fadeAnimation)
             playerEpisodeFiller.startAnimation(fadeAnimation)
             playerVideoTitleHolder.startAnimation(fadeAnimation)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -514,7 +514,7 @@ class GeneratorPlayer : FullScreenPlayer() {
         }
         //  setEpisodes(viewModel.getAllMeta() ?: emptyList())
         isActive = true
-        setPlayerDimen(null)
+        updatePlayerInfo(reset = true)
         setTitle()
         if (!sameEpisode)
             hasRequestedStamps = false
@@ -1679,7 +1679,7 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         return sortSubs(subtitles).firstOrNull { it.matchesLanguageCode(langCode) }
     }
-    
+
     private fun autoSelectFromSettings(): Boolean {
         // auto select subtitle based on settings
         val langCode = preferredAutoSelectSubtitles
@@ -1812,33 +1812,26 @@ class GeneratorPlayer : FullScreenPlayer() {
         playerBinding?.offlinePin?.isVisible = lastUsedGenerator is DownloadFileGenerator
     }
 
-    @SuppressLint("SetTextI18n")
-    fun setPlayerDimen(widthHeight: Pair<Int, Int>?) {
-        val resolution = widthHeight?.let { "${it.first}x${it.second}" }
-        val name = currentSelectedLink?.first?.name ?: currentSelectedLink?.second?.name
-        val title = getHeaderName()
-
-        val result = listOfNotNull(
-            title?.takeIf { showTitle && it.isNotBlank() },
-            name?.takeIf { showName && it.isNotBlank() },
-            resolution?.takeIf { showResolution && it.isNotBlank() },
-        ).joinToString(" - ")
-
-        playerBinding?.playerVideoTitleRez?.apply {
-            text = result
-            isVisible = result.isNotBlank()
+    /**
+     * Show the current playback information (e.g. resolution, codec) in the player info text view.
+     *
+     * If [reset] is set to `true`, the text view will be cleared instead.
+     */
+    private fun updatePlayerInfo(reset: Boolean = false) {
+        if (reset) {
+            playerBinding?.playerVideoInfo?.text = ""
+            playerBinding?.playerVideoInfo?.isGone = true
+            return
         }
-    }
 
-    private fun updatePlayerInfo() {
         val tracks = player.getVideoTracks()
 
         val videoTrack = tracks.currentVideoTrack
         val audioTrack = tracks.currentAudioTrack
 
-        val ctx = context ?: return
-        val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
-        showMediaInfo = prefs.getBoolean(ctx.getString(R.string.show_media_info_key), false)
+        val resolution = videoTrack?.let { "${it.width}x${it.height}" }
+        val source = currentSelectedLink?.first?.name ?: currentSelectedLink?.second?.name
+        val headerName = getHeaderName().orEmpty()
 
         val videoCodec = videoTrack?.sampleMimeType?.substringAfterLast('/')?.uppercase()
         val audioCodec = audioTrack?.sampleMimeType?.substringAfterLast('/')?.uppercase()
@@ -1847,17 +1840,22 @@ class GeneratorPlayer : FullScreenPlayer() {
             fromTagToLanguageName(audioTrack?.language)?.let { "[$it]" }
         ).joinToString(" ")
 
-        val stats = arrayOf(videoCodec, audioCodec, language).filter { !it.isNullOrBlank() }.joinToString(" • ")
+        val stats = listOfNotNull(
+            source.takeIf { showTitle },
+            headerName.takeIf { showName },
+            resolution.takeIf { showResolution }
+        ) + arrayOf(videoCodec, audioCodec, language)
+            .takeIf { showMediaInfo }.orEmpty()
 
         playerBinding?.playerVideoInfo?.apply {
-            text = stats
-            isVisible = showMediaInfo && stats.isNotBlank()
+            text = stats.filter { !it.isNullOrBlank() }.joinToString(" • ")
+            isVisible = text.isNotEmpty()
         }
     }
 
     override fun playerDimensionsLoaded(width: Int, height: Int) {
         super.playerDimensionsLoaded(width, height)
-        setPlayerDimen(width to height)
+        updatePlayerInfo()
     }
 
     private fun unwrapBundle(savedInstanceState: Bundle?) {
@@ -2047,6 +2045,7 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         context?.let { ctx ->
             val settingsManager = PreferenceManager.getDefaultSharedPreferences(ctx)
+            showTitle = settingsManager.getBoolean(ctx.getString(R.string.show_title_key), true)
             showName        = settingsManager.getBoolean(ctx.getString(R.string.show_name_key), true)
             showResolution  = settingsManager.getBoolean(ctx.getString(R.string.show_resolution_key), true)
             showMediaInfo   = settingsManager.getBoolean(ctx.getString(R.string.show_media_info_key), false)

--- a/app/src/main/res/layout/player_custom_layout.xml
+++ b/app/src/main/res/layout/player_custom_layout.xml
@@ -147,24 +147,14 @@
                     app:layout_constraintTop_toTopOf="parent">
 
                     <TextView
-                        android:id="@+id/player_video_title_rez"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="2.5dp"
-                        android:gravity="center"
-                        android:textColor="@color/white"
-                        tools:text="1920x1080" />
-
-
-                    <TextView
                         android:id="@+id/player_video_info"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginBottom="6dp"
                         android:gravity="center"
-                        android:layout_marginBottom="2.5dp"
-                        android:textColor="@color/white"
-                        android:visibility="gone"
-                        tools:text="HEVC" />
+                        android:textColor="@color/grayTextColor"
+                        android:textSize="12sp"
+                        tools:text="1920x1080 • HDR10 • HEVC" />
 
                     <LinearLayout
                         android:id="@+id/player_video_title_holder"

--- a/app/src/main/res/layout/player_custom_layout_tv.xml
+++ b/app/src/main/res/layout/player_custom_layout_tv.xml
@@ -308,29 +308,16 @@
                     </LinearLayout>
 
                     <TextView
-                        android:id="@+id/player_video_title_rez"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="end"
-                        android:gravity="end"
-                        android:maxWidth="600dp"
-                        android:textAlignment="viewEnd"
-                        android:textColor="@color/white"
-                        android:textSize="16sp"
-                        tools:text="1920x1080" />
-
-                    <TextView
                         android:id="@+id/player_video_info"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="6dp"
+                        android:layout_marginTop="6dp"
                         android:layout_marginBottom="2.5dp"
                         android:layout_gravity="end"
-                        android:textColor="#B3FFFFFF"
-                        android:textSize="16sp"
-                        android:visibility="gone"
-                        tools:text="HEVC • English • 5.1 • E-AC3" />
-
+                        android:textColor="@color/white"
+                        android:textSize="12sp"
+                        tools:text="1920x1080 • HDR10 • HEVC" />
 
                     <FrameLayout
                         android:id="@+id/player_episode_filler_holder"

--- a/app/src/main/res/layout/trailer_custom_layout.xml
+++ b/app/src/main/res/layout/trailer_custom_layout.xml
@@ -86,7 +86,7 @@
         android:id="@+id/player_top_holder"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone">
+       >
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -95,6 +95,17 @@
             android:layout_marginTop="20dp"
             android:layout_marginEnd="32dp"
             android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/player_video_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:layout_marginBottom="6dp"
+                android:textColor="@color/grayTextColor"
+                android:textSize="12sp"
+                android:ellipsize="end"
+                tools:text="1920x1080 • HDR10 • HEVC" />
 
             <LinearLayout
                 android:id="@+id/player_video_title_holder"
@@ -111,16 +122,7 @@
                     android:textSize="16sp"
                     android:textStyle="bold"
                     tools:text="Hello world" />
-                <TextView
-                    android:id="@+id/player_video_info"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="6dp"
-                    android:layout_marginBottom="2.5dp"
-                    android:textColor="@color/white"
-                    android:textSize="10sp"
-                    android:visibility="gone"
-                    tools:text="HDR10 • HEVC" />
+
                 <ImageView
                     android:id="@+id/offline_pin"
                     android:layout_width="16dp"
@@ -131,14 +133,6 @@
                     tools:visibility="visible"
                     android:layout_gravity="center"/>
             </LinearLayout>
-            <TextView
-                android:id="@+id/player_video_title_rez"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="end"
-                android:textColor="@color/white"
-                android:textSize="16sp"
-                tools:text="1920x1080" />
 
             <FrameLayout
                 android:id="@+id/player_episode_filler_holder"


### PR DESCRIPTION
This is a follow-up to #2454 by @phisher98.

I noticed that it's problematic that currently, there are two text views displaying video info:
- one for the resolution and provider name
- one for the video stats added in #2454 
This is kind of redundant.

The second issue I noticed is that the video title is as much highlighted as the playback info, i.e. they use the same text size and color. This is problematic because the video title is much more important that such meta information and thus should be visually emphasized more than these statistics that most users probably don't need that often.

(For people that don't know what I'm talking about - it's about the "Vidoza [Deutsch] - Black Mirror - ..." text at the top in the screenshots)

Screenshot on my phone:
<img width="2400" height="1080" alt="video-info-demo" src="https://github.com/user-attachments/assets/2ce501f8-1b35-4da1-9808-1232c0852232" />

TV layout:
<img width="691" height="360" alt="Screenshot from 2026-02-01 12-47-12" src="https://github.com/user-attachments/assets/85312888-e7c0-49bf-b54f-4e4020e63cc5" />

Player/Trailer layout:
<img width="806" height="363" alt="Screenshot from 2026-02-01 12-47-51" src="https://github.com/user-attachments/assets/949da1ff-5623-48f0-a831-aca28d339565" />

