### PR TITLE
Minor fixes to player

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -763,12 +763,10 @@ open class FullScreenPlayer : AbstractPlayerFragment<FragmentPlayerBinding>(
             }
         }
         playerBinding?.apply {
-
             playerLockHolder.isGone = isGone
             playerVideoBar.isGone = isGone
 
-            playerPausePlay.isGone = isGone
-            // player_buffering?.isGone = isGone
+            playerPausePlayHolderHolder.isGone = isGone
             playerTopHolder.isGone = isGone
             val showPlayerEpisodes = !isGone && isThereEpisodes()
             playerEpisodesButtonRoot.isVisible = showPlayerEpisodes
@@ -778,7 +776,6 @@ open class FullScreenPlayer : AbstractPlayerFragment<FragmentPlayerBinding>(
             playerEpisodeFiller.isGone = isGone
             playerCenterMenu.isGone = isGone
             playerLock.isGone = !isShowing
-            // player_media_route_button?.isClickable = !isGone
             playerGoBackHolder.isGone = isGone
             playerSourcesBtt.isGone = isGone
             playerSkipEpisode.isClickable = !isGone
@@ -1176,15 +1173,6 @@ open class FullScreenPlayer : AbstractPlayerFragment<FragmentPlayerBinding>(
                         text.isSelected = true
                         text.isVisible = true
                     }
-                }
-            }
-
-            playerPausePlay.setOnClickListener {
-                autoHide()
-                if (currentPlayerStatus == CSPlayerLoading.IsEnded && isLayout(PHONE)) {
-                    player.handleEvent(CSPlayerEvent.Restart)
-                } else {
-                    player.handleEvent(CSPlayerEvent.PlayPauseToggle)
                 }
             }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -780,11 +780,7 @@ open class FullScreenPlayer : AbstractPlayerFragment<FragmentPlayerBinding>(
             playerGoBackHolder.isGone = isGone
             playerSourcesBtt.isGone = isGone
             shadowOverlay.isGone = isGone
-
             playerSkipEpisode.isClickable = !isGone
-            playerPausePlay.isClickable = !isGone
-            playerRew.isClickable = !isGone
-            playerFfwd.isClickable = !isGone
         }
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -766,7 +766,8 @@ open class FullScreenPlayer : AbstractPlayerFragment<FragmentPlayerBinding>(
             playerLockHolder.isGone = isGone
             playerVideoBar.isGone = isGone
 
-            playerPausePlayHolderHolder.isGone = isGone
+            playerPausePlayHolderHolder.isGone =
+                isGone || currentPlayerStatus == CSPlayerLoading.IsBuffering
             playerTopHolder.isGone = isGone
             val showPlayerEpisodes = !isGone && isThereEpisodes()
             playerEpisodesButtonRoot.isVisible = showPlayerEpisodes
@@ -778,7 +779,12 @@ open class FullScreenPlayer : AbstractPlayerFragment<FragmentPlayerBinding>(
             playerLock.isGone = !isShowing
             playerGoBackHolder.isGone = isGone
             playerSourcesBtt.isGone = isGone
+            shadowOverlay.isGone = isGone
+
             playerSkipEpisode.isClickable = !isGone
+            playerPausePlay.isClickable = !isGone
+            playerRew.isClickable = !isGone
+            playerFfwd.isClickable = !isGone
         }
     }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerView.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerView.kt
