### PR TITLE
Fix `DownloadedPlayerActivity` not loading new files when activity is already running

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
@@ -14,7 +14,9 @@ import com.lagradost.cloudstream3.utils.BackPressedCallbackHelper.attachBackPres
 import com.lagradost.cloudstream3.utils.UIHelper.enableEdgeToEdgeCompat
 
 class DownloadedPlayerActivity : AppCompatActivity() {
-    private val dTAG = "DownloadedPlayerAct"
+    companion object {
+        const val TAG = "DownloadedPlayerActivity"
+    }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean =
         CommonActivity.dispatchKeyEvent(this, event) ?: super.dispatchKeyEvent(event)
@@ -27,49 +29,50 @@ class DownloadedPlayerActivity : AppCompatActivity() {
         CommonActivity.onUserLeaveHint(this)
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        Log.i(TAG, "onNewIntent")
+        handleIntent(intent)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         CommonActivity.loadThemes(this)
         CommonActivity.init(this)
         enableEdgeToEdgeCompat()
         setContentView(R.layout.empty_layout)
-        Log.i(dTAG, "onCreate")
+        Log.i(TAG, "onCreate")
 
+        handleIntent(intent)
+        attachBackPressedCallback("DownloadedPlayerActivity") { finish() }
+    }
+
+    private fun handleIntent(intent: Intent) {
         val data = intent.data
-
         if (OfflinePlaybackHelper.playIntent(activity = this, intent = intent)) {
             return
         }
 
-        if (intent?.action == Intent.ACTION_SEND || intent?.action == Intent.ACTION_OPEN_DOCUMENT || intent?.action == Intent.ACTION_VIEW) {
-            val extraText = safe { // I dont trust android
-                intent.getStringExtra(Intent.EXTRA_TEXT)
-            }
+        if (
+            intent.action == Intent.ACTION_SEND ||
+            intent.action == Intent.ACTION_OPEN_DOCUMENT ||
+            intent.action == Intent.ACTION_VIEW
+        ) {
+            val extraText = safe { intent.getStringExtra(Intent.EXTRA_TEXT) }
             val cd = intent.clipData
             val item = if (cd != null && cd.itemCount > 0) cd.getItemAt(0) else null
             val url = item?.text?.toString()
-
-            // idk what I am doing, just hope any of these work
-            if (item?.uri != null)
-                playUri(this, item.uri)
-            else if (url != null)
-                playLink(this, url)
-            else if (data != null)
-                playUri(this, data)
-            else if (extraText != null)
-                playLink(this, extraText)
-            else {
-                finish()
-                return
+            when {
+                item?.uri != null -> playUri(this, item.uri)
+                url != null -> playLink(this, url)
+                data != null -> playUri(this, data)
+                extraText != null -> playLink(this, extraText)
+                else -> { finish(); return }
             }
         } else if (data?.scheme == "content") {
             playUri(this, data)
-        } else {
-            finish()
-            return
-        }
-
-        attachBackPressedCallback("DownloadedPlayerActivity") { finish() }
+        } else finish()
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
@@ -31,9 +31,24 @@ class DownloadedPlayerActivity : AppCompatActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        // Ignore same intent so the player doesnt totally
+        // reload if you are playing the same thing.
+        if (isSameIntent(intent)) return
         setIntent(intent)
         Log.i(TAG, "onNewIntent")
         handleIntent(intent)
+    }
+
+    private fun isSameIntent(newIntent: Intent): Boolean {
+        val old = intent ?: return false
+        // Compare URIs first
+        val oldUri = old.data ?: old.clipData?.getItemAt(0)?.uri
+        val newUri = newIntent.data ?: newIntent.clipData?.getItemAt(0)?.uri
+        if (oldUri != null && oldUri == newUri) return true
+        // Fall back to comparing EXTRA_TEXT links
+        val oldText = safe { old.getStringExtra(Intent.EXTRA_TEXT) }
+        val newText = safe { newIntent.getStringExtra(Intent.EXTRA_TEXT) }
+        return oldText != null && oldText == newText
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
When the activity was already open (e.g. after pressing the device home button) and a new file was opened, the new intent was silently dropped and the previous file continued playing. Pressing Back and reopening worked fine because that path hit `onCreate()` fresh.

The root cause is that Android reuses an existing activity instance and delivers the new intent via `onNewIntent()` instead of `onCreate()`. Since `onNewIntent()` was not overridden, the new intent was never handled.

Additionally, with the new `onNewIntent()` handling, opening the same file that is already playing would now cause it to unnecessarily reload as well. Therefore, we add a new `isSameIntent` check to prevent the same currently playing file from reloading unnecessarily.