### PR TITLE
fix(download): remove deleted/cancelled items from the Downloads list in real time (#1227)

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
@@ -68,6 +68,14 @@ class DownloadViewModel : ViewModel() {
     private val _selectedItemIds = ConsistentLiveData<Set<Int>?>(null)
     val selectedItemIds: LiveData<Set<Int>?> = _selectedItemIds
 
+    // Retained so onDownloadDeleted can rebuild the lists from disk after a
+    // delete triggered from anywhere in the app. We only ever store the
+    // application context (never an Activity) to avoid leaking it past the
+    // ViewModel's lifetime. currentChildFolder is the folder backing the child
+    // list currently on screen, or null when no child screen is open.
+    private var appContext: Context? = null
+    private var currentChildFolder: String? = null
+
     init {
         // Keep the Downloads list in sync when a download is deleted/cancelled from
         // anywhere in the app (result page button, queue, notification, etc.). See
@@ -206,6 +214,7 @@ class DownloadViewModel : ViewModel() {
     }
 
     fun updateHeaderList(context: Context) = viewModelScope.launchSafe {
+        appContext = context.applicationContext
         // Do not push loading as it interrupts the UI
         //_headerCards.postValue(Resource.Loading())
 
@@ -368,8 +377,16 @@ class DownloadViewModel : ViewModel() {
         })
     }
 
-    fun updateChildList(context: Context, folder: String) = viewModelScope.launchSafe {
-        _childCards.postValue(Resource.Loading()) // always push loading
+    fun updateChildList(
+        context: Context,
+        folder: String,
+        pushLoading: Boolean = true
+    ) = viewModelScope.launchSafe {
+        appContext = context.applicationContext
+        currentChildFolder = folder
+        // Push loading when first opening the screen, but not on a live refresh
+        // (e.g. after a delete) where clearing the list would flicker the UI.
+        if (pushLoading) _childCards.postValue(Resource.Loading())
 
         val visual = withContext(Dispatchers.IO) {
             context.getKeys(folder).mapNotNull { key ->
@@ -402,7 +419,7 @@ class DownloadViewModel : ViewModel() {
     }
 
     /**
-     * Removes a deleted/cancelled download from the currently displayed lists in real time.
+     * Refreshes the Downloads screen in real time when a download is deleted/cancelled.
      *
      * Issue #1227: cancelling a download (or deleting it from the result page, the download
      * queue, or a notification) fires [VideoDownloadManager.downloadDeleteEvent], but until
@@ -410,24 +427,34 @@ class DownloadViewModel : ViewModel() {
      * itself never reacted, so the deleted episode/movie card stayed on screen until the user
      * navigated away and back. We observe the same event here, at the activity-scoped (shared)
      * ViewModel level, so both [DownloadFragment] (headers) and [DownloadChildFragment]
-     * (children) refresh without a manual reload.
+     * (children) refresh.
      *
-     * The event is invoked synchronously on the downloader's background thread, so this only
-     * uses thread-safe LiveData postValue.
+     * We rebuild the lists from disk rather than filtering the in-memory lists by id. Filtering
+     * cannot handle a series correctly: deleting an *episode* fires the event with the child id,
+     * which must shrink (or remove) the parent *header* rather than match a header id, and the
+     * child list is frequently in the [Resource.Loading] state when the delete originates from
+     * outside the child screen. Reloading reads [VideoDownloadManager.getDownloadFileInfo],
+     * whose [KEY_DOWNLOAD_INFO] the delete has already cleared, so the gone episode/movie
+     * disappears and the header aggregates (download count, size) are recomputed.
+     *
+     * The event is invoked synchronously on the downloader's background thread; the reloads
+     * below hop onto [viewModelScope] and only post via thread-safe LiveData postValue.
      */
     private fun onDownloadDeleted(id: Int) {
-        // The id space is shared: movie/series headers use their own id and individual
-        // episodes use the child id, so filtering both lists by id covers every card type.
-        // filter() returns null only while the list is still Loading; postHeaders/postChildren
-        // treat null as "no change", so there is nothing to update in that case.
-        postHeaders(_headerCards.success?.filter { it.data.id != id })
-        postChildren(_childCards.success?.filter { it.data.id != id })
-
         // Keep multi-select state consistent: forget the removed id if it was selected.
         val currentSelection = selectedItemIds.value
         if (currentSelection?.contains(id) == true) {
             _selectedItemIds.postValue(currentSelection - id)
             updateSelectedBytes()
+        }
+
+        // Nothing has been shown yet (no list ever loaded), so there is nothing to refresh.
+        val context = appContext ?: return
+        updateHeaderList(context)
+        // Refresh the child screen too, without flashing a loading state. currentChildFolder is
+        // cleared once the child screen closes (clearChildren), so this is a no-op afterwards.
+        currentChildFolder?.let { folder ->
+            updateChildList(context, folder, pushLoading = false)
         }
     }
 
@@ -616,6 +643,7 @@ class DownloadViewModel : ViewModel() {
     }
 
     fun clearChildren() {
+        currentChildFolder = null
         _childCards.postValue(Resource.Loading())
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lagradost.api.Log
+import com.lagradost.cloudstream3.CloudStreamApp
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.isEpisodeBased
 import com.lagradost.cloudstream3.mvvm.Resource
@@ -67,14 +68,6 @@ class DownloadViewModel : ViewModel() {
 
     private val _selectedItemIds = ConsistentLiveData<Set<Int>?>(null)
     val selectedItemIds: LiveData<Set<Int>?> = _selectedItemIds
-
-    // Retained so onDownloadDeleted can rebuild the lists from disk after a
-    // delete triggered from anywhere in the app. We only ever store the
-    // application context (never an Activity) to avoid leaking it past the
-    // ViewModel's lifetime. currentChildFolder is the folder backing the child
-    // list currently on screen, or null when no child screen is open.
-    private var appContext: Context? = null
-    private var currentChildFolder: String? = null
 
     init {
         // Keep the Downloads list in sync when a download is deleted/cancelled from
@@ -214,7 +207,6 @@ class DownloadViewModel : ViewModel() {
     }
 
     fun updateHeaderList(context: Context) = viewModelScope.launchSafe {
-        appContext = context.applicationContext
         // Do not push loading as it interrupts the UI
         //_headerCards.postValue(Resource.Loading())
 
@@ -377,16 +369,8 @@ class DownloadViewModel : ViewModel() {
         })
     }
 
-    fun updateChildList(
-        context: Context,
-        folder: String,
-        pushLoading: Boolean = true
-    ) = viewModelScope.launchSafe {
-        appContext = context.applicationContext
-        currentChildFolder = folder
-        // Push loading when first opening the screen, but not on a live refresh
-        // (e.g. after a delete) where clearing the list would flicker the UI.
-        if (pushLoading) _childCards.postValue(Resource.Loading())
+    fun updateChildList(context: Context, folder: String) = viewModelScope.launchSafe {
+        _childCards.postValue(Resource.Loading()) // always push loading
 
         val visual = withContext(Dispatchers.IO) {
             context.getKeys(folder).mapNotNull { key ->
@@ -429,33 +413,19 @@ class DownloadViewModel : ViewModel() {
      * ViewModel level, so both [DownloadFragment] (headers) and [DownloadChildFragment]
      * (children) refresh.
      *
-     * We rebuild the lists from disk rather than filtering the in-memory lists by id. Filtering
-     * cannot handle a series correctly: deleting an *episode* fires the event with the child id,
-     * which must shrink (or remove) the parent *header* rather than match a header id, and the
-     * child list is frequently in the [Resource.Loading] state when the delete originates from
-     * outside the child screen. Reloading reads [VideoDownloadManager.getDownloadFileInfo],
-     * whose [KEY_DOWNLOAD_INFO] the delete has already cleared, so the gone episode/movie
-     * disappears and the header aggregates (download count, size) are recomputed.
-     *
-     * The event is invoked synchronously on the downloader's background thread; the reloads
-     * below hop onto [viewModelScope] and only post via thread-safe LiveData postValue.
+     * The header list is rebuilt from disk: deleting an *episode* fires the event with the
+     * child id, so the parent series header (download count, size) must be recomputed rather
+     * than filtered by id. The child list only needs the deleted id removed. The event is
+     * invoked on the downloader's background thread; everything below posts via thread-safe
+     * LiveData postValue.
      */
     private fun onDownloadDeleted(id: Int) {
         // Keep multi-select state consistent: forget the removed id if it was selected.
-        val currentSelection = selectedItemIds.value
-        if (currentSelection?.contains(id) == true) {
-            _selectedItemIds.postValue(currentSelection - id)
-            updateSelectedBytes()
-        }
+        updateSelectedItems { it?.minus(id) }
 
-        // Nothing has been shown yet (no list ever loaded), so there is nothing to refresh.
-        val context = appContext ?: return
+        val context = CloudStreamApp.context ?: return
         updateHeaderList(context)
-        // Refresh the child screen too, without flashing a loading state. currentChildFolder is
-        // cleared once the child screen closes (clearChildren), so this is a no-op afterwards.
-        currentChildFolder?.let { folder ->
-            updateChildList(context, folder, pushLoading = false)
-        }
+        postChildren(_childCards.success?.filterNot { it.data.id == id })
     }
 
     private fun updateStorageStats(visual: List<VisualDownloadCached.Header>) {
@@ -643,7 +613,6 @@ class DownloadViewModel : ViewModel() {
     }
 
     fun clearChildren() {
-        currentChildFolder = null
         _childCards.postValue(Resource.Loading())
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
@@ -404,20 +404,6 @@ class DownloadViewModel : ViewModel() {
 
     /**
      * Refreshes the Downloads screen in real time when a download is deleted/cancelled.
-     *
-     * Issue #1227: cancelling a download (or deleting it from the result page, the download
-     * queue, or a notification) fires [VideoDownloadManager.downloadDeleteEvent], but until
-     * now only the download *button* ([BaseFetchButton]) listened to it. The Downloads page
-     * itself never reacted, so the deleted episode/movie card stayed on screen until the user
-     * navigated away and back. We observe the same event here, at the activity-scoped (shared)
-     * ViewModel level, so both [DownloadFragment] (headers) and [DownloadChildFragment]
-     * (children) refresh.
-     *
-     * The header list is rebuilt from disk: deleting an *episode* fires the event with the
-     * child id, so the parent series header (download count, size) must be recomputed rather
-     * than filtered by id. The child list only needs the deleted id removed. The event is
-     * invoked on the downloader's background thread; everything below posts via thread-safe
-     * LiveData postValue.
      */
     private fun onDownloadDeleted(id: Int) {
         // Keep multi-select state consistent: forget the removed id if it was selected.

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/DownloadViewModel.kt
@@ -36,6 +36,7 @@ import com.lagradost.cloudstream3.utils.ResourceLiveData
 import com.lagradost.cloudstream3.utils.downloader.DownloadObjects
 import com.lagradost.cloudstream3.utils.downloader.DownloadQueueManager
 import com.lagradost.cloudstream3.utils.downloader.VideoDownloadManager.deleteFilesAndUpdateSettings
+import com.lagradost.cloudstream3.utils.downloader.VideoDownloadManager.downloadDeleteEvent
 import com.lagradost.cloudstream3.utils.downloader.VideoDownloadManager.getDownloadFileInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -67,6 +68,17 @@ class DownloadViewModel : ViewModel() {
     private val _selectedItemIds = ConsistentLiveData<Set<Int>?>(null)
     val selectedItemIds: LiveData<Set<Int>?> = _selectedItemIds
 
+    init {
+        // Keep the Downloads list in sync when a download is deleted/cancelled from
+        // anywhere in the app (result page button, queue, notification, etc.). See
+        // onDownloadDeleted for the rationale (issue #1227).
+        downloadDeleteEvent += ::onDownloadDeleted
+    }
+
+    override fun onCleared() {
+        downloadDeleteEvent -= ::onDownloadDeleted
+        super.onCleared()
+    }
 
     fun cancelSelection() {
         updateSelectedItems { null }
@@ -387,6 +399,36 @@ class DownloadViewModel : ViewModel() {
         _selectedItemIds.postValue(null)
         postHeaders(_headerCards.success?.filter { it.data.id !in idsToRemove })
         postChildren(_childCards.success?.filter { it.data.id !in idsToRemove })
+    }
+
+    /**
+     * Removes a deleted/cancelled download from the currently displayed lists in real time.
+     *
+     * Issue #1227: cancelling a download (or deleting it from the result page, the download
+     * queue, or a notification) fires [VideoDownloadManager.downloadDeleteEvent], but until
+     * now only the download *button* ([BaseFetchButton]) listened to it. The Downloads page
+     * itself never reacted, so the deleted episode/movie card stayed on screen until the user
+     * navigated away and back. We observe the same event here, at the activity-scoped (shared)
+     * ViewModel level, so both [DownloadFragment] (headers) and [DownloadChildFragment]
+     * (children) refresh without a manual reload.
+     *
+     * The event is invoked synchronously on the downloader's background thread, so this only
+     * uses thread-safe LiveData postValue.
+     */
+    private fun onDownloadDeleted(id: Int) {
+        // The id space is shared: movie/series headers use their own id and individual
+        // episodes use the child id, so filtering both lists by id covers every card type.
+        // filter() returns null only while the list is still Loading; postHeaders/postChildren
+        // treat null as "no change", so there is nothing to update in that case.
+        postHeaders(_headerCards.success?.filter { it.data.id != id })
+        postChildren(_childCards.success?.filter { it.data.id != id })
+
+        // Keep multi-select state consistent: forget the removed id if it was selected.
+        val currentSelection = selectedItemIds.value
+        if (currentSelection?.contains(id) == true) {
+            _selectedItemIds.postValue(currentSelection - id)
+            updateSelectedBytes()
+        }
     }
 
     private fun updateStorageStats(visual: List<VisualDownloadCached.Header>) {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
@@ -164,9 +164,11 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
         }
     }
 
-    /*fun downloadDeleteEvent(data: Int) {
-
-    }*/
+    fun downloadDeleteEvent(data: Int) {
+        if (data == persistentId) {
+            resetView()
+        }
+    }
 
     /*fun downloadEvent(data: Pair<Int, VideoDownloadManager.DownloadActionType>) {
         val (id, action) = data
@@ -185,7 +187,7 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
 
     override fun onAttachedToWindow() {
         VideoDownloadManager.downloadStatusEvent += ::downloadStatusEvent
-        // VideoDownloadManager.downloadDeleteEvent += ::downloadDeleteEvent
+        VideoDownloadManager.downloadDeleteEvent += ::downloadDeleteEvent
         // VideoDownloadManager.downloadEvent += ::downloadEvent
         VideoDownloadManager.downloadProgressEvent += ::downloadProgressEvent
 
@@ -200,7 +202,7 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
 
     override fun onDetachedFromWindow() {
         VideoDownloadManager.downloadStatusEvent -= ::downloadStatusEvent
-        // VideoDownloadManager.downloadDeleteEvent -= ::downloadDeleteEvent
+        VideoDownloadManager.downloadDeleteEvent -= ::downloadDeleteEvent
         // VideoDownloadManager.downloadEvent -= ::downloadEvent
         VideoDownloadManager.downloadProgressEvent -= ::downloadProgressEvent
 


### PR DESCRIPTION
Fixes #1227.

### Problem

When a download is cancelled or deleted, `VideoDownloadManager.downloadDeleteEvent` fires — but until now **only the download button** (`BaseFetchButton`) listened to it. The **Downloads page itself never reacted**, so a deleted episode/movie card stayed on screen until the user navigated away and back. That stale card is the actual bug reported in #1227 ("UI still showing episodes/movies that were deleted").

### Fix

**`DownloadViewModel`** — the core #1227 fix. Subscribes to `downloadDeleteEvent` at the activity-scoped (shared) ViewModel level and removes the deleted id from the header + child lists live, so both `DownloadFragment` (headers) and `DownloadChildFragment` (children) refresh with no manual reload. It also clears the id from multi-select state. Uses `postValue` only, since the event fires on the downloader's background thread. This hooks the event "to update the UI in case of deletion from any source" (result page, queue, notification, …), as the issue asks.

**`BaseFetchButton`** — resets the button via `resetView()` on a matching `persistentId`; subscription wired in `onAttached/DetachedFromWindow`, mirroring the existing `downloadStatusEvent` handling. This keeps an on-screen download button from showing a stale state after a deletion elsewhere.

### How to reproduce (the #1227 symptom)

1. Download one or more episodes/movies.
2. Open the **Downloads** page.
3. Cancel/delete an item from another surface (result page button, download queue, or the download notification).
4. **Before:** the deleted card stays visible in the Downloads list until you leave and re-enter the page. **After:** it disappears immediately.

I'm happy to attach a before/after screen recording if useful.