### PR TITLE
Bump compilesdk to 37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ zipline = "1.24.0"
 jvmTarget = "1.8"
 jdkToolchain = "17"
 minSdk = "23"
-compileSdk = "36"
+compileSdk = "37"
 targetSdk = "36"
 
 [libraries]


### PR DESCRIPTION
37 *shouldn't* have any changes that will break anything here. But still going to split compileSdk and targetSdk out.