### PR TITLE
Fix resume watching

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.lagradost.cloudstream3.APIHolder.apis
 import com.lagradost.cloudstream3.APIHolder.getApiFromNameNull
 import com.lagradost.cloudstream3.CloudStreamApp.Companion.context
 import com.lagradost.cloudstream3.CloudStreamApp.Companion.getKey
+import com.lagradost.cloudstream3.CloudStreamApp.Companion.setKey
 import com.lagradost.cloudstream3.CommonActivity.activity
 import com.lagradost.cloudstream3.HomePageList
 import com.lagradost.cloudstream3.LoadResponse
@@ -40,6 +41,7 @@ import com.lagradost.cloudstream3.utils.AppContextUtils.filterSearchResultByFilm
 import com.lagradost.cloudstream3.utils.AppContextUtils.loadResult
 import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.DOWNLOAD_HEADER_CACHE
+import com.lagradost.cloudstream3.utils.DOWNLOAD_HEADER_CACHE_BACKUP
 import com.lagradost.cloudstream3.utils.DataStoreHelper
 import com.lagradost.cloudstream3.utils.DataStoreHelper.deleteAllResumeStateIds
 import com.lagradost.cloudstream3.utils.DataStoreHelper.getAllResumeStateIds
@@ -67,11 +69,26 @@ class HomeViewModel : ViewModel() {
             }
             val resumeWatchingResult = withContext(Dispatchers.IO) {
                 resumeWatching?.mapNotNull { resume ->
-
-                    val data = getKey<DownloadObjects.DownloadHeaderCached>(
+                    val headerCache = getKey<DownloadObjects.DownloadHeaderCached>(
                         DOWNLOAD_HEADER_CACHE,
                         resume.parentId.toString()
-                    ) ?: return@mapNotNull null
+                    )
+
+                    val data = if (headerCache == null) {
+                        // We store resume watching data in download header cache
+                        // Because downloads automatically pruned outdated download headers we
+                        // removed resume watching data. We should restore the data for affected users.
+                        val oldData = getKey<DownloadObjects.DownloadHeaderCached>(
+                            DOWNLOAD_HEADER_CACHE_BACKUP,
+                            resume.parentId.toString()
+                        ) ?: return@mapNotNull null
+
+                        // Restore data
+                        setKey(DOWNLOAD_HEADER_CACHE, resume.parentId.toString(), oldData)
+                        oldData
+                    } else {
+                        headerCache
+                    }
 
                     val watchPos = getViewPos(resume.episodeId)
 

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/DataStore.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/DataStore.kt
@@ -14,6 +14,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import androidx.core.content.edit
 
+/** Used to display metadata about downloads and resume watching */
 const val DOWNLOAD_HEADER_CACHE = "download_header_cache"
 const val DOWNLOAD_HEADER_CACHE_BACKUP = "BACKUP_download_header_cache"
 
@@ -115,7 +116,9 @@ object DataStore {
     }
 
     fun Context.getKeys(folder: String): List<String> {
-        return this.getSharedPrefs().all.keys.filter { it.startsWith(folder) }
+        // Ensure that the folder ends with "/" to prevent matching with other folders
+        val fixedFolder = folder.trimEnd('/') + "/"
+        return this.getSharedPrefs().all.keys.filter { it.startsWith(fixedFolder) }
     }
 
     fun Context.removeKey(folder: String, path: String) {


### PR DESCRIPTION
This fixes the current issue of resume watching getting removed whenever the download tab is opened.
The data was not deleted, just moved to a backup key.

This should be merged as soon as possible to make resume watching work again. @fire-light42 