### PR TITLE
feat(extractors): add vide0 doodstream mirror

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/DoodExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/DoodExtractor.kt
@@ -4,11 +4,9 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
-import com.lagradost.cloudstream3.utils.INFER_TYPE
 import com.lagradost.cloudstream3.utils.getQualityFromName
 import com.lagradost.cloudstream3.utils.newExtractorLink
 import java.net.URI
-import kotlin.random.Random
 
 class Doodspro : DoodLaExtractor() {
     override var mainUrl = "https://doods.pro"
@@ -79,6 +77,10 @@ class Ds2play : DoodLaExtractor() {
 
 class Ds2video : DoodLaExtractor() {
     override var mainUrl = "https://ds2video.com"
+}
+
+class Vide0Net: DoodLaExtractor() {
+    override var mainUrl = "https://vide0.net"
 }
 
 class MyVidPlay : DoodLaExtractor() {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -281,6 +281,7 @@ import com.lagradost.cloudstream3.extractors.Vidoza
 import com.lagradost.cloudstream3.extractors.VinovoSi
 import com.lagradost.cloudstream3.extractors.VinovoTo
 import com.lagradost.cloudstream3.extractors.VidNest
+import com.lagradost.cloudstream3.extractors.Vide0Net
 import com.lagradost.cloudstream3.extractors.VkExtractor
 import com.lagradost.cloudstream3.extractors.Voe
 import com.lagradost.cloudstream3.extractors.Voe1
@@ -1227,6 +1228,7 @@ val extractorApis: MutableList<ExtractorApi> = arrayListOf(
     ByseVepoin(),
     ByseBuho(),
     MyVidPlay(),
+    Vide0Net(),
     Up4Stream(),
     Up4FunTop(),
     GUpload(),


### PR DESCRIPTION
Example URL: https://vide0.net/e/dws3vppcqzzg (immediately redirects to another doodstream mirror via HTTP 301)