### PR TITLE
Always go to next source in player and add thread safety

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -213,6 +213,7 @@ dependencies {
     // Android Core & Lifecycle
     implementation(libs.core.ktx)
     implementation(libs.activity.ktx)
+    implementation(libs.annotation)
     implementation(libs.appcompat)
     implementation(libs.fragment.ktx)
     implementation(libs.bundles.lifecycle)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/download/button/BaseFetchButton.kt
@@ -76,10 +76,10 @@ abstract class BaseFetchButton(context: Context, attributeSet: AttributeSet) :
         currentMetaData.id = id
 
         if (!doSetProgress) return
+        val appContext = context.applicationContext
 
         ioSafe {
-            val savedData = VideoDownloadManager.getDownloadFileInfo(context, id)
-
+            val savedData = VideoDownloadManager.getDownloadFileInfo(appContext, id)
             mainWork {
                 if (savedData != null) {
                     val downloadedBytes = savedData.fileLength

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -1770,7 +1770,6 @@ class CS3IPlayer : IPlayer {
         return exoPlayer != null
     }
 
-
     @MainThread
     private fun loadTorrent(context: Context, link: ExtractorLink) {
         ioSafe {
@@ -1791,7 +1790,7 @@ class CS3IPlayer : IPlayer {
                     loadOnlinePlayer(context, newLink)
                 }
             } catch (t: Throwable) {
-                event(ErrorEvent(t))
+                runOnMainThread { event(ErrorEvent(t)) }
             }
         }
     }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -12,6 +12,7 @@ import android.os.Looper
 import android.util.Log
 import android.util.Rational
 import android.widget.FrameLayout
+import androidx.annotation.AnyThread
 import androidx.annotation.MainThread
 import androidx.annotation.OptIn
 import androidx.appcompat.app.AlertDialog
@@ -206,16 +207,14 @@ class CS3IPlayer : IPlayer {
     private var requestedListeningPercentages: List<Int>? = null
 
     private var eventHandler: ((PlayerEvent) -> Unit)? = null
-    private val mainHandler = Handler(Looper.getMainLooper())
 
+    @AnyThread
     fun event(event: PlayerEvent) {
-        // Ensure that all work is done on the main looper, aka main thread
-        if (Looper.myLooper() == mainHandler.looper) {
+        // Ensure that all work is done on the main thread.
+        if (Looper.getMainLooper().isCurrentThread) {
             eventHandler?.invoke(event)
-        } else {
-            mainHandler.post {
-                eventHandler?.invoke(event)
-            }
+        } else runOnMainThread {
+            eventHandler?.invoke(event)
         }
     }
 
@@ -235,8 +234,9 @@ class CS3IPlayer : IPlayer {
         }
     }
 
+    @AnyThread
     override fun initCallbacks(
-        eventHandler: ((PlayerEvent) -> Unit),
+        @MainThread eventHandler: ((PlayerEvent) -> Unit),
         requestedListeningPercentages: List<Int>?,
     ) {
         this.requestedListeningPercentages = requestedListeningPercentages
@@ -1790,7 +1790,7 @@ class CS3IPlayer : IPlayer {
                     loadOnlinePlayer(context, newLink)
                 }
             } catch (t: Throwable) {
-                runOnMainThread { event(ErrorEvent(t)) }
+                event(ErrorEvent(t))
             }
         }
     }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
@@ -3,7 +3,8 @@ package com.lagradost.cloudstream3.ui.player
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.Rational
-import androidx.annotation.UiThread
+import androidx.annotation.AnyThread
+import androidx.annotation.MainThread
 import com.lagradost.cloudstream3.ui.subtitles.SaveCaptionStyle
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.videoskip.VideoSkipStamp
@@ -80,7 +81,6 @@ data class PositionEvent(
 }
 
 /** player error when rendering or misc, used to display toast or log */
-@UiThread
 data class ErrorEvent(
     val error: Throwable,
     override val source: PlayerEventSource = PlayerEventSource.Player,
@@ -243,8 +243,9 @@ interface IPlayer {
     fun getSubtitleOffset(): Long // in ms
     fun setSubtitleOffset(offset: Long) // in ms
 
+    @AnyThread
     fun initCallbacks(
-        eventHandler: ((PlayerEvent) -> Unit),
+        @MainThread eventHandler: ((PlayerEvent) -> Unit),
         /** this is used to request when the player should report back view percentage */
         requestedListeningPercentages: List<Int>? = null,
     )

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/IPlayer.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.ui.player
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.Rational
+import androidx.annotation.UiThread
 import com.lagradost.cloudstream3.ui.subtitles.SaveCaptionStyle
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.videoskip.VideoSkipStamp
@@ -79,6 +80,7 @@ data class PositionEvent(
 }
 
 /** player error when rendering or misc, used to display toast or log */
+@UiThread
 data class ErrorEvent(
     val error: Throwable,
     override val source: PlayerEventSource = PlayerEventSource.Player,
@@ -219,8 +221,6 @@ data class CurrentTracks(
     val allAudioTracks: List<AudioTrack>,
     val allTextTracks: List<TextTrack>,
 )
-
-class InvalidFileException(msg: String) : Exception(msg)
 
 //http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
 const val ACTION_MEDIA_CONTROL = "media_control"

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerView.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerView.kt
@@ -615,8 +615,8 @@ class PlayerView @JvmOverloads constructor(
     /** Error handling */
 
     fun playerError(exception: Throwable) {
-        fun showErrorToast(message: String, gotoNext: Boolean = false) {
-            if (gotoNext && callbacks?.hasNextMirror() == true) {
+        fun showErrorToast(message: String) {
+            if (callbacks?.hasNextMirror() == true) {
                 showToast(message, Toast.LENGTH_SHORT)
                 callbacks?.nextMirror()
             } else {
@@ -638,7 +638,7 @@ class PlayerView @JvmOverloads constructor(
                     PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE,
                     PlaybackException.ERROR_CODE_IO_UNSPECIFIED,
                     PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED ->
-                        showErrorToast("${context.getString(R.string.source_error)}\n$errorName ($code)\n$msg", gotoNext = true)
+                        showErrorToast("${context.getString(R.string.source_error)}\n$errorName ($code)\n$msg")
 
                     PlaybackException.ERROR_CODE_REMOTE_ERROR,
                     PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
@@ -646,7 +646,7 @@ class PlayerView @JvmOverloads constructor(
                     PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
                     PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT,
                     PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE ->
-                        showErrorToast("${context.getString(R.string.remote_error)}\n$errorName ($code)\n$msg", gotoNext = true)
+                        showErrorToast("${context.getString(R.string.remote_error)}\n$errorName ($code)\n$msg")
 
                     PlaybackErrorEvent.ERROR_AUDIO_TRACK_INIT_FAILED,
                     PlaybackErrorEvent.ERROR_AUDIO_TRACK_OTHER,
@@ -654,23 +654,23 @@ class PlayerView @JvmOverloads constructor(
                     PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED,
                     PlaybackException.ERROR_CODE_DECODER_INIT_FAILED,
                     PlaybackException.ERROR_CODE_DECODER_QUERY_FAILED ->
-                        showErrorToast("${context.getString(R.string.render_error)}\n$errorName ($code)\n$msg", gotoNext = true)
+                        showErrorToast("${context.getString(R.string.render_error)}\n$errorName ($code)\n$msg")
 
                     PlaybackException.ERROR_CODE_DECODING_FORMAT_UNSUPPORTED,
                     PlaybackException.ERROR_CODE_DECODING_FORMAT_EXCEEDS_CAPABILITIES ->
-                        showErrorToast("${context.getString(R.string.unsupported_error)}\n$errorName ($code)\n$msg", gotoNext = true)
+                        showErrorToast("${context.getString(R.string.unsupported_error)}\n$errorName ($code)\n$msg")
 
                     PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED,
                     PlaybackException.ERROR_CODE_PARSING_MANIFEST_MALFORMED ->
-                        showErrorToast("${context.getString(R.string.encoding_error)}\n$errorName ($code)\n$msg", gotoNext = true)
+                        showErrorToast("${context.getString(R.string.encoding_error)}\n$errorName ($code)\n$msg")
 
                     else ->
-                        showErrorToast("${context.getString(R.string.unexpected_error)}\n$errorName ($code)\n$msg", gotoNext = false)
+                        showErrorToast("${context.getString(R.string.unexpected_error)}\n$errorName ($code)\n$msg")
                 }
             }
 
             is InvalidFileException ->
-                showErrorToast("${context.getString(R.string.source_error)}\n${exception.message}", gotoNext = true)
+                showErrorToast("${context.getString(R.string.source_error)}\n${exception.message}")
 
             is SocketTimeoutException -> {
                 /**
@@ -680,17 +680,17 @@ class PlayerView @JvmOverloads constructor(
                  * prevent switching to the next source.
                  */
                 (context as? Activity)?.runOnUiThread {
-                    showErrorToast("${context.getString(R.string.remote_error)}\n${exception.message}", gotoNext = true)
+                    showErrorToast("${context.getString(R.string.remote_error)}\n${exception.message}")
                 }
             }
 
             is ErrorLoadingException ->
-                exception.message?.let { showErrorToast(it, gotoNext = true) }
-                    ?: showErrorToast(exception.toString(), gotoNext = true)
+                exception.message?.let { showErrorToast(it) }
+                    ?: showErrorToast(exception.toString())
 
             else ->
-                exception.message?.let { showErrorToast(it, gotoNext = false) }
-                    ?: showErrorToast(exception.toString(), gotoNext = false)
+                exception.message?.let { showErrorToast(it) }
+                    ?: showErrorToast(exception.toString())
         }
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerView.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerView.kt
@@ -25,8 +25,8 @@ import android.widget.ProgressBar
 import android.widget.RelativeLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.annotation.MainThread
 import androidx.annotation.OptIn
-import androidx.annotation.UiThread
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
@@ -621,7 +621,7 @@ class PlayerView @JvmOverloads constructor(
 
     /** Error handling */
 
-    @UiThread
+    @MainThread
     fun playerError(exception: Throwable) {
         fun showErrorToast(message: String) {
             if (callbacks?.hasNextMirror() == true) {
@@ -736,6 +736,7 @@ class PlayerView @JvmOverloads constructor(
      * and returning early WON'T stop it from changing in e.g. the player time
      * or pause status.
      */
+    @MainThread
     fun mainCallback(event: PlayerEvent) {
         // We don't want to spam DownloadEvent.
         if (event !is DownloadEvent) Log.i(TAG, "Handle event: $event")

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerView.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerView.kt
@@ -26,6 +26,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.OptIn
+import androidx.annotation.UiThread
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
@@ -614,6 +615,7 @@ class PlayerView @JvmOverloads constructor(
 
     /** Error handling */
 
+    @UiThread
     fun playerError(exception: Throwable) {
         fun showErrorToast(message: String) {
             if (callbacks?.hasNextMirror() == true) {
@@ -669,20 +671,8 @@ class PlayerView @JvmOverloads constructor(
                 }
             }
 
-            is InvalidFileException ->
-                showErrorToast("${context.getString(R.string.source_error)}\n${exception.message}")
-
-            is SocketTimeoutException -> {
-                /**
-                 * Ensures this is run on the UI thread to prevent issues
-                 * caused by SocketTimeoutException in torrents. Running
-                 * on another thread can break player interactions or
-                 * prevent switching to the next source.
-                 */
-                (context as? Activity)?.runOnUiThread {
-                    showErrorToast("${context.getString(R.string.remote_error)}\n${exception.message}")
-                }
-            }
+            is SocketTimeoutException ->
+                showErrorToast("${context.getString(R.string.remote_error)}\n${exception.message}")
 
             is ErrorLoadingException ->
                 exception.message?.let { showErrorToast(it) }
@@ -729,8 +719,7 @@ class PlayerView @JvmOverloads constructor(
         if (isLayout(TV or EMULATOR)) return ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
         return if (autoPlayerRotateEnabled && isVerticalOrientation)
             ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
-        else
-            ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        else ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
     }
 
     /** Event dispatch */
@@ -761,11 +750,7 @@ class PlayerView @JvmOverloads constructor(
             is TimestampInvokedEvent -> callbacks?.onTimestamp(event.timestamp)
             is TracksChangedEvent -> callbacks?.onTracksInfoChanged()
             is EmbeddedSubtitlesFetchedEvent -> callbacks?.embeddedSubtitlesFetched(event.tracks)
-            is ErrorEvent -> {
-                val cb = callbacks
-                if (cb != null) cb.playerError(event.error)
-                else playerError(event.error)
-            }
+            is ErrorEvent -> callbacks?.playerError(event.error) ?: playerError(event.error)
             is RequestAudioFocusEvent -> requestAudioFocus()
             is EpisodeSeekEvent -> when (event.offset) {
                 -1 -> callbacks?.prevEpisode()

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/ExtensionsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/extensions/ExtensionsFragment.kt
@@ -119,13 +119,14 @@ class ExtensionsFragment : BaseFragment<FragmentExtensionsBinding>(
             }, { repo ->
                 // Prompt user before deleting repo
                 main {
-                    val builder = AlertDialog.Builder(context ?: binding.root.context)
+                    val uiContext = context ?: binding.root.context
+                    val builder = AlertDialog.Builder(uiContext)
                     val dialogClickListener =
                         DialogInterface.OnClickListener { _, which ->
                             when (which) {
                                 DialogInterface.BUTTON_POSITIVE -> {
                                     ioSafe {
-                                        RepositoryManager.removeRepository(binding.root.context, repo)
+                                        RepositoryManager.removeRepository(uiContext.applicationContext, repo)
                                         extensionViewModel.loadStats()
                                         extensionViewModel.loadRepositories()
                                     }
@@ -136,9 +137,7 @@ class ExtensionsFragment : BaseFragment<FragmentExtensionsBinding>(
                         }
 
                     builder.setTitle(R.string.delete_repository)
-                        .setMessage(
-                            context?.getString(R.string.delete_repository_plugins)
-                        )
+                        .setMessage(uiContext.getString(R.string.delete_repository_plugins))
                         .setPositiveButton(R.string.delete, dialogClickListener)
                         .setNegativeButton(R.string.cancel, dialogClickListener)
                         .show().setDefaultFocus()
@@ -210,9 +209,9 @@ class ExtensionsFragment : BaseFragment<FragmentExtensionsBinding>(
 
             binding.applyBtt.setOnClickListener secondListener@{
                 val name = binding.repoNameInput.text?.toString()
+                val urlInput = binding.repoUrlInput.text?.toString()
                 ioSafe {
-                    val url = binding.repoUrlInput.text?.toString()
-                        ?.let { it1 -> RepositoryManager.parseRepoUrl(it1) }
+                    val url = urlInput?.let { it1 -> RepositoryManager.parseRepoUrl(it1) }
                     if (url.isNullOrBlank()) {
                         main {
                             showToast(R.string.error_invalid_data, Toast.LENGTH_SHORT)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 activityKtx = "1.13.0"
 androidGradlePlugin = "9.1.1"
 animeDb = "1.0.2"
+annotation = "1.10.0"
 appcompat = "1.7.1"
 biometric = "1.4.0-alpha06"
 buildkonfigGradlePlugin = "0.18.0"
@@ -57,6 +58,7 @@ targetSdk = "36"
 [libraries]
 activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
 anime-db = { module = "com.github.recloudstream:anime-db", version.ref = "animeDb" }
+annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
 coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
         }
 
         commonMain.dependencies {
+            implementation(libs.annotation) // Annotations
             implementation(libs.nicehttp) // HTTP Lib
             implementation(libs.jackson.module.kotlin) // JSON Parser
             implementation(libs.kotlinx.coroutines.core)

--- a/library/src/androidMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.android.kt
+++ b/library/src/androidMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.android.kt
@@ -2,8 +2,11 @@ package com.lagradost.cloudstream3.utils
 
 import android.os.Handler
 import android.os.Looper
+import androidx.annotation.AnyThread
+import androidx.annotation.MainThread
 
-actual fun runOnMainThreadNative(work: () -> Unit) {
+@AnyThread
+actual fun runOnMainThreadNative(@MainThread work: () -> Unit) {
     val mainHandler = Handler(Looper.getMainLooper())
     mainHandler.post {
         work()

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.kt
@@ -1,28 +1,34 @@
 package com.lagradost.cloudstream3.utils
 
+import androidx.annotation.AnyThread
+import androidx.annotation.MainThread
+import androidx.annotation.WorkerThread
 import com.lagradost.cloudstream3.mvvm.launchSafe
 import com.lagradost.cloudstream3.mvvm.logError
 import kotlinx.coroutines.*
 import java.util.Collections.synchronizedList
 
-expect fun runOnMainThreadNative(work: (() -> Unit))
+@AnyThread
+expect fun runOnMainThreadNative(@MainThread work: (() -> Unit))
 object Coroutines {
-    fun <T> T.main(work: suspend ((T) -> Unit)): Job {
+    @AnyThread
+    fun <T> T.main(@MainThread work: suspend ((T) -> Unit)): Job {
         val value = this
         return CoroutineScope(Dispatchers.Main).launchSafe {
             work(value)
         }
     }
 
-    fun <T> T.ioSafe(work: suspend (CoroutineScope.(T) -> Unit)): Job {
+    @AnyThread
+    fun <T> T.ioSafe(@WorkerThread work: suspend (CoroutineScope.(T) -> Unit)): Job {
         val value = this
-
         return CoroutineScope(Dispatchers.IO).launchSafe {
             work(value)
         }
     }
 
-    suspend fun <T, V> V.ioWorkSafe(work: suspend (CoroutineScope.(V) -> T)): T? {
+    @AnyThread
+    suspend fun <T, V> V.ioWorkSafe(@WorkerThread work: suspend (CoroutineScope.(V) -> T)): T? {
         val value = this
         return withContext(Dispatchers.IO) {
             try {
@@ -34,21 +40,24 @@ object Coroutines {
         }
     }
 
-    suspend fun <T, V> V.ioWork(work: suspend (CoroutineScope.(V) -> T)): T {
+    @AnyThread
+    suspend fun <T, V> V.ioWork(@WorkerThread work: suspend (CoroutineScope.(V) -> T)): T {
         val value = this
         return withContext(Dispatchers.IO) {
             work(value)
         }
     }
 
-    suspend fun <T, V> V.mainWork(work: suspend (CoroutineScope.(V) -> T)): T {
+    @AnyThread
+    suspend fun <T, V> V.mainWork(@MainThread work: suspend (CoroutineScope.(V) -> T)): T {
         val value = this
         return withContext(Dispatchers.Main) {
             work(value)
         }
     }
 
-    fun runOnMainThread(work: (() -> Unit)) {
+    @AnyThread
+    fun runOnMainThread(@MainThread work: (() -> Unit)) {
         runOnMainThreadNative(work)
     }
 
@@ -56,7 +65,7 @@ object Coroutines {
      * Safe to add and remove how you want
      * If you want to iterate over the list then you need to do:
      * synchronized(allProviders) { code here }
-     **/
+     */
     fun <T> threadSafeListOf(vararg items: T): MutableList<T> {
         return synchronizedList(items.toMutableList())
     }

--- a/library/src/jvmMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.jvm.kt
@@ -1,5 +1,9 @@
 package com.lagradost.cloudstream3.utils
 
-actual fun runOnMainThreadNative(work: () -> Unit) {
+import androidx.annotation.AnyThread
+import androidx.annotation.MainThread
+
+@AnyThread
+actual fun runOnMainThreadNative(@MainThread work: () -> Unit) {
     work.invoke()
 }


### PR DESCRIPTION
We don't want to ever kick out of the player if the first source fails, we can just show the unknown error toast and still go to the next source for more stable error handling. In the future we can still expand the different types of toasts shown to be clear about what the error is, but in reality we should never just kick out of the player if the first source is an error and there are other sources.

This also adds thread safety, and fixes issues with context required on the UI thread. Before lint couldn't follow `ioSafe` or other custom Coroutines methods, but this adds annotations to tell lint to follow properly ensuring proper build failures with `WrongThread` should it be called on the wrong thread.

For example with context:
```
Error: Method getContext must be called from the UI thread, currently inferred thread is worker thread
```
Is now given if called on the wrong thread. Doing it like this also would have caught other issues in the past as well.

Also, `androidx.annotation:annotation` is fully KMP compatible so has no issues with being in `commonMain` in library either. Just for consistency to ensure we always use the same version, it is also added explicitly to the `app` module.