### PR TITLE
Always use `exitProcess()` to exit the app

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -674,9 +674,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
         val confirmBeforeExit = settingsManager.getInt(getString(R.string.confirm_exit_key), -1)
 
         if (confirmBeforeExit == 1 || (confirmBeforeExit == -1 && isLayout(PHONE))) {
-            // finish() causes a bug on some TVs where player
-            // may keep playing after closing the app.
-            if (isLayout(TV)) exitProcess(0) else finish()
+            exitProcess(0)
             return
         }
 
@@ -692,9 +690,8 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                         putInt(getString(R.string.confirm_exit_key), 1)
                     }
                 }
-                // finish() causes a bug on some TVs where player
-                // may keep playing after closing the app.
-                if (isLayout(TV)) exitProcess(0) else finish()
+
+                exitProcess(0)
             }
 
         builder.show().setDefaultFocus()


### PR DESCRIPTION
Even on phones, when the app enters safe mode and the user clicks the back button to exit, it does not exit safe mode upon restarting if the "confirm exit" setting is enabled and they exit from the dialog. Always using `exitProcess()` fixes this.