### PR TITLE
Quality: Bitmap cache uses non-thread-safe HashMap from potentially concurrent callers

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/downloader/DownloadUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/downloader/DownloadUtils.kt
@@ -20,16 +20,17 @@ import com.lagradost.cloudstream3.utils.downloader.DownloadFileManagement.getFol
 import com.lagradost.cloudstream3.utils.txt
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
+import java.util.concurrent.ConcurrentHashMap
 
 /** Separate object with helper functions for the downloader */
 object DownloadUtils {
-    private val cachedBitmaps = hashMapOf<String, Bitmap>()
+    private val cachedBitmaps = ConcurrentHashMap<String, Bitmap>()
     internal fun Context.getImageBitmapFromUrl(
         url: String,
         headers: Map<String, String>? = null
     ): Bitmap? = safe {
-        if (cachedBitmaps.containsKey(url)) {
-            return@safe cachedBitmaps[url]
+        cachedBitmaps[url]?.let {
+            return@safe it
         }
 
         val imageLoader = SingletonImageLoader.get(this)
@@ -50,7 +51,7 @@ object DownloadUtils {
         }
 
         bitmap?.let {
-            cachedBitmaps[url] = it
+            cachedBitmaps.putIfAbsent(url, it)
         }
 
         return@safe bitmap


### PR DESCRIPTION
## Problem

`cachedBitmaps` is a global mutable `HashMap` accessed without synchronization in `getImageBitmapFromUrl`. This utility is likely called from multiple coroutine/background contexts. Concurrent read/write on `HashMap` is unsafe and can lead to race conditions, stale reads, or map corruption/crashes under load.


**Severity**: `medium`
**File**: `app/src/main/java/com/lagradost/cloudstream3/utils/downloader/DownloadUtils.kt`

## Solution

Replace with a thread-safe map and atomic put: `private val cachedBitmaps = ConcurrentHashMap<String, Bitmap>()` Then use: `cachedBitmaps[cacheKey]?.let { return@safe it }` ... `bitmap?.let { cachedBitmaps.putIfAbsent(cacheKey, it) }`


## Changes

- `app/src/main/java/com/lagradost/cloudstream3/utils/downloader/DownloadUtils.kt` (modified)


## AI usage
This pull request was partially AI-assisted. AI was used to help with code drafting, refactoring suggestions, and PR text.

## Testing
I personally reviewed all generated suggestions, verified the logic, and tested the final implementation before opening this PR.

- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced
