### PR TITLE
Change default installer to legacy

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
@@ -205,8 +205,9 @@ class SettingsUpdates : BasePreferenceFragmentCompat() {
             val prefNames = resources.getStringArray(R.array.apk_installer_pref)
             val prefValues = resources.getIntArray(R.array.apk_installer_values)
 
+            // Default legacy installed until we make the new installer completely reliable
             val currentInstaller =
-                settingsManager.getInt(getString(R.string.apk_installer_key), 0)
+                settingsManager.getInt(getString(R.string.apk_installer_key), 1)
 
             activity?.showBottomDialog(
                 prefNames.toList(),

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUpdates.kt
@@ -205,7 +205,7 @@ class SettingsUpdates : BasePreferenceFragmentCompat() {
             val prefNames = resources.getStringArray(R.array.apk_installer_pref)
             val prefValues = resources.getIntArray(R.array.apk_installer_values)
 
-            // Default legacy installed until we make the new installer completely reliable
+            // Use legacy installer as default until we make the new installer completely reliable
             val currentInstaller =
                 settingsManager.getInt(getString(R.string.apk_installer_key), 1)
 

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
@@ -308,7 +308,7 @@ object InAppUpdater {
                         }
 
                         val currentInstaller = settingsManager.getInt(
-                            getString(R.string.apk_installer_key), 0
+                            getString(R.string.apk_installer_key), 1
                         )
 
                         when (currentInstaller) {


### PR DESCRIPTION
I have seen people report issues with the default APK installer. We need to ensure that the "new" installer is fully reliable.

I am switching the default to the more reliable legacy installer until we have fixed the new installer.