### PR TITLE
Fix trailer zoom not resetting after fullscreen exit

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -630,27 +630,7 @@ open class FullScreenPlayer : AbstractPlayerFragment() {
         activity?.showSystemUI()
     }
     private fun resetZoomToDefault() {
-        matrixAnimation?.cancel()
-        matrixAnimation = null
-        zoomMatrix = null
-        desiredMatrix = null
-        playerView?.videoSurfaceView?.apply {
-            scaleX = 1.0f
-            scaleY = 1.0f
-            translationX = 0.0f
-            translationY = 0.0f
-            invalidate()
-        }
-        playerView?.let {
-            if (it.resizeMode == AspectRatioFrameLayout.RESIZE_MODE_ZOOM) {
-                it.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
-            }
-        }
-        playerView?.post {
-            playerView?.requestLayout()
-            playerView?.invalidate()
-        }
-        requestUpdateBrightnessOverlayOnNextLayout()
+        if (zoomMatrix != null) resize(PlayerResize.Fit, false)
     }
 
     override fun onResume() {


### PR DESCRIPTION
Fixes trailer size issue after fullscreen exit.
When zooming in fullscreen and then exiting, the video would become too small.
Now it correctly resets to its original dimensions.

![Screenshot_2026-02-18-22-37-28-519_com discord-edit](https://github.com/user-attachments/assets/ea1438ed-c3df-4148-851d-8bc76ed47d93)
![Screenshot_2026-02-18-22-39-32-787_com lagradost cloudstream3 prerelease debug-edit](https://github.com/user-attachments/assets/7ea119b7-6347-40bb-8cfb-96d9048b3111)
