### PR TITLE
Add fallback url for kitsu sync

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/syncproviders/providers/KitsuApi.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/syncproviders/providers/KitsuApi.kt
@@ -76,13 +76,6 @@ class KitsuApi: SyncAPI() {
                 response.close()
 
             } catch (_: Exception) {
-
-                val fallbackRequest: Request = request.newBuilder()
-                    .url(request.url.toString().replaceFirst(apiUrl, fallbackApiUrl))
-                    .build()
-
-                return chain.proceed(fallbackRequest)
-
             }
 
             val fallbackRequest: Request = request.newBuilder()


### PR DESCRIPTION
As I mentioned in #2527 kitsu.io sometimes is down while kitsu.app is working and are equivalent but kitsu.io is the one that is documented as the api url domain.

So I added a fallback when any of the requests targeting kitsu.io fails it tries with kitsu.app.

This may fix the issue about not syncing anime.