### PR TITLE
Don't explicitly enable WebContentsDebugging

### DIFF
--- a/library/src/androidMain/kotlin/com/lagradost/cloudstream3/network/WebViewResolver.android.kt
+++ b/library/src/androidMain/kotlin/com/lagradost/cloudstream3/network/WebViewResolver.android.kt
@@ -123,7 +123,6 @@ actual class WebViewResolver actual constructor(
         val extraRequestList = threadSafeListOf<Request>()
 
         main {
-            // Useful for debugging
             try {
                 webView = WebView(
                     (getContext() as? Context)

--- a/library/src/androidMain/kotlin/com/lagradost/cloudstream3/network/WebViewResolver.android.kt
+++ b/library/src/androidMain/kotlin/com/lagradost/cloudstream3/network/WebViewResolver.android.kt
@@ -124,7 +124,6 @@ actual class WebViewResolver actual constructor(
 
         main {
             // Useful for debugging
-            WebView.setWebContentsDebuggingEnabled(true)
             try {
                 webView = WebView(
                     (getContext() as? Context)


### PR DESCRIPTION
https://developer.android.com/reference/android/webkit/WebView#setWebContentsDebuggingEnabled(boolean)

"this is enabled automatically if the app is declared as `android:debuggable="true"` in its manifest; otherwise, the default is false." - which we set on CloudStream Debug but not release flavors.

"Enabling web contents debugging allows the state of any WebView in the app to be inspected and modified by the user via adb. **This is a *security liability* and should not be enabled in production builds of apps** unless this is an explicitly intended use of the app."