### PR TITLE
Prefer player default live position for HLS/DASH

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -1868,6 +1868,13 @@ class CS3IPlayer : IPlayer {
                 )
             }
 
+            // For DASH or HLS single streams (non-playlist), prefer the player's default
+            // live position instead of starting at 0. Use TIME_UNSET to let ExoPlayer pick
+            // the live/default position when no explicit start position was provided.
+            if (playbackPosition == 0L && (link.type == ExtractorLinkType.M3U8 || link.type == ExtractorLinkType.DASH)) {
+                playbackPosition = TIME_UNSET
+            }
+
             val provider = getApiFromNameNull(link.source)
             val interceptor: Interceptor? = provider?.getVideoInterceptor(link)
 


### PR DESCRIPTION
When starting a single HLS (M3U8) or DASH stream and no explicit start position was provided (playbackPosition == 0), set playbackPosition to TIME_UNSET so ExoPlayer can choose its default/live position. This prevents forcing a 0 ms start for live/non-playlist streams and lets the player resume at the correct live/default offset.


I made this PR because when i play HLS/DASH live streams that has larger Playback window eg: 1hr, the stream plays from 0ms rather than playing live which always  made to make me fastforward to live. This PR fixes this