### PR TITLE
Remove unnecessary ?: 0

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGestureHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGestureHelper.kt
@@ -1055,7 +1055,7 @@ class PlayerGestureHelper(private val playerView: PlayerView) {
             return validHeight && validWidth
         }
 
-        return rawY > (context.getStatusBarHeight() ?: 0) && rawX < screenWidthWithOrientation
+        return rawY > context.getStatusBarHeight() && rawX < screenWidthWithOrientation
     }
 
     private fun handleGesture(view: View, event: MotionEvent): Boolean {


### PR DESCRIPTION
This is accidental leftover from before the player rework where this used a nullable variable in `FullScreenPlayer`. Using `getStatusBarHeight()` directly is not nullable and just causes a build warning.