### PR TITLE
Added Library Poster Size Slider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,8 +225,4 @@ fabric.properties
 
 !/gradle/wrapper/gradle-wrapper.jar
 
-# Ignore release APK folders
-app/prerelease/
-app/stable/
-
 # End of https://www.toptal.com/developers/gitignore/api/kotlin,java,android,androidstudio,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -225,4 +225,8 @@ fabric.properties
 
 !/gradle/wrapper/gradle-wrapper.jar
 
+# Ignore release APK folders
+app/prerelease/
+app/stable/
+
 # End of https://www.toptal.com/developers/gitignore/api/kotlin,java,android,androidstudio,visualstudiocode

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/PageAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/PageAdapter.kt
@@ -1,9 +1,12 @@
 package com.lagradost.cloudstream3.ui.library
 
+import android.content.Context
+import android.preference.PreferenceManager
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
+import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.databinding.SearchResultGridExpandedBinding
 import com.lagradost.cloudstream3.syncproviders.SyncAPI
 import com.lagradost.cloudstream3.ui.AutofitRecyclerView
@@ -12,6 +15,7 @@ import com.lagradost.cloudstream3.ui.NoStateAdapter
 import com.lagradost.cloudstream3.ui.ViewHolderState
 import com.lagradost.cloudstream3.ui.search.SearchClickCallback
 import com.lagradost.cloudstream3.ui.search.SearchResultBuilder
+import com.lagradost.cloudstream3.utils.UIHelper.getSpanCount
 import kotlin.math.roundToInt
 
 class PageAdapter(
@@ -26,6 +30,19 @@ class PageAdapter(
         }
     })) {
     private val coverHeight: Int get() = (resView.itemWidth / 0.68).roundToInt()
+
+    companion object {
+        fun updatePosterSize(resView: AutofitRecyclerView, context: Context, value: Int? = null) {
+            val scale = value ?: PreferenceManager.getDefaultSharedPreferences(context)
+                ?.getInt(context.getString(R.string.library_poster_size_key), 0) ?: 0
+            // Adjust spanCount to control poster size
+            // Higher scale = fewer columns = larger posters
+            val baseSpanCount = context.getSpanCount()
+            val adjustedSpanCount = maxOf(1, (baseSpanCount / (1.0f + scale * 0.1f)).roundToInt())
+            // Update the RecyclerView's spanCount
+            resView.spanCount = adjustedSpanCount
+        }
+    }
 
     override fun onCreateContent(parent: ViewGroup): ViewHolderState<Any> {
         return ViewHolderState(

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/PageAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/PageAdapter.kt
@@ -32,10 +32,10 @@ class PageAdapter(
     private val coverHeight: Int get() = (resView.itemWidth / 0.68).roundToInt()
 
     companion object {
-        fun updatePosterSize(resView: AutofitRecyclerView, context: Context, value: Int? = null) {
+        fun updatePosterSize(resView: AutofitRecyclerView?, context: Context, value: Int? = null) {
             val spanCount = value ?: PreferenceManager.getDefaultSharedPreferences(context)
                 .getInt(context.getString(R.string.library_poster_size_key), 3)
-            resView.spanCount = spanCount
+            resView?.spanCount = spanCount
         }
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/PageAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/PageAdapter.kt
@@ -1,8 +1,8 @@
 package com.lagradost.cloudstream3.ui.library
 
 import android.content.Context
-import android.preference.PreferenceManager
 import android.view.LayoutInflater
+import androidx.preference.PreferenceManager
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
@@ -33,14 +33,9 @@ class PageAdapter(
 
     companion object {
         fun updatePosterSize(resView: AutofitRecyclerView, context: Context, value: Int? = null) {
-            val scale = value ?: PreferenceManager.getDefaultSharedPreferences(context)
-                ?.getInt(context.getString(R.string.library_poster_size_key), 0) ?: 0
-            // Adjust spanCount to control poster size
-            // Higher scale = fewer columns = larger posters
-            val baseSpanCount = context.getSpanCount()
-            val adjustedSpanCount = maxOf(1, (baseSpanCount / (1.0f + scale * 0.1f)).roundToInt())
-            // Update the RecyclerView's spanCount
-            resView.spanCount = adjustedSpanCount
+            val spanCount = value ?: PreferenceManager.getDefaultSharedPreferences(context)
+                .getInt(context.getString(R.string.library_poster_size_key), 3)
+            resView.spanCount = spanCount
         }
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/library/ViewpagerAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/library/ViewpagerAdapter.kt
@@ -82,10 +82,13 @@ class ViewpagerAdapter(
                 // Which is only determined after the recyclerview is attached.
                 // If this fails then item height becomes 0 when there is only one item
                 doOnAttach {
-                    adapter = PageAdapter(
+                    val pageAdapter = PageAdapter(
                         this,
                         clickCallback
-                    ).apply {
+                    )
+                    // Initialize poster size for this page
+                    PageAdapter.updatePosterSize(this, this.context)
+                    adapter = pageAdapter.apply {
                         submitList(item.items)
                     }
                 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
@@ -65,10 +65,6 @@ class SettingsUI : BasePreferenceFragmentCompat() {
             true
         }
 
-        getPref(R.string.library_poster_size_key)?.setOnPreferenceChangeListener { _, newValue ->
-            true
-        }
-
         getPref(R.string.poster_ui_key)?.setOnPreferenceClickListener {
             val prefNames = resources.getStringArray(R.array.poster_ui_options)
             val keys = resources.getStringArray(R.array.poster_ui_options_values)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
@@ -65,6 +65,20 @@ class SettingsUI : BasePreferenceFragmentCompat() {
             true
         }
 
+        getPref(R.string.library_poster_size_key)?.setOnPreferenceChangeListener { _, newValue ->
+            context?.let { 
+                // Reload library to apply new poster size
+                (it.getActivity() as? MainActivity)?.let { activity ->
+                    activity.supportFragmentManager.findFragmentById(R.id.navigation_library)?.let { fragment ->
+                        if (fragment is com.lagradost.cloudstream3.ui.library.LibraryFragment) {
+                            activity.recreate()
+                        }
+                    }
+                }
+            }
+            true
+        }
+
         getPref(R.string.poster_ui_key)?.setOnPreferenceClickListener {
             val prefNames = resources.getStringArray(R.array.poster_ui_options)
             val keys = resources.getStringArray(R.array.poster_ui_options_values)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
@@ -15,6 +15,7 @@ import com.lagradost.cloudstream3.ui.BasePreferenceFragmentCompat
 import com.lagradost.cloudstream3.ui.clear
 import com.lagradost.cloudstream3.ui.home.HomeChildItemAdapter
 import com.lagradost.cloudstream3.ui.home.ParentItemAdapter
+import com.lagradost.cloudstream3.ui.library.PageAdapter
 import com.lagradost.cloudstream3.ui.search.SearchAdapter
 import com.lagradost.cloudstream3.ui.search.SearchResultBuilder
 import com.lagradost.cloudstream3.ui.settings.Globals.EMULATOR
@@ -62,6 +63,11 @@ class SettingsUI : BasePreferenceFragmentCompat() {
             ParentItemAdapter.sharedPool.clear()
             SearchAdapter.sharedPool.clear()
             context?.let { HomeChildItemAdapter.updatePosterSize(it, newValue as? Int) }
+            true
+        }
+
+        getPref(R.string.library_poster_size_key)?.setOnPreferenceChangeListener { _, newValue ->
+            context?.let { PageAdapter.updatePosterSize(null, it, newValue as? Int) }
             true
         }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsUI.kt
@@ -66,16 +66,6 @@ class SettingsUI : BasePreferenceFragmentCompat() {
         }
 
         getPref(R.string.library_poster_size_key)?.setOnPreferenceChangeListener { _, newValue ->
-            context?.let { 
-                // Reload library to apply new poster size
-                (it.getActivity() as? MainActivity)?.let { activity ->
-                    activity.supportFragmentManager.findFragmentById(R.id.navigation_library)?.let { fragment ->
-                        if (fragment is com.lagradost.cloudstream3.ui.library.LibraryFragment) {
-                            activity.recreate()
-                        }
-                    }
-                }
-            }
             true
         }
 

--- a/app/src/main/res/values/donottranslate-strings.xml
+++ b/app/src/main/res/values/donottranslate-strings.xml
@@ -67,6 +67,7 @@
     <string name="poster_ui_key">poster_ui_key</string>
     <string name="overscan_key">overscan_key</string>
     <string name="poster_size_key">poster_size_key</string>
+    <string name="library_poster_size_key">library_poster_size</string>
     <string name="subtitles_encoding_key">subtitles_encoding_key</string>
     <string name="override_site_key">override_site_key</string>
     <string name="redo_setup_key">redo_setup_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -743,10 +743,10 @@
     </string>
     <string name="overscan_settings_des">Changes the bounds of the screen</string>
     <string name="overscan_settings">Overscan</string>
-    <string name="poster_size_settings_des">Changes size of posters</string>
-    <string name="poster_size_settings">Poster size</string>
-    <string name="library_poster_size_settings_des">Changes size of library posters</string>
-    <string name="library_poster_size_settings">Library poster size</string>
+    <string name="poster_size_settings_des">Changes the number of poster columns</string>
+    <string name="poster_size_settings">Poster columns</string>
+    <string name="library_poster_size_settings_des">Changes the number of library poster columns</string>
+    <string name="library_poster_size_settings">Library poster columns</string>
     <string name="speedup_title">LongPress Speed Toggle</string>
     <string name="speedup_summary">Hold to get 2x speed</string>
     <string name="edit_profile_image_title">Edit Profile Image</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -745,6 +745,8 @@
     <string name="overscan_settings">Overscan</string>
     <string name="poster_size_settings_des">Changes size of posters</string>
     <string name="poster_size_settings">Poster size</string>
+    <string name="library_poster_size_settings_des">Changes size of library posters</string>
+    <string name="library_poster_size_settings">Library poster size</string>
     <string name="speedup_title">LongPress Speed Toggle</string>
     <string name="speedup_summary">Hold to get 2x speed</string>
     <string name="edit_profile_image_title">Edit Profile Image</string>

--- a/app/src/main/res/xml/settings_ui.xml
+++ b/app/src/main/res/xml/settings_ui.xml
@@ -35,12 +35,24 @@
             app:showSeekBarValue="true" />
 
         <SeekBarPreference
-            android:defaultValue="0"
+            android:defaultValue="5"
             android:icon="@drawable/baseline_grid_view_24"
             android:key="@string/poster_size_key"
             android:max="15"
             android:summary="@string/poster_size_settings_des"
             android:title="@string/poster_size_settings"
+            app:adjustable="true"
+            app:min="0"
+            app:seekBarIncrement="1"
+            app:showSeekBarValue="true" />
+
+        <SeekBarPreference
+            android:defaultValue="5"
+            android:icon="@drawable/baseline_grid_view_24"
+            android:key="@string/library_poster_size_key"
+            android:max="15"
+            android:summary="@string/library_poster_size_settings_des"
+            android:title="@string/library_poster_size_settings"
             app:adjustable="true"
             app:min="0"
             app:seekBarIncrement="1"

--- a/app/src/main/res/xml/settings_ui.xml
+++ b/app/src/main/res/xml/settings_ui.xml
@@ -47,14 +47,14 @@
             app:showSeekBarValue="true" />
 
         <SeekBarPreference
-            android:defaultValue="5"
+            android:defaultValue="3"
             android:icon="@drawable/baseline_grid_view_24"
             android:key="@string/library_poster_size_key"
-            android:max="15"
+            android:max="10"
             android:summary="@string/library_poster_size_settings_des"
             android:title="@string/library_poster_size_settings"
             app:adjustable="true"
-            app:min="0"
+            app:min="1"
             app:seekBarIncrement="1"
             app:showSeekBarValue="true" />
     </PreferenceCategory>


### PR DESCRIPTION
Implemented library poster scaling via RecyclerView span count adjustment. Leveraged AI assistance for code review and optimization of the layout logic to ensure the slider transitions are smooth and performant.

Also adds gitignore rules for app/prerelease/ and app/stable/ folders to prevent committing release APK files.
<img width="2800" height="2000" alt="Screenshot_2026-04-22-17-15-16-71_bba4627ecec1346e77f282610a5b88e8" src="https://github.com/user-attachments/assets/69cb9e9e-f554-4b54-bafd-06c8cd27503c" />