@@ -375,7 +375,8 @@ class PlayerView @JvmOverloads constructor(
             exoFfwdText?.text = context.getString(R.string.ffw_text_regular_format).format(seekSecs)
 
             playerPausePlay?.setOnClickListener {
-                if (currentPlayerStatus == CSPlayerLoading.IsEnded) {
+                scheduleAutoHide()
+                if (currentPlayerStatus == CSPlayerLoading.IsEnded && isLayout(PHONE)) {
                     player.handleEvent(CSPlayerEvent.Restart, PlayerEventSource.UI)
                 } else {
                     player.handleEvent(CSPlayerEvent.PlayPauseToggle, PlayerEventSource.UI)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
@@ -58,6 +58,12 @@ class ResultTrailerPlayer : ResultFragmentPhone() {
 
     override fun onHidePlayerUI() = uiReset()
 
+    // When the hold-speedup gesture fires, hide controls so the video is unobstructed.
+    // The speedup button show/hide and speed change are handled by PlayerView.
+    override fun onHoldSpeedUp(show: Boolean) {
+        if (show && isShowing) onSingleTap()
+    }
+
     override fun nextEpisode() {}
     override fun prevEpisode() {}
     override fun playerPositionChanged(position: Long, duration: Long) {}

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
@@ -63,6 +63,13 @@ class ResultTrailerPlayer : ResultFragmentPhone() {
         if (show && isShowing) uiReset()
     }
 
+    override fun onGestureEnd(hadSwipe: Boolean, wasUiShowing: Boolean) {
+        if (!player.getIsPlaying() && hadSwipe && wasUiShowing && !isShowing) {
+            isShowing = true
+            showControls()
+        } else playerHostView?.scheduleAutoHide()
+    }
+
     override fun nextEpisode() {}
     override fun prevEpisode() {}
     override fun playerPositionChanged(position: Long, duration: Long) {}

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
@@ -38,9 +38,8 @@ class ResultTrailerPlayer : ResultFragmentPhone() {
 
     // Single-tap on empty player area: toggle controls.
     override fun onSingleTap() {
-        if (!introVisible) {
-            if (isShowing) uiReset() else showControls()
-        }
+        if (introVisible) return
+        if (isShowing) uiReset() else showControls()
     }
 
     private fun showControls() {
@@ -61,7 +60,7 @@ class ResultTrailerPlayer : ResultFragmentPhone() {
     // When the hold-speedup gesture fires, hide controls so the video is unobstructed.
     // The speedup button show/hide and speed change are handled by PlayerView.
     override fun onHoldSpeedUp(show: Boolean) {
-        if (show && isShowing) onSingleTap()
+        if (show && isShowing) uiReset()
     }
 
     override fun nextEpisode() {}

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
@@ -218,6 +218,10 @@ class ResultTrailerPlayer : ResultFragmentPhone() {
             shadowOverlay.isVisible = controlsVisible
             playerPausePlayHolderHolder.isVisible =
                 controlsVisible && playerHostView?.currentPlayerStatus != CSPlayerLoading.IsBuffering
+
+            playerPausePlay.isClickable = controlsVisible
+            playerRew.isClickable = controlsVisible
+            playerFfwd.isClickable = controlsVisible
         }
         // Fade center controls in/out; also resets stale fillAfter alpha from seek animations.
         playerHostView?.gestureHelper?.animateCenterControls(if (isShowing && !introVisible) 1f else 0f)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultTrailerPlayer.kt
@@ -218,10 +218,6 @@ class ResultTrailerPlayer : ResultFragmentPhone() {
             shadowOverlay.isVisible = controlsVisible
             playerPausePlayHolderHolder.isVisible =
                 controlsVisible && playerHostView?.currentPlayerStatus != CSPlayerLoading.IsBuffering
-
-            playerPausePlay.isClickable = controlsVisible
-            playerRew.isClickable = controlsVisible
-            playerFfwd.isClickable = controlsVisible
         }
         // Fade center controls in/out; also resets stale fillAfter alpha from seek animations.
         playerHostView?.gestureHelper?.animateCenterControls(if (isShowing && !introVisible) 1f else 0f)


### PR DESCRIPTION
Fixes:

* Shadow overlay not properly hidden (except in trailer player)
* ~~Sometimes the play pause or fast forward/rewind buttons would be clicked again even after they had already hidden (usually only for about 0.2 seconds though)~~ (not doing in this for now as I don't think it is a proper fix)
* Duplicate `setOnClickListener` for `playerPausePlay` (one in `PlayerView` and one in `FullScreenPlayer`) - the one in `PlayerView` accidentally omitted the `isLayout(PHONE)` check, causing phone-only behavior to also apply on TV and Emulator
* Buffer icon sometimes overlaps play/pause in `FullScreenPlayer` (not trailer)
* 2x speed on trailer not hiding controls, an inconsistent behavior from `FullScreenPlayer`
* UI not showing after gesture end if it was visible before while paused (trailer-only)