### PR TITLE
Improve subtitle selection UX: Move "No Subtitles" option to bottom

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1171,8 +1171,11 @@ class GeneratorPlayer : FullScreenPlayer() {
 
                 val subtitles = subtitlesGrouped.map { it.key.html() }
 
-                val subtitleGroupIndexStart =
+                val subtitleGroupIndexStart = if (currentSelectedSubtitles == null) {
+                    subtitlesGrouped.size
+                } else {
                     subtitlesGrouped.keys.indexOf(currentSelectedSubtitles?.originalName)
+                }
                 var subtitleGroupIndex = subtitleGroupIndexStart
 
                 val subtitleOptionIndexStart =

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1162,7 +1162,6 @@ class GeneratorPlayer : FullScreenPlayer() {
 
                 val subsArrayAdapter =
                     ArrayAdapter<Spanned>(ctx, R.layout.sort_bottom_single_choice)
-                subsArrayAdapter.add(ctx.getString(R.string.no_subtitles).html())
 
                 val subtitlesGrouped =
                     currentSubtitles.groupBy { it.originalName }.map { (key, value) ->
@@ -1173,7 +1172,7 @@ class GeneratorPlayer : FullScreenPlayer() {
                 val subtitles = subtitlesGrouped.map { it.key.html() }
 
                 val subtitleGroupIndexStart =
-                    subtitlesGrouped.keys.indexOf(currentSelectedSubtitles?.originalName) + 1
+                    subtitlesGrouped.keys.indexOf(currentSelectedSubtitles?.originalName)
                 var subtitleGroupIndex = subtitleGroupIndexStart
 
                 val subtitleOptionIndexStart =
@@ -1182,6 +1181,7 @@ class GeneratorPlayer : FullScreenPlayer() {
                 var subtitleOptionIndex = subtitleOptionIndexStart
 
                 subsArrayAdapter.addAll(subtitles)
+                subsArrayAdapter.add(ctx.getString(R.string.no_subtitles).html())
 
                 subtitleList.adapter = subsArrayAdapter
                 subtitleList.choiceMode = AbsListView.CHOICE_MODE_SINGLE
@@ -1200,7 +1200,7 @@ class GeneratorPlayer : FullScreenPlayer() {
 
                     val subtitleOptions =
                         subtitlesGroupedList
-                            .getOrNull(subtitleGroupIndex - 1)?.value?.map { subtitle ->
+                            .getOrNull(subtitleGroupIndex)?.value?.map { subtitle ->
                                 val nameSuffix = subtitle.nameSuffix.html()
                                 nameSuffix.ifBlank {
                                     when (subtitle.origin) {
@@ -1252,7 +1252,7 @@ class GeneratorPlayer : FullScreenPlayer() {
                 }
 
                 subtitleOptionList.setOnItemClickListener { _, _, which, _ ->
-                    if (which >= (subtitlesGroupedList.getOrNull(subtitleGroupIndex - 1)?.value?.size
+                    if (which >= (subtitlesGroupedList.getOrNull(subtitleGroupIndex)?.value?.size
                             ?: -1)
                     ) {
                         val child = subtitleOptionList.adapter.getView(which, null, subtitleList)
@@ -1337,10 +1337,10 @@ class GeneratorPlayer : FullScreenPlayer() {
                 binding.applyBtt.setOnClickListener {
                     var init = sourceIndex != startSource
                     if (subtitleGroupIndex != subtitleGroupIndexStart || subtitleOptionIndex != subtitleOptionIndexStart) {
-                        init = init or if (subtitleGroupIndex <= 0) {
+                        init = init or if (subtitleGroupIndex >= subtitlesGrouped.size) {
                             noSubtitles()
                         } else {
-                            subtitlesGroupedList.getOrNull(subtitleGroupIndex - 1)?.value?.getOrNull(
+                            subtitlesGroupedList.getOrNull(subtitleGroupIndex)?.value?.getOrNull(
                                 subtitleOptionIndex
                             )?.let {
                                 setSubtitles(it, true)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1174,7 +1174,8 @@ class GeneratorPlayer : FullScreenPlayer() {
                 val subtitleGroupIndexStart = if (currentSelectedSubtitles == null) {
                     subtitlesGrouped.size
                 } else {
-                    subtitlesGrouped.keys.indexOf(currentSelectedSubtitles?.originalName)
+                    val index = subtitlesGrouped.keys.indexOf(currentSelectedSubtitles?.originalName)
+                    if (index == -1) subtitlesGrouped.size else index
                 }
                 var subtitleGroupIndex = subtitleGroupIndexStart
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1171,11 +1171,12 @@ class GeneratorPlayer : FullScreenPlayer() {
 
                 val subtitles = subtitlesGrouped.map { it.key.html() }
 
-                val subtitleGroupIndexStart = if (currentSelectedSubtitles == null) {
+                val realIndex = subtitlesGrouped.keys.indexOf(currentSelectedSubtitles?.originalName)
+                val subtitleGroupIndexStart = if (realIndex == -1) {
+                    // The "No Subtitles" option is outside the subtitlesGrouped list.
                     subtitlesGrouped.size
                 } else {
-                    val index = subtitlesGrouped.keys.indexOf(currentSelectedSubtitles?.originalName)
-                    if (index == -1) subtitlesGrouped.size else index
+                    realIndex
                 }
                 var subtitleGroupIndex = subtitleGroupIndexStart
 


### PR DESCRIPTION
## Problem
The "No Subtitles" option was hidden at the top of the subtitle list, requiring users to scroll up to discover it. This was not intuitive, especially for new users who expected options to be visible or at the bottom.

## Solution
- Moved "No Subtitles" to bottom as a footer button (always accessible without scrolling up)
- Removed confusing plus icon by changing from `sort_bottom_footer_add_choice` to `sort_bottom_single_choice` layout
- Added scroll indicators (fading edge + scrollbar) to make scrollable content obvious
- Adjusted container height (84dp bottom margin) so the last visible subtitle item is cut in half, visually indicating more content below
- Fixed index calculations to properly handle -1 for no subtitles selection

## Changes
Files modified:
- `app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt`
  - Moved "No Subtitles" from array adapter to footer
  - Updated `subtitleGroupIndexStart` calculation (removed +1 offset)
  - Fixed boundary checks and index handling
  
- `app/src/main/res/layout/player_select_source_and_subs.xml`
  - Added scroll indicators to subtitle ListView
  - Adjusted container margin to show cut-off effect

## Testing
Tested on Android device with multiple subtitle sources. Verified:
- "No Subtitles" button appears at bottom
- Clicking it disables subtitles correctly
- Scroll indicators visible when list is scrollable
- Last visible item cut in half to indicate more content
- No regression in subtitle selection functionality

## Demo

### Before
![before](https://github.com/user-attachments/assets/1d051654-b1b4-4045-b526-8db704fc031d)

"No Subtitles" hidden at top, requiring upward scroll

### After
![after](https://github.com/user-attachments/assets/a8cf38d2-a969-4762-b5d4-4cd2f650918a)

"No Subtitles" visible at bottom, scroll indicators show more content

## Related
Improves UX for subtitle management without requiring new features or breaking changes.
