### PR TITLE
Fix process death and recreation causing generator conflict

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -131,6 +131,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.io.Serializable
 import java.util.Calendar
+import java.util.UUID
 
 @OptIn(UnstableApi::class)
 class GeneratorPlayer : FullScreenPlayer() {
@@ -139,11 +140,13 @@ class GeneratorPlayer : FullScreenPlayer() {
         const val CHANNEL_ID = 7340
         const val STOP_ACTION = "stopcs3"
 
-        private var lastUsedGenerator: IGenerator? = null
+        private var generatorMap = mutableMapOf<String, IGenerator>()
         fun newInstance(generator: IGenerator, syncData: HashMap<String, String>? = null): Bundle {
             Log.i(TAG, "newInstance = $syncData")
-            lastUsedGenerator = generator
+            val key = UUID.randomUUID().toString()
+            generatorMap[key] = generator
             return Bundle().apply {
+                putString("generatorKey", key)
                 if (syncData != null) putSerializable("syncData", syncData)
             }
         }
@@ -2125,13 +2128,17 @@ class GeneratorPlayer : FullScreenPlayer() {
         }
     }
 
+    private var lastUsedGenerator: IGenerator? = null
     override fun onBindingCreated(binding: FragmentPlayerBinding, savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(this)[PlayerGeneratorViewModel::class.java]
         sync = ViewModelProvider(this)[SyncViewModel::class.java]
+
+        val key = arguments?.getString("generatorKey")
+        lastUsedGenerator = key?.let { generatorMap[it] }
         viewModel.attachGenerator(lastUsedGenerator)
+
         unwrapBundle(savedInstanceState)
         unwrapBundle(arguments)
-
         super.onBindingCreated(binding, savedInstanceState)
 
         var langFilterList = listOf<String>()


### PR DESCRIPTION
If the system stops the activity (process death) and you open it up again (recreates it), but you last actually used DownloadedPlayerActivity generator and links, and you also have the player open in MainActivity, then the generator loses its state and sometimes uses the wrong one and loads the wrong links from a different instance. Using unique keys for the generator should fix that (or does for me anyway).