### PR TITLE
Fix intent launches

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,14 +108,31 @@
         android:launchMode="singleTask"
         is a bit experimental, it makes loading repositories from browser still stay on the same page
         no idea about side effects
+
+        Not exported to prevent bypassing the AccountSelectActivity
         -->
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboard|keyboardHidden|navigation|uiMode"
-            android:exported="true"
+            android:exported="false"
             android:launchMode="singleTask"
             android:resizeableActivity="true"
-            android:supportsPictureInPicture="true">
+            android:supportsPictureInPicture="true" />
+
+        <activity
+            android:name=".ui.account.AccountSelectActivity"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboard|keyboardHidden"
+            android:exported="true">
+            <intent-filter android:exported="true">
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
 
             <!-- cloudstreamplayer://encodedUrl?name=Dune -->
             <intent-filter>
@@ -173,7 +190,7 @@
                 <data android:scheme="cloudstreamcontinuewatching" />
             </intent-filter>
 
-            <intent-filter>
+            <intent-filter android:autoVerify="false">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -183,21 +200,6 @@
                     android:host="cs.repo"
                     android:pathPrefix="/"
                     android:scheme="https" />
-            </intent-filter>
-        </activity>
-
-        <activity
-            android:name=".ui.account.AccountSelectActivity"
-            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboard|keyboardHidden"
-            android:exported="true">
-            <intent-filter android:exported="true">
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountSelectActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/account/AccountSelectActivity.kt
@@ -38,11 +38,24 @@ import com.lagradost.cloudstream3.utils.UIHelper.setNavigationBarColorCompat
 
 class AccountSelectActivity : FragmentActivity(), BiometricCallback {
 
+    companion object {
+        var hasLoggedIn: Boolean = false
+    }
+
     val accountViewModel: AccountViewModel by viewModels()
 
     @SuppressLint("NotifyDataSetChanged")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Sometimes we start this activity when we have already logged in
+        // For example when using cloudstreamsearch://
+        // In those cases we want to just go to the main activity instantly
+        if (hasLoggedIn) {
+            navigateToMainActivity()
+            return
+        }
+
         loadThemes(this)
 
         enableEdgeToEdgeCompat()
@@ -188,8 +201,11 @@ class AccountSelectActivity : FragmentActivity(), BiometricCallback {
         askBiometricAuth()
     }
 
+    @SuppressLint("UnsafeIntentLaunch")
     private fun navigateToMainActivity() {
-        openActivity(MainActivity::class.java)
+        hasLoggedIn = true
+        // We want to propagate any intent we get here to MainActivity since this is just an intermediary
+        openActivity(MainActivity::class.java, baseIntent = intent)
         finish() // Finish the account selection activity
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
@@ -23,6 +23,7 @@ import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.doOnLayout
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.button.MaterialButton
@@ -413,7 +414,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(
             binding.searchFilter.isFocusable = true
             binding.searchFilter.isFocusableInTouchMode = true
         }
-        
+
         // Hide suggestions when search view loses focus (phone only)
         if (isLayout(PHONE)) {
             binding.mainSearch.setOnQueryTextFocusChangeListener { _, hasFocus ->
@@ -571,7 +572,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(
                     removeKey("$currentAccount/$SEARCH_HISTORY_KEY", searchItem.key)
                     searchViewModel.updateHistory()
                 }
-                
+
                 SEARCH_HISTORY_CLEAR -> {
                     // Show confirmation dialog (from footer button)
                     activity?.let { ctx ->
@@ -652,7 +653,11 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(
 
             sq?.let { query ->
                 if (query.isBlank()) return@let
-                mainSearch.setQuery(query, true)
+
+                // Queries are dropped if you are submitted before layout finishes
+                mainSearch.doOnLayout {
+                    mainSearch.setQuery(query, true)
+                }
                 // Clear the query as to not make it request the same query every time the page is opened
                 arguments?.remove(SEARCH_QUERY)
                 savedInstanceState?.remove(SEARCH_QUERY)
@@ -673,7 +678,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(
             val hasSuggestions = suggestions.isNotEmpty()
             binding.searchSuggestionsRecycler.isVisible = hasSuggestions
             (binding.searchSuggestionsRecycler.adapter as? SearchSuggestionAdapter?)?.submitList(suggestions)
-            
+
             // On non-phone layouts, redirect focus and handle back button
             if (!isLayout(PHONE)) {
                 if (hasSuggestions) {

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
@@ -259,10 +259,12 @@ object UIHelper {
     }
 
     // Open activities from an activity outside the nav graph
-    fun Context.openActivity(activity: Class<*>, args: Bundle? = null) {
+    fun Context.openActivity(activity: Class<*>, args: Bundle? = null, baseIntent: Intent? = null) {
         val tag = "NavComponent"
         try {
-            val intent = Intent(this, activity)
+            val intent = baseIntent ?: Intent()
+            intent.setClass(this, activity)
+
             if (args != null) {
                 intent.putExtras(args)
             }


### PR DESCRIPTION
By using intents it was possible to bypass the account selection screen. 
This pull request fixes the security issue.

App usage should remain identical because `hasLoggedIn` skips subsequent logins.