### PR TITLE
Remove setup-android action from Dokka action

### DIFF
--- a/.github/workflows/generate_dokka.yml
+++ b/.github/workflows/generate_dokka.yml
@@ -54,9 +54,6 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v4
-
       - name: Generate Dokka
         run: |
           cd $GITHUB_WORKSPACE/src/


### PR DESCRIPTION
It shouldn't be necessary with setup-gradle.

This can be reverted if something goes wrong with it.