### PR TITLE
Fix ConcurrentModificationException when loading many plugins

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/plugins/PluginManager.kt
@@ -691,16 +691,25 @@ object PluginManager {
             APIHolder.allProviders.removeIf { provider: MainAPI -> provider.sourcePlugin == plugin.filename }
         }
 
-        extractorApis.removeIf { provider: ExtractorApi -> provider.sourcePlugin == plugin.filename }
+        synchronized(extractorApis) {
+            extractorApis.removeIf { provider: ExtractorApi -> provider.sourcePlugin == plugin.filename }
+        }
 
         synchronized(VideoClickActionHolder.allVideoClickActions) {
             VideoClickActionHolder.allVideoClickActions.removeIf { action: VideoClickAction -> action.sourcePlugin == plugin.filename }
         }
 
-        classLoaders.values.removeIf { v -> v == plugin }
+        synchronized(classLoaders) {
+            classLoaders.values.removeIf { v -> v == plugin }
+        }
 
-        plugins.remove(absolutePath)
-        urlPlugins.values.removeIf { v -> v == plugin }
+        synchronized(plugins) {
+            plugins.remove(absolutePath)
+        }
+
+        synchronized(urlPlugins) {
+            urlPlugins.values.removeIf { v -> v == plugin }
+        }
     }
 
     /**

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/plugins/BasePlugin.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/plugins/BasePlugin.kt
@@ -31,7 +31,9 @@ abstract class BasePlugin {
     fun registerExtractorAPI(element: ExtractorApi) {
         Log.i(PLUGIN_TAG, "Adding ${element.name} (${element.mainUrl}) ExtractorApi")
         element.sourcePlugin = this.filename
-        extractorApis.add(element)
+        synchronized(extractorApis) {
+            extractorApis.add(element)
+        }
     }
 
     /**


### PR DESCRIPTION
When loading hundreds of plugins we may get some ConcurrentModificationExceptions from the remaining unsynchronized objects. This fixes all remaining ConcurrentModificationExceptions.