### PR TITLE
Fix SSL issues

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1169,8 +1169,9 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        app.initClient(this)
-        val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
+        app.initClient(this, ignoreSSL = false)
+        @OptIn(UnsafeSSL::class)
+        insecureApp.initClient(this, ignoreSSL = true)
 
         setLastError(this)
 

--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -1173,6 +1173,8 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
         @OptIn(UnsafeSSL::class)
         insecureApp.initClient(this, ignoreSSL = true)
 
+        val settingsManager = PreferenceManager.getDefaultSharedPreferences(this)
+
         setLastError(this)
 
         val settingsForProvider = SettingsJson()

--- a/app/src/main/java/com/lagradost/cloudstream3/network/RequestsHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/network/RequestsHelper.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.network
 
 import android.content.Context
 import androidx.preference.PreferenceManager
+import com.lagradost.cloudstream3.Prerelease
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.mvvm.safe
@@ -15,11 +16,26 @@ import org.conscrypt.Conscrypt
 import java.io.File
 import java.security.Security
 
+// Backwards compatible constructor, mark as deprecated later
 fun Requests.initClient(context: Context) {
     this.baseClient = buildDefaultClient(context)
 }
 
+/** Only use ignoreSSL if you know what you are doing*/
+@Prerelease
+fun Requests.initClient(context: Context, ignoreSSL: Boolean = false) {
+    this.baseClient = buildDefaultClient(context, ignoreSSL)
+}
+
+
+// Backwards compatible constructor, mark as deprecated later
 fun buildDefaultClient(context: Context): OkHttpClient {
+    return buildDefaultClient(context, false)
+}
+
+/** Only use ignoreSSL if you know what you are doing*/
+@Prerelease
+fun buildDefaultClient(context: Context, ignoreSSL: Boolean = false): OkHttpClient {
     safe { Security.insertProviderAt(Conscrypt.newProvider(), 1) }
     
     val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
@@ -27,7 +43,11 @@ fun buildDefaultClient(context: Context): OkHttpClient {
     val baseClient = OkHttpClient.Builder()
         .followRedirects(true)
         .followSslRedirects(true)
-        .ignoreAllSSLErrors()
+        .apply {
+            if (ignoreSSL) {
+                ignoreAllSSLErrors()
+            }
+        }
         .cache(
             // Note that you need to add a ResponseInterceptor to make this 100% active.
             // The server response dictates if and when stuff should be cached.
@@ -51,11 +71,6 @@ fun buildDefaultClient(context: Context): OkHttpClient {
         .build()
     return baseClient
 }
-
-//val Request.cookies: Map<String, String>
-//    get() {
-//        return this.headers.getCookies("Cookie")
-//    }
 
 private val DEFAULT_HEADERS = mapOf("user-agent" to USER_AGENT)
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -55,6 +55,13 @@ annotation class Prerelease
 )
 annotation class InternalAPI
 
+@Retention(AnnotationRetention.BINARY) // This is only an IDE hint, and will not be used in the runtime
+@RequiresOptIn(
+    message = "Only use this if you know what you are doing and you need to bypass the SSL certificate checks. Never use this for sensitive network requests such as logins.",
+    level = RequiresOptIn.Level.WARNING
+)
+annotation class UnsafeSSL
+
 /**
  * Defines the constant for the all languages preference, if this is set then it is
  * the equivalent of all languages being set

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainActivity.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainActivity.kt
@@ -8,8 +8,7 @@ import com.lagradost.nicehttp.ResponseParser
 import kotlin.reflect.KClass
 
 // Short name for requests client to make it nicer to use
-
-var app = Requests(responseParser = object : ResponseParser {
+private val jacksonResponseParser = object : ResponseParser {
     val mapper: ObjectMapper = jacksonObjectMapper().configure(
         DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
         false
@@ -30,6 +29,18 @@ var app = Requests(responseParser = object : ResponseParser {
     override fun writeValueAsString(obj: Any): String {
         return mapper.writeValueAsString(obj)
     }
-}).apply {
+}
+
+/** The default networking helper. This helper performs SSL checks.
+ * If you need to make requests to websites with invalid SSL certificates use insecureApp instead. */
+var app = Requests(responseParser = jacksonResponseParser).apply {
+    defaultHeaders = mapOf("user-agent" to USER_AGENT)
+}
+
+/** Same as the default app networking helper, but this instance ignores SSL certificates.
+ * This should NEVER be used for sensitive networking operations such as logins. Only use this when required. */
+@Prerelease
+@UnsafeSSL
+var insecureApp = Requests(responseParser = jacksonResponseParser).apply {
     defaultHeaders = mapOf("user-agent" to USER_AGENT)
 }


### PR DESCRIPTION
We want to check all SSL traffic to prevent security issues and we want it to be secure by default. This *can* break some existing extensions, but the change is worth it to ensure everyone stays secure by default.

Extension developers can opt out by using `insecureApp`, which comes with an appropriate warning.
I think it would be best to merge this quickly and publish the April stable release shortly after, to maximize security and minimize extension breakage. 

Thoughts @LagradOst @Luna712 ?