### PR TITLE
Fixobserveorder

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -2298,7 +2298,7 @@ class GeneratorPlayer : FullScreenPlayer() {
             }
 
             safe {
-                if (viewModel.state.links.any { link ->
+                if (!isPlayerActive.get() && viewModel.state.links.any { link ->
                         getLinkPriority(currentQualityProfile, link.first) >=
                                 QualityDataHelper.AUTO_SKIP_PRIORITY
                     }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -2146,6 +2146,7 @@ class GeneratorPlayer : FullScreenPlayer() {
     fun releasePlayer() {
         player.release()
         currentSelectedSubtitles = null
+        currentSelectedLink = null
         isPlayerActive.set(false)
         binding?.overlayLoadingSkipButton?.isVisible = false
         binding?.playerLoadingOverlay?.isVisible = true
@@ -2206,8 +2207,12 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         preferredAutoSelectSubtitles = getAutoSelectLanguageTagIETF()
 
-        if (currentSelectedLink == null) {
+        val selectedLink = currentSelectedLink
+        if (selectedLink == null) {
             viewModel.loadLinks()
+        } else {
+            // Recreated view, so we need to recreate the
+            loadLink(selectedLink, true)
         }
 
         binding.overlayLoadingSkipButton.setOnClickListener {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -2159,6 +2159,11 @@ class GeneratorPlayer : FullScreenPlayer() {
         activity?.popCurrentPage()
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putInt("index", viewModel.episodeIndex)
+        super.onSaveInstanceState(outState)
+    }
+
     override fun onBindingCreated(binding: FragmentPlayerBinding, savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(this)[PlayerGeneratorViewModel::class.java]
         sync = ViewModelProvider(this)[SyncViewModel::class.java]

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -2170,8 +2170,7 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         val uuid = savedInstanceState?.getString("uuid") ?: arguments?.getString("uuid")
         val index = savedInstanceState?.getInt("index") ?: arguments?.getInt("index")
-
-        viewModel.attachGenerator(generators[uuid], index)
+        val generator = generators[uuid]
 
         unwrapBundle(savedInstanceState)
         unwrapBundle(arguments)
@@ -2179,10 +2178,11 @@ class GeneratorPlayer : FullScreenPlayer() {
         super.onBindingCreated(binding, savedInstanceState)
 
         // Avoid showing no links found
-        if(viewModel.generator == null) {
+        if (generator == null || index == null) {
             exitPlayer()
             return
         }
+        viewModel.attachGenerator(generator, index)
 
         context?.let { ctx ->
             val settingsManager = PreferenceManager.getDefaultSharedPreferences(ctx)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -143,7 +143,11 @@ class GeneratorPlayer : FullScreenPlayer() {
         const val STOP_ACTION = "stopcs3"
 
         private val generators = ConcurrentHashMap<String, VideoGenerator<*>>()
-        fun newInstance(generator: VideoGenerator<*>, index : Int, syncData: HashMap<String, String>? = null): Bundle {
+        fun newInstance(
+            generator: VideoGenerator<*>,
+            index: Int,
+            syncData: HashMap<String, String>? = null
+        ): Bundle {
             Log.i(TAG, "newInstance = $syncData")
             val uuid = UUID.randomUUID().toString()
             generators[uuid] = generator
@@ -178,12 +182,14 @@ class GeneratorPlayer : FullScreenPlayer() {
     private var isNextEpisode: Boolean = false // this is used to reset the watch time
 
     private var preferredAutoSelectSubtitles: String? = null // null means do nothing, "" means none
-    private val allMeta: List<ResultEpisode>? get() = viewModel.state.generatorState?.allMeta?.filterIsInstance<ResultEpisode>()?.map { episode ->
-        // Refresh all the episodes watch duration
-        getViewPos(episode.id)?.let { data ->
-            episode.copy(position = data.position, duration = data.duration)
-        } ?: episode
-    }
+    private val allMeta: List<ResultEpisode>?
+        get() = viewModel.state.generatorState?.allMeta?.filterIsInstance<ResultEpisode>()
+            ?.map { episode ->
+                // Refresh all the episodes watch duration
+                getViewPos(episode.id)?.let { data ->
+                    episode.copy(position = data.position, duration = data.duration)
+                } ?: episode
+            }
 
     private fun setSubtitles(subtitle: SubtitleData?, userInitiated: Boolean): Boolean {
         // If subtitle is changed and user initiated -> Save the language
@@ -1541,7 +1547,7 @@ class GeneratorPlayer : FullScreenPlayer() {
 
     private fun startPlayer() {
         // We don't want double load when you skip loading
-        if(isPlayerActive.get()) {
+        if (isPlayerActive.get()) {
             return
         }
 
@@ -2165,6 +2171,13 @@ class GeneratorPlayer : FullScreenPlayer() {
         unwrapBundle(arguments)
 
         super.onBindingCreated(binding, savedInstanceState)
+
+        // Avoid showing no links found
+        if(viewModel.generator == null) {
+            exitPlayer()
+            return
+        }
+
         context?.let { ctx ->
             val settingsManager = PreferenceManager.getDefaultSharedPreferences(ctx)
             showName = settingsManager.getBoolean(ctx.getString(R.string.show_name_key), true)
@@ -2200,7 +2213,7 @@ class GeneratorPlayer : FullScreenPlayer() {
         binding.overlayLoadingSkipButton.setOnClickListener {
             // Mark as "success" early
             viewModel.modifyState {
-                copy(loading = Resource.Success(true))
+                copy(loading = Resource.Success(Unit))
             }
         }
 
@@ -2218,11 +2231,13 @@ class GeneratorPlayer : FullScreenPlayer() {
             }
         }
 
-        observe(viewModel.currentStamps) { stamps ->
+        observe(viewModel.currentStamps) { (stamps, instance) ->
+            if (instance != viewModel.state.instance) return@observe // Outdated observe
             player.addTimeStamps(stamps)
         }
 
-        observe(viewModel.currentSubtitles) { subtitles ->
+        observe(viewModel.currentSubtitles) { (subtitles, instance) ->
+            if (instance != viewModel.state.instance) return@observe // Outdated observe
             player.setActiveSubtitles(subtitles)
 
             // If the file is downloaded then do not select auto select the subtitles
@@ -2233,7 +2248,9 @@ class GeneratorPlayer : FullScreenPlayer() {
                 autoSelectSubtitles()
             }
         }
-        observe(viewModel.loadingLinks) { loading ->
+        observe(viewModel.loadingLinks) { (loading, instance) ->
+            if (instance != viewModel.state.instance) return@observe // Outdated observe
+
             when (loading) {
                 is Resource.Loading -> {
                     releasePlayer()
@@ -2254,7 +2271,9 @@ class GeneratorPlayer : FullScreenPlayer() {
             }
         }
 
-        observe(viewModel.currentLinks) { links ->
+        observe(viewModel.currentLinks) { (links, instance) ->
+            if (instance != viewModel.state.instance) return@observe // Outdated observe
+
             val turnVisible = links.isNotEmpty() && viewModel.generator?.canSkipLoading == true
             val wasGone = binding.overlayLoadingSkipButton.isGone
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGeneratorViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGeneratorViewModel.kt
@@ -268,14 +268,10 @@ class PlayerGeneratorViewModel : ViewModel() {
         loadLinks()
     }
 
-    fun attachGenerator(newGenerator: VideoGenerator<*>?, index: Int?) {
+    fun attachGenerator(newGenerator: VideoGenerator<*>, index: Int) {
         Log.i(TAG, "attachGenerator with generator=$newGenerator and index=$index")
-        if (generator == null) {
-            generator = newGenerator
-            if (index != null) {
-                episodeIndex = index
-            }
-        }
+        generator = newGenerator
+        episodeIndex = index
     }
 
     /**

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGeneratorViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGeneratorViewModel.kt
@@ -47,8 +47,9 @@ data class VideoState(
     val subtitles: PersistentSet<SubtitleData> = persistentSetOf(),
     val links: PersistentSet<VideoLink> = persistentSetOf(),
     val stamps: PersistentList<VideoSkipStamp> = persistentListOf(),
-    val loading: Resource<Boolean?> = Resource.Loading(),
+    val loading: Resource<Unit> = Resource.Loading(),
     val generatorState: GeneratorState? = null,
+    val instance: Int,
 ) {
     /**
      * This acts as a local cache for sorted links that are not copied over by the copy constructor.
@@ -114,6 +115,11 @@ data class VideoState(
     fun set(items: Collection<VideoSkipStamp>): VideoState = copy(stamps = items.toPersistentList())
 }
 
+data class VideoLive<T>(
+    val value: T,
+    val instance: Int,
+)
+
 class PlayerGeneratorViewModel : ViewModel() {
     companion object {
         const val TAG = "PlayViewGen"
@@ -132,20 +138,21 @@ class PlayerGeneratorViewModel : ViewModel() {
      * This value can be used without Synchronized or locking when reading, as all fields are immutable.
      * */
     @Volatile
-    var state = VideoState()
+    var state = VideoState(instance = 0)
         private set
 
-    private val _currentLinks = MutableLiveData<Set<Pair<ExtractorLink?, ExtractorUri?>>>(setOf())
-    val currentLinks: LiveData<Set<Pair<ExtractorLink?, ExtractorUri?>>> = _currentLinks
+    private val _currentLinks =
+        MutableLiveData<VideoLive<Set<Pair<ExtractorLink?, ExtractorUri?>>>>(null)
+    val currentLinks: LiveData<VideoLive<Set<Pair<ExtractorLink?, ExtractorUri?>>>> = _currentLinks
 
-    private val _currentSubtitles = MutableLiveData<Set<SubtitleData>>(setOf())
-    val currentSubtitles: LiveData<Set<SubtitleData>> = _currentSubtitles
+    private val _currentSubtitles = MutableLiveData<VideoLive<Set<SubtitleData>>>(null)
+    val currentSubtitles: LiveData<VideoLive<Set<SubtitleData>>> = _currentSubtitles
 
-    private val _loadingLinks = MutableLiveData<Resource<Boolean?>>()
-    val loadingLinks: LiveData<Resource<Boolean?>> = _loadingLinks
+    private val _loadingLinks = MutableLiveData<VideoLive<Resource<Unit>>>()
+    val loadingLinks: LiveData<VideoLive<Resource<Unit>>> = _loadingLinks
 
-    private val _currentStamps = MutableLiveData<List<VideoSkipStamp>>(emptyList())
-    val currentStamps: LiveData<List<VideoSkipStamp>> = _currentStamps
+    private val _currentStamps = MutableLiveData<VideoLive<List<VideoSkipStamp>>>(null)
+    val currentStamps: LiveData<VideoLive<List<VideoSkipStamp>>> = _currentStamps
 
     /**
      * Modifies the `state` variable safely, and with the correct observe behavior.
@@ -158,6 +165,15 @@ class PlayerGeneratorViewModel : ViewModel() {
         val oldState = state
         state = op.invoke(oldState)
 
+        /** New instance, always push state */
+        if (state.instance != oldState.instance) {
+            _currentSubtitles.postValue(VideoLive(state.subtitles, state.instance))
+            _currentStamps.postValue(VideoLive(state.stamps, state.instance))
+            _currentLinks.postValue(VideoLive(state.links, state.instance))
+            _loadingLinks.postValue(VideoLive(state.loading, state.instance))
+            return
+        }
+
         /**
          * Only post the changed values, this makes sure we do not invoke the "observe"
          *
@@ -165,15 +181,15 @@ class PlayerGeneratorViewModel : ViewModel() {
          * to avoid comparing the entire set or list as "Persistent" classes will hold the same reference if they are unchanged.
          * */
         if (state.links !== oldState.links)
-            _currentLinks.postValue(state.links)
+            _currentLinks.postValue(VideoLive(state.links, state.instance))
         if (state.stamps !== oldState.stamps)
-            _currentStamps.postValue(state.stamps)
+            _currentStamps.postValue(VideoLive(state.stamps, state.instance))
         if (state.subtitles !== oldState.subtitles)
-            _currentSubtitles.postValue(state.subtitles)
+            _currentSubtitles.postValue(VideoLive(state.subtitles, state.instance))
 
         /** Normal equality here as it is not a collection */
         if (state.loading != oldState.loading)
-            _loadingLinks.postValue(state.loading)
+            _loadingLinks.postValue(VideoLive(state.loading, state.instance))
     }
 
     private val _currentSubtitleYear = MutableLiveData<Int?>(null)
@@ -253,6 +269,7 @@ class PlayerGeneratorViewModel : ViewModel() {
     }
 
     fun attachGenerator(newGenerator: VideoGenerator<*>?, index: Int?) {
+        Log.i(TAG, "attachGenerator with generator=$newGenerator and index=$index")
         if (generator == null) {
             generator = newGenerator
             if (index != null) {
@@ -321,45 +338,48 @@ class PlayerGeneratorViewModel : ViewModel() {
     }
 
     fun loadLinks(sourceTypes: Set<ExtractorLinkType> = LOADTYPE_INAPP) {
-        Log.i(TAG, "loadLinks")
+        Log.i(TAG, "loadLinks with generator=$generator and index=$episodeIndex")
         currentJob?.cancel()
         val index = episodeIndex
 
-        currentJob = viewModelScope.launchSafe {
-            // Clear old data and reset the state
-            modifyState {
-                VideoState(
-                    generatorState = generator?.let { gen ->
-                        GeneratorState(
-                            meta = gen.videos.getOrNull(index),
-                            nextMeta = gen.videos.getOrNull(index + 1),
-                            id = gen.getId(index),
-                            response = (gen as? RepoLinkGenerator)?.page,
-                            index = index,
-                            allMeta = gen.videos
-                        )
-                    }
-                )
-            }
+        // Clear old data and reset the state
+        modifyState {
+            VideoState(
+                generatorState = generator?.let { gen ->
+                    GeneratorState(
+                        meta = gen.videos.getOrNull(index),
+                        nextMeta = gen.videos.getOrNull(index + 1),
+                        id = gen.getId(index),
+                        response = (gen as? RepoLinkGenerator)?.page,
+                        index = index,
+                        allMeta = gen.videos
+                    )
+                },
+                instance = instance + 1
+            )
+        }
 
+        currentJob = viewModelScope.launchSafe {
             // Load more data
             val loadingState = safeApiCall {
                 generator?.generateLinks(
                     sourceTypes = sourceTypes,
                     clearCache = forceClearCache,
                     callback = { link ->
-                        modifyState {
-                            add(link)
-                        }
+                        if (isActive)
+                            modifyState {
+                                add(link)
+                            }
                     },
                     isCasting = false,
                     offset = index,
                     subtitleCallback = { link ->
-                        if (isValidSubtitle(link))
+                        if (isActive && isValidSubtitle(link))
                             modifyState {
                                 add(link)
                             }
                     })
+                Unit
             }
 
             if (!isActive) {
@@ -368,9 +388,13 @@ class PlayerGeneratorViewModel : ViewModel() {
 
             /** Only mark as success if we have not skipped loading */
             modifyState {
-                when (loading) {
-                    is Resource.Loading -> copy(loading = loadingState)
-                    else -> this
+                if (!isActive) {
+                    this
+                } else {
+                    when (loading) {
+                        is Resource.Loading -> copy(loading = loadingState)
+                        else -> this
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGeneratorViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGeneratorViewModel.kt
@@ -129,7 +129,7 @@ class PlayerGeneratorViewModel : ViewModel() {
     var generator: VideoGenerator<*>? = null
 
     @Volatile
-    private var episodeIndex: Int = 0
+    var episodeIndex: Int = 0
 
     /**
      * The state of the video player, only modify it by modifyState to make sure observe is called,

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGeneratorViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/PlayerGeneratorViewModel.kt
@@ -341,6 +341,7 @@ class PlayerGeneratorViewModel : ViewModel() {
         // Clear old data and reset the state
         modifyState {
             VideoState(
+                loading = Resource.Loading(),
                 generatorState = generator?.let { gen ->
                     GeneratorState(
                         meta = gen.videos.getOrNull(index),


### PR DESCRIPTION
The problem with the old system was that observe might say that the link loading is finished when the viewModel.state disagrees, and this fixes that by dropping livedata

1. This should fix some issues with #2764 by dropping observe calls made with the wrong instance number. 
2. I also moved the loadLinks state change to not race the observe by having the state change immediately. 
3. The player also quits if it is fully recreated without showing a "no links found" if the generator does not exists. We need to serialize the generator if we want full relaunch capability, do note that this is not possible inside a bundle due to size limit.
4. And finally when the fragment is recreated it restarts the player from the same link to properly resync the UI.

I tested with:
```
adb shell am kill com.lagradost.cloudstream3.prerelease.debug
```
```
adb shell am force-stop com.lagradost.cloudstream3.prerelease.debug
```

```kotlin
playerGoBack.setOnClickListener {
    requireFragmentManager()
        .beginTransaction()
        .detach(this@FullScreenPlayer).commit()
    requireFragmentManager()
        .beginTransaction()
        .attach(this@FullScreenPlayer).commit()
}
```
```kotlin
playerGoBack.setOnClickListener {
    activity?.recreate()
}
```
``` Background process limit -> No background processes ```.

@Luna712

This should give:
Fragment recreated -> Reloads player
Activity recreated -> Reloads links (may use link cache)
Process killed -> Exists player

There might be some other possibility I am unaware of given some weird recreation order, but now the view-model should be in-sync at all times. 
