### PR TITLE
Remove commented android.enableJetifier from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,6 @@ org.gradle.jvmargs=-Xmx4G -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-# android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.nonTransitiveRClass=true


### PR DESCRIPTION
It is now deprecated anyway. We will never use it now, so we can just fully remove it.