### PR TITLE
Add support for ksoup and migrate core extractors to it

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -253,7 +253,8 @@ dependencies {
     implementation(libs.qrcode.kotlin) // QR Code for PIN Auth on TV
 
     // Extensions & Other Libs
-    implementation(libs.jsoup) // HTML Parser
+    implementation(libs.jsoup) // HTML Parser (Deprecated usage)
+    implementation(libs.ksoup) // HTML Parser (KMP support)
     implementation(libs.rhino) // Run JavaScript
     implementation(libs.fuzzywuzzy) // Library/Ext Searching with Levenshtein Distance
     implementation(libs.safefile) // To Prevent the URI File Fu*kery

--- a/app/src/main/java/com/lagradost/cloudstream3/syncproviders/providers/Addic7ed.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/syncproviders/providers/Addic7ed.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.syncproviders.providers
 
 import com.lagradost.cloudstream3.AllLanguagesName
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.subtitles.AbstractSubtitleEntities.SubtitleEntity
 import com.lagradost.cloudstream3.subtitles.AbstractSubtitleEntities.SubtitleSearch
 import com.lagradost.cloudstream3.syncproviders.AuthData
@@ -66,7 +67,7 @@ class Addic7ed : SubtitleAPI() {
         }
 
         val response = app.get(url = "$HOST/search.php?search=$searchQuery&Submit=Search")
-        val hostDocument = response.document
+        val hostDocument = response.ksoupDocument
 
         // 1st case: found one movie or episode. Redirected to $HOST/movie/1234 or $HOST/serie/show-name/$seasonNum/$epNum/ep-name
         if (response.url.contains("/movie/") || response.url.contains("/serie/"))
@@ -78,7 +79,7 @@ class Addic7ed : SubtitleAPI() {
             val doc = app.get(
                 "$HOST/ajax_loadShow.php?show=$showId&season=$seasonNum&langs=|$langNumAddic7ed|&hd=0&hi=0",
                 referer = "$HOST/"
-            ).document
+            ).ksoupDocument
 
             // get direct subtitles links from list
             return doc.select("#season tbody tr").mapNotNull { node ->
@@ -105,7 +106,7 @@ class Addic7ed : SubtitleAPI() {
         // filter download page by language. Do not work for movies :/
         if (downloadPage.contains("/serie/"))
             downloadPage = downloadPage.substringBeforeLast("/") + "/$langNumAddic7ed"
-        val doc = app.get(url = downloadPage).document
+        val doc = app.get(url = downloadPage).ksoupDocument
 
         // get subtitles links from download page
         return doc.select(".tabel95 .tabel95 tr:has(.language):contains($langName)").mapNotNull { node ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ juniversalchardet = "2.5.0"
 kotlinGradlePlugin = "2.3.20"
 kotlinxCollectionsImmutable = "0.4.0"
 kotlinxCoroutinesCore = "1.10.2"
+ksoup = "0.2.6"
 lifecycleKtx = "2.10.0"
 material = "1.14.0-beta01"
 media3 = "1.9.3"
@@ -83,6 +84,7 @@ junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "junitKtx" }
 juniversalchardet = { module = "com.github.albfernandez:juniversalchardet", version.ref = "juniversalchardet" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
+ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
 lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleKtx" }
 lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleKtx" }
 material = { module = "com.google.android.material:material", version.ref = "material" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -58,7 +58,7 @@ kotlin {
             implementation(libs.jackson.module.kotlin) // JSON Parser
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.fuzzywuzzy) // Match Extractors
-            implementation(libs.jsoup) // HTML Parser
+            implementation(libs.ksoup) // HTML Parser
             implementation(libs.rhino) // Run JavaScript
             implementation(libs.newpipeextractor)
             implementation(libs.tmdb.java) // TMDB API v3 Wrapper Made with RetroFit

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -177,7 +177,7 @@ object APIHolder {
                     .substringBefore("/")
             val recapToken =
                 app.get("https://www.google.com/recaptcha/api2/anchor?ar=1&hl=en&size=invisible&cb=cs3&k=$key&co=$domain&v=$vToken")
-                    .document
+                    .ksoupDocument
                     .selectFirst("#recaptcha-token")?.attr("value")
             if (recapToken != null) {
                 return app.post(

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainActivity.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainActivity.kt
@@ -3,6 +3,9 @@ package com.lagradost.cloudstream3
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Document
+import com.lagradost.nicehttp.NiceResponse
 import com.lagradost.nicehttp.Requests
 import com.lagradost.nicehttp.ResponseParser
 import kotlin.reflect.KClass
@@ -36,6 +39,10 @@ private val jacksonResponseParser = object : ResponseParser {
 var app = Requests(responseParser = jacksonResponseParser).apply {
     defaultHeaders = mapOf("user-agent" to USER_AGENT)
 }
+
+/** Parses the response body as a Ksoup Document. */
+val NiceResponse.ksoupDocument: Document
+    get() = Ksoup.parse(text)
 
 /** Same as the default app networking helper, but this instance ignores SSL certificates.
  * This should NEVER be used for sensitive networking operations such as logins. Only use this when required. */

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Blogger.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Blogger.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.*
 import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 
@@ -12,7 +13,7 @@ open class Blogger : ExtractorApi() {
 
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink> {
         val sources = mutableListOf<ExtractorLink>()
-        with(app.get(url).document) {
+        with(app.get(url).ksoupDocument) {
             this.select("script").map { script ->
                 if (script.data().contains("\"streams\":[")) {
                     val data = script.data().substringAfter("\"streams\":[")

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Cda.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Cda.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
@@ -25,7 +26,7 @@ open class Cda : ExtractorApi() {
                 "User-Agent" to USER_AGENT,
                 "Cookie" to "cda.player=html5"
             )
-        ).document
+        ).ksoupDocument
         val dataRaw = doc.selectFirst("[player_data]")?.attr("player_data") ?: return null
         val playerData = tryParseJson<PlayerData>(dataRaw) ?: return null
         return listOf(

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Embedgram.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Embedgram.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getQualityFromName
@@ -19,7 +20,7 @@ open class Embedgram : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val document = app.get(url, referer = referer).document
+        val document = app.get(url, referer = referer).ksoupDocument
         val link = document.select("video source:last-child").attr("src")
         val quality = document.select("video source:last-child").attr("title")
         callback.invoke(

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.ExtractorLinkType
@@ -16,9 +17,9 @@ open class EmturbovidExtractor : ExtractorApi() {
         val response = app.get(
             url, referer = referer ?: "$mainUrl/"
         )
-        val playerScript =
-            response.document.selectXpath("//script[contains(text(),'var urlPlay')]")
-                .html()
+        val playerScript = response.ksoupDocument
+            .select("script:contains(var urlPlay)")
+            .html()
 
         val sources = mutableListOf<ExtractorLink>()
         if (playerScript.isNotBlank()) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Fastream.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Fastream.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.amap
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getAndUnpack
@@ -30,9 +31,9 @@ open class Fastream : ExtractorApi() {
                     "file_code" to id,
                     "auto" to "1"
                 )
-            ).document
+            ).ksoupDocument
         } else {
-            app.get(url, referer = url).document
+            app.get(url, referer = url).ksoupDocument
         }
         response.select("script").amap { script ->
             if (getPacked(script.data()) != null) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filegram.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filegram.kt
@@ -1,13 +1,14 @@
 package com.lagradost.cloudstream3.extractors
 
+import com.fleeksoft.ksoup.nodes.Element
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getAndUnpack
-import org.jsoup.nodes.Element
 
 open class Filegram : ExtractorApi() {
     override val name = "Filegram"
@@ -32,7 +33,7 @@ open class Filegram : ExtractorApi() {
             "user-agent" to USER_AGENT,
         )
 
-        val doc = app.get(getEmbedUrl(url), referer = referer).document
+        val doc = app.get(getEmbedUrl(url), referer = referer).ksoupDocument
         val unpackedJs = unpackJs(doc).toString()
 
         JwPlayerHelper.extractStreamLinks(unpackedJs, name, mainUrl, callback, subtitleCallback, headers = header)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filemoon.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filemoon.kt
@@ -4,6 +4,7 @@ import com.lagradost.api.Log
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.network.WebViewResolver
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
@@ -47,10 +48,10 @@ open class FilemoonV2 : ExtractorApi() {
         )
 
         val initialResponse = app.get(url, defaultHeaders)
-        val iframeSrcUrl = initialResponse.document.selectFirst("iframe")?.attr("src")
+        val iframeSrcUrl = initialResponse.ksoupDocument.selectFirst("iframe")?.attr("src")
 
         if (iframeSrcUrl.isNullOrEmpty()) {
-            val fallbackScriptData = initialResponse.document
+            val fallbackScriptData = initialResponse.ksoupDocument
                 .selectFirst("script:containsData(function(p,a,c,k,e,d))")
                 ?.data().orEmpty()
             val unpackedScript = JsUnpacker(fallbackScriptData).unpack()
@@ -74,7 +75,7 @@ open class FilemoonV2 : ExtractorApi() {
         val iframeHeaders = defaultHeaders + ("Accept-Language" to "en-US,en;q=0.5")
         val iframeResponse = app.get(iframeSrcUrl, headers = iframeHeaders)
 
-        val iframeScriptData = iframeResponse.document
+        val iframeScriptData = iframeResponse.ksoupDocument
             .selectFirst("script:containsData(function(p,a,c,k,e,d))")
             ?.data().orEmpty()
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filesim.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Filesim.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.*
 import com.lagradost.api.Log
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
@@ -60,7 +61,7 @@ open class Filesim : ExtractorApi() {
         val embedUrl = url.replace("/download/", "/e/")
         var pageResponse = app.get(embedUrl, referer = referer)
 
-        val iframeElement = pageResponse.document.selectFirst("iframe")
+        val iframeElement = pageResponse.ksoupDocument.selectFirst("iframe")
         if (iframeElement != null) {
             val iframeUrl = iframeElement.attr("src")
             pageResponse = app.get(
@@ -76,7 +77,7 @@ open class Filesim : ExtractorApi() {
         val scriptData = if (!getPacked(pageResponse.text).isNullOrEmpty()) {
             getAndUnpack(pageResponse.text)
         } else {
-            pageResponse.document.selectFirst("script:containsData(sources:)")?.data()
+            pageResponse.ksoupDocument.selectFirst("script:containsData(sources:)")?.data()
         }
 
         val linkFound = JwPlayerHelper.extractStreamLinks(scriptData.orEmpty(), name, mainUrl, callback, subtitleCallback)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GamoVideo.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GamoVideo.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 
@@ -18,7 +19,7 @@ open class GamoVideo : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        app.get(url, referer = referer).document.select("script")
+        app.get(url, referer = referer).ksoupDocument.select("script")
             .firstOrNull { JwPlayerHelper.canParseJwScript(it.data()) }!!.let {
                 JwPlayerHelper.extractStreamLinks(it.data(), name, mainUrl, callback, subtitleCallback)
             }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Gdriveplayer.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Gdriveplayer.kt
@@ -1,11 +1,11 @@
 package com.lagradost.cloudstream3.extractors
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fleeksoft.ksoup.nodes.Element
 import com.lagradost.cloudstream3.*
 import com.lagradost.cloudstream3.extractors.helper.AesHelper.cryptoAESHandler
 import com.lagradost.cloudstream3.utils.*
 import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
-import org.jsoup.nodes.Element
 
 class DatabaseGdrive2 : Gdriveplayer() {
     override var mainUrl = "https://databasegdriveplayer.co"
@@ -75,7 +75,7 @@ open class Gdriveplayer : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val document = app.get(url).document
+        val document = app.get(url).ksoupDocument
 
         val eval = unpackJs(document)?.replace("\\", "") ?: return
         val data = Regex("data='(\\S+?)'").first(eval) ?: return

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GoodstreamExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/GoodstreamExtractor.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
@@ -18,7 +19,7 @@ class GoodstreamExtractor : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        app.get(url).document.select("script").map { script ->
+        app.get(url).ksoupDocument.select("script").map { script ->
             if (script.data().contains(Regex("file|player"))) {
                 val urlRegex = Regex("file: \"(https:\\/\\/[a-z0-9.\\/-_?=&]+)\",")
                 urlRegex.find(script.data())?.groupValues?.get(1).let { link ->

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/HubCloud.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/HubCloud.kt
@@ -4,6 +4,7 @@ import com.lagradost.api.Log
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.amap
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
@@ -33,7 +34,7 @@ class HubCloud : ExtractorApi() {
             if ("hubcloud.php" in realUrl) {
                 realUrl
             } else {
-                val rawHref = app.get(realUrl).document.select("#download").attr("href")
+                val rawHref = app.get(realUrl).ksoupDocument.select("#download").attr("href")
                 if (rawHref.startsWith("http", ignoreCase = true)) {
                     rawHref
                 } else {
@@ -50,7 +51,7 @@ class HubCloud : ExtractorApi() {
             return
         }
 
-        val document = app.get(href).document
+        val document = app.get(href).ksoupDocument
         val size = document.selectFirst("i#size")?.text().orEmpty()
         val header = document.selectFirst("div.card-header")?.text().orEmpty()
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Hxfile.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Hxfile.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.*
 
 class Neonime7n : Hxfile() {
@@ -45,7 +46,7 @@ open class Hxfile : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val document = app.get(url, allowRedirects = redirect, referer = referer).document
+        val document = app.get(url, allowRedirects = redirect, referer = referer).ksoupDocument
         with(document) {
             this.select("script").map { script ->
                 if (getPacked(script.data()) != null) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/InternetArchive.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/InternetArchive.kt
@@ -1,15 +1,16 @@
 package com.lagradost.cloudstream3.extractors
 
+import com.fleeksoft.ksoup.nodes.Document
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.newSubtitleFile
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.StringUtils.decodeUri
 import com.lagradost.cloudstream3.utils.newExtractorLink
-import org.jsoup.nodes.Document
 
 open class InternetArchive : ExtractorApi() {
     override val mainUrl = "https://archive.org"
@@ -34,7 +35,7 @@ open class InternetArchive : ExtractorApi() {
     ) {
         val document = archivedItems[url] ?: run {
             try {
-                val doc = app.get(url).document
+                val doc = app.get(url).ksoupDocument
                 archivedItems[url] = doc
                 doc
             } catch (e: Exception) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/JWPlayer.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/JWPlayer.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 
@@ -60,7 +61,7 @@ open class JWPlayer : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val script = app.get(url).document.selectFirst("script:containsData(sources:)") ?: return
+        val script = app.get(url).ksoupDocument.selectFirst("script:containsData(sources:)") ?: return
         JwPlayerHelper.extractStreamLinks(script.data(), name, mainUrl, callback, subtitleCallback)
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Jeniusplay.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Jeniusplay.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.M3u8Helper
@@ -21,7 +22,7 @@ open class Jeniusplay : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val document = app.get(url, referer = "$mainUrl/").document
+        val document = app.get(url, referer = "$mainUrl/").ksoupDocument
         val hash = url.split("/").last().substringAfter("data=")
 
         val m3uLink = app.post(

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Krakenfiles.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Krakenfiles.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
@@ -20,7 +21,7 @@ open class Krakenfiles : ExtractorApi() {
         callback: (ExtractorLink) -> Unit
     ) {
         val id = Regex("/(?:view|embed-video)/([\\da-zA-Z]+)").find(url)?.groupValues?.get(1)
-        val doc = app.get("$mainUrl/embed-video/$id").document
+        val doc = app.get("$mainUrl/embed-video/$id").ksoupDocument
         val link = doc.selectFirst("source")?.attr("src")
 
         callback.invoke(

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/LuluStream.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/LuluStream.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 
@@ -42,7 +43,7 @@ open class LuluStream : ExtractorApi() {
                 "auto" to "1",
                 "referer" to (referer ?: "")
             )
-        ).document
+        ).ksoupDocument
         post.selectFirst("script:containsData(vplayer)")?.data()
             ?.let { script ->
                 JwPlayerHelper.extractStreamLinks(script, name, mainUrl, callback, subtitleCallback)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Mediafire.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Mediafire.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.INFER_TYPE
@@ -19,7 +20,7 @@ open class Mediafire : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val res = app.get(url, referer = referer).document
+        val res = app.get(url, referer = referer).ksoupDocument
         val title = res.select("div.dl-btn-label").text()
         val video = res.selectFirst("a#downloadButton")?.attr("href")
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Moviehab.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Moviehab.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.newSubtitleFile
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
@@ -23,7 +24,7 @@ open class Moviehab : ExtractorApi() {
         callback: (ExtractorLink) -> Unit
     ) {
         val res = app.get(url)
-        res.document.select("video#player").let {
+        res.ksoupDocument.select("video#player").let {
             //should redirect first for making it works
             val link = app.get("$mainUrl/${it.select("source").attr("src")}", referer = url).url
             M3u8Helper.generateM3u8(

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PlayLtXyz.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/PlayLtXyz.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.api.Log
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.*
 import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 
@@ -21,7 +22,7 @@ open class PlayLtXyz: ExtractorApi() {
         var idUser = ""
         var idFile = ""
         var bodyText = ""
-        val doc = app.get(url, referer = referer).document
+        val doc = app.get(url, referer = referer).ksoupDocument
         //Log.i(this.name, "Result => (url, script) $url / ${doc.select("script")}")
         bodyText = doc.select("script").firstOrNull {
             val text = it.toString()

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SBPlay.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SBPlay.kt
@@ -1,5 +1,6 @@
 package com.lagradost.cloudstream3.extractors
 
+import com.fleeksoft.ksoup.Ksoup
 import com.lagradost.cloudstream3.APIHolder.unixTimeMS
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.mvvm.logError
@@ -8,7 +9,6 @@ import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.getPostForm
 import com.lagradost.cloudstream3.utils.newExtractorLink
-import org.jsoup.Jsoup
 
 //class SBPlay1 : SBPlay() {
 //    override var mainUrl = "https://sbplay1.com"
@@ -25,7 +25,7 @@ open class SBPlay : ExtractorApi() {
 
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink> {
         val response = app.get(url, referer = referer).text
-        val document = Jsoup.parse(response)
+        val document = Ksoup.parse(response)
 
         val links = ArrayList<ExtractorLink>()
 
@@ -44,11 +44,11 @@ open class SBPlay : ExtractorApi() {
                         "https://sbplay.one/?op=notifications&open=&_=$unixTimeMS",
                         referer = href
                     )
-                    val hrefDocument = Jsoup.parse(hrefResponse)
+                    val hrefDocument = Ksoup.parse(hrefResponse)
                     val hrefSpan = hrefDocument.selectFirst("span > a")
                     if (hrefSpan == null) {
                         getPostForm(href, hrefResponse)?.let { form ->
-                            val postDocument = Jsoup.parse(form)
+                            val postDocument = Ksoup.parse(form)
                             val downloadBtn =
                                 postDocument.selectFirst("a.downloadbtn")?.attr("href")
                             if (downloadBtn.isNullOrEmpty()) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SecvideoOnline.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/SecvideoOnline.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.newSubtitleFile
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
@@ -24,7 +25,7 @@ open class SecvideoOnline : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val doc = app.get(url, referer = referer).document
+        val doc = app.get(url, referer = referer).ksoupDocument
         for (script in doc.select("script")) {
             val files = fileListRegex.findAll(script.data())
                 .mapNotNull { it.groupValues.getOrNull(1)?.split(",") }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Sendvid.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Sendvid.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.utils.*
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.M3u8Helper.Companion.generateM3u8
 
 open class Sendvid : ExtractorApi() {
@@ -15,7 +16,7 @@ open class Sendvid : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val doc = app.get(url).document
+        val doc = app.get(url).ksoupDocument
         val urlString = doc.select("head meta[property=og:video:secure_url]").attr("content")
         if (urlString.contains("m3u8"))  {
             generateM3u8(

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamSilk.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamSilk.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.*
 
 open class StreamSilk : ExtractorApi() {
@@ -18,7 +19,7 @@ open class StreamSilk : ExtractorApi() {
         callback: (ExtractorLink) -> Unit
     ) {
         val response = app.get(url, headers = mapOf("Accept" to "*/*"))
-        response.document.select("script").firstOrNull {
+        response.ksoupDocument.select("script").firstOrNull {
             it.html().contains("h,u,n,t,e,r")
         }?.html()?.let { hunted ->
             JsHunter(hunted).dehunt()?.let { script ->

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamTape.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamTape.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
@@ -31,7 +32,7 @@ open class StreamTape : ExtractorApi() {
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink>? {
         with(app.get(url)) {
             var result =
-                this.document.select("script").firstOrNull { it.html().contains("botlink').innerHTML") }
+                this.ksoupDocument.select("script").firstOrNull { it.html().contains("botlink').innerHTML") }
                     ?.html()?.lines()?.firstOrNull{ it.contains("botlink').innerHTML") }?.let {
                         val scriptContent =
                             it.substringAfter(").innerHTML").replaceFirst("=", "var url =")

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamWishExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamWishExtractor.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.M3u8Helper
@@ -173,11 +174,11 @@ open class StreamWishExtractor : ExtractorApi() {
 
         val playerScriptData = when {
             !getPacked(pageResponse.text).isNullOrEmpty() -> getAndUnpack(pageResponse.text)
-            pageResponse.document.select("script").any { it.html().contains("jwplayer(\"vplayer\").setup(") } ->
-                pageResponse.document.select("script").firstOrNull {
+            pageResponse.ksoupDocument.select("script").any { it.html().contains("jwplayer(\"vplayer\").setup(") } ->
+                pageResponse.ksoupDocument.select("script").firstOrNull {
                     it.html().contains("jwplayer(\"vplayer\").setup(")
                 }?.html()
-            else -> pageResponse.document.selectFirst("script:containsData(sources:)")?.data()
+            else -> pageResponse.ksoupDocument.selectFirst("script:containsData(sources:)")?.data()
         }
 
         val linkFound = JwPlayerHelper.extractStreamLinks(playerScriptData.orEmpty(), name, mainUrl, callback, subtitleCallback, headers)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamoUpload.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/StreamoUpload.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getAndUnpack
@@ -20,7 +21,7 @@ open class StreamoUpload : ExtractorApi() {
         callback: (ExtractorLink) -> Unit
     ) {
         val response = app.get(url, referer = referer)
-        response.document.select("script").map { script ->
+        response.ksoupDocument.select("script").map { script ->
             if (getPacked(script.data()) != null) {
                 val data = getAndUnpack(script.data())
                 JwPlayerHelper.extractStreamLinks(data, name, mainUrl, callback, subtitleCallback)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamplay.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Streamplay.kt
@@ -5,6 +5,7 @@ import com.lagradost.cloudstream3.APIHolder.getCaptchaToken
 import com.lagradost.cloudstream3.ErrorLoadingException
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.*
 import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 import java.net.URI
@@ -27,7 +28,7 @@ open class Streamplay : ExtractorApi() {
         }
         val key = redirectUrl.substringAfter("embed-").substringBefore(".html")
         val token =
-            request.document.select("script").find { it.data().contains("sitekey:") }?.data()
+            request.ksoupDocument.select("script").find { it.data().contains("sitekey:") }?.data()
                 ?.substringAfterLast("sitekey: '")?.substringBefore("',")?.let { captchaKey ->
                     getCaptchaToken(
                         redirectUrl,
@@ -45,7 +46,7 @@ open class Streamplay : ExtractorApi() {
                 "Accept" to "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
                 "Content-Type" to "application/x-www-form-urlencoded"
             )
-        ).document.select("script").find { script ->
+        ).ksoupDocument.select("script").find { script ->
             script.data().contains("eval(function(p,a,c,k,e,d)")
         }?.let {
             val data = getAndUnpack(it.data()).substringAfter("sources=[").substringBefore(",desc")

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Up4Stream.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Up4Stream.kt
@@ -4,6 +4,7 @@ import com.lagradost.api.Log
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.JsUnpacker
@@ -29,7 +30,7 @@ open class Up4Stream : ExtractorApi() {
 
         // redirect from "wait 5 seconds" page to actual movie page
         val redirectResponse = app.get(url, cookies = mapOf("id" to movieId))
-        val redirectForm = redirectResponse.document.selectFirst("form[method=POST]") ?: return
+        val redirectForm = redirectResponse.ksoupDocument.selectFirst("form[method=POST]") ?: return
         val redirectUrl = fixUrl(redirectForm.attr("action"))
         val redirectParams = redirectForm.select("input[type=hidden]").associate { input ->
             input.attr("name") to input.attr("value")
@@ -37,7 +38,7 @@ open class Up4Stream : ExtractorApi() {
 
         // wait for 5 seconds, otherwise the below md5 hash is invalid
         delay(5000)
-        val response = app.post(redirectUrl, data = redirectParams).document
+        val response = app.post(redirectUrl, data = redirectParams).ksoupDocument
 
         // starting here, this works similar to many other extractors like StreamWish
         val extractedpack =

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userload.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userload.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.*
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.EvaluatorException
@@ -101,7 +102,7 @@ open class Userload : ExtractorApi() {
             "mycountry" to mycountry
         ))
         val videoLink = videoLinkPage.text
-        val nameSource = app.get(url).document.head().selectFirst("title")!!.text()
+        val nameSource = app.get(url).ksoupDocument.head().selectFirst("title")!!.text()
         extractedLinksList.add(
             newExtractorLink(
                 name,

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userscloud.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userscloud.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
@@ -18,7 +19,7 @@ open class Userscloud : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val res = app.get(url).document
+        val res = app.get(url).ksoupDocument
         val video = res.selectFirst("video#vjsplayer source")?.attr("src")
         val quality = res.selectFirst("div.innerTB h2 b")?.text()
         callback.invoke(

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Uservideo.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Uservideo.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.AppUtils
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
@@ -20,7 +21,7 @@ open class Uservideo : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val script = app.get(url).document.selectFirst("script:containsData(hosts =)")?.data()
+        val script = app.get(url).ksoupDocument.selectFirst("script:containsData(hosts =)")?.data()
         val host = script?.substringAfter("hosts = [\"")?.substringBefore("\"];")
         val servers = script?.substringAfter("servers = \"")?.substringBefore("\";")
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidHidePro.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidHidePro.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.getAndUnpack
@@ -79,7 +80,7 @@ open class VidHidePro : ExtractorApi() {
         val script = if (!getPacked(response.text).isNullOrEmpty()) {
             getAndUnpack(response.text)
         } else {
-            response.document.selectFirst("script:containsData(sources:)")?.data()
+            response.ksoupDocument.selectFirst("script:containsData(sources:)")?.data()
         } ?: return
 
         JwPlayerHelper.extractStreamLinks(script, name, mainUrl, callback, subtitleCallback, headers)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -4,6 +4,7 @@ import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 
@@ -40,7 +41,7 @@ open class Vidmoly : ExtractorApi() {
             else url
 
         val script = app.get(newUrl, headers = headers, referer = referer)
-            .document.select("script")
+            .ksoupDocument.select("script")
             .firstOrNull { it.data().contains("sources:") }
             ?.data()
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidoza.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidoza.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.api.Log
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.AppUtils
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
@@ -25,7 +26,7 @@ open class Vidoza: ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val response = app.get(url).document
+        val response = app.get(url).ksoupDocument
         val script = response.selectFirst("script:containsData(sourcesCode)")?.data()
             ?: throw RuntimeException("couldn't find script containing video data")
 

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vinovo.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vinovo.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.APIHolder
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.Qualities
@@ -28,7 +29,7 @@ open class VinovoTo : ExtractorApi() {
         val fixedUrl = url.replace("/d/", "/e/")
 
         val resp = app.get(fixedUrl, referer = referer)
-        val doc = resp.document
+        val doc = resp.ksoupDocument
 
         val videoBaseUrl = doc.selectFirst("video")?.attr("data-base") ?: return
         val videoToken = doc.selectFirst("meta[name=token]")?.attr("content") ?: return

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Voe.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Voe.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.base64Decode
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.INFER_TYPE
@@ -62,11 +63,11 @@ open class Voe : ExtractorApi() {
         callback: (ExtractorLink) -> Unit
     ) {
         var res = app.get(url, referer = referer)
-        val redirectUrl = redirectRegex.find(res.document.data())?.groupValues?.get(1)
+        val redirectUrl = redirectRegex.find(res.ksoupDocument.data())?.groupValues?.get(1)
         if (redirectUrl != null) {
             res = app.get(redirectUrl, referer = referer)
         }
-        val encodedString = res.document.selectFirst("script[type=application/json]")?.data()?.trim()?.substringAfter("[\"")?.substringBeforeLast("\"]")
+        val encodedString = res.ksoupDocument.selectFirst("script[type=application/json]")?.data()?.trim()?.substringAfter("[\"")?.substringBeforeLast("\"]")
         if (encodedString == null) {
             println("encoded string not found.")
             return

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vtbe.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vtbe.kt
@@ -3,6 +3,7 @@ package com.lagradost.cloudstream3.extractors
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.JsUnpacker
@@ -19,7 +20,7 @@ open class Vtbe : ExtractorApi() {
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
-        val response = app.get(url,referer=mainUrl).document
+        val response = app.get(url,referer=mainUrl).ksoupDocument
         val extractedpack = response.selectFirst("script:containsData(function(p,a,c,k,e,d))")?.data().toString()
         JsUnpacker(extractedpack).unpack()?.let { unPacked ->
             JwPlayerHelper.extractStreamLinks(unPacked, name, mainUrl, callback, subtitleCallback)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YourUpload.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/YourUpload.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.AppUtils.tryParseJson
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
@@ -15,7 +16,7 @@ open class YourUpload: ExtractorApi() {
 
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink> {
         val sources = mutableListOf<ExtractorLink>()
-        with(app.get(url).document) {
+        with(app.get(url).ksoupDocument) {
             val quality = Regex("\\d{3,4}p").find(this.select("title").text())?.groupValues?.get(0)
             this.select("script").map { script ->
                 if (script.data().contains("var jwplayerOptions = {")) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Zplayer.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Zplayer.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors
 
 import com.lagradost.cloudstream3.amap
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.M3u8Helper
@@ -28,7 +29,7 @@ open class ZplayerV2 : ExtractorApi() {
     override val requiresReferer = false
 
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink> {
-        val doc = app.get(url).document
+        val doc = app.get(url).ksoupDocument
         val sources = mutableListOf<ExtractorLink>()
         doc.select("script").map { script ->
             if (script.data().contains("eval(function(p,a,c,k,e,d)")) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/AsianEmbedHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/AsianEmbedHelper.kt
@@ -4,6 +4,7 @@ import com.lagradost.api.Log
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.amap
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.loadExtractor
 
@@ -15,7 +16,7 @@ class AsianEmbedHelper {
             callback: (ExtractorLink) -> Unit
         ) {
             // Fetch links
-            val doc = app.get(url).document
+            val doc = app.get(url).ksoupDocument
             val links = doc.select("div#list-server-more > ul > li.linkserver")
             if (!links.isNullOrEmpty()) {
                 links.amap {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/GogoHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/GogoHelper.kt
@@ -1,10 +1,12 @@
 package com.lagradost.cloudstream3.extractors.helper
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fleeksoft.ksoup.nodes.Document
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.base64Decode
 import com.lagradost.cloudstream3.base64DecodeArray
 import com.lagradost.cloudstream3.base64Encode
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.mvvm.safe
 import com.lagradost.cloudstream3.mvvm.safeApiCall
 import com.lagradost.cloudstream3.utils.AppUtils
@@ -12,7 +14,6 @@ import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.M3u8Helper
 import com.lagradost.cloudstream3.utils.getQualityFromName
 import com.lagradost.cloudstream3.utils.newExtractorLink
-import org.jsoup.nodes.Document
 import java.net.URI
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
@@ -82,7 +83,7 @@ object GogoHelper {
 
         var document: Document? = iframeDocument
         val foundIv =
-            iv ?: (document ?: app.get(iframeUrl).document.also { document = it })
+            iv ?: (document ?: app.get(iframeUrl).ksoupDocument.also { document = it })
                 .select("""div.wrapper[class*=container]""")
                 .attr("class").split("-").lastOrNull() ?: return@safeApiCall
         val foundKey = secretKey ?: getKey(base64Decode(id) + foundIv) ?: return@safeApiCall
@@ -94,7 +95,7 @@ object GogoHelper {
         val encryptedId = cryptoHandler(id, foundIv, foundKey)
         val encryptRequestData = if (isUsingAdaptiveData) {
             // Only fetch the document if necessary
-            val realDocument = document ?: app.get(iframeUrl).document
+            val realDocument = document ?: app.get(iframeUrl).ksoupDocument
             val dataEncrypted =
                 realDocument.select("script[data-name='episode']").attr("data-value")
             val headers = cryptoHandler(dataEncrypted, foundIv, foundKey, false)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/VstreamhubHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/VstreamhubHelper.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.extractors.helper
 
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.Qualities
@@ -20,7 +21,7 @@ class VstreamhubHelper {
         ) {
             if (url.startsWith(baseUrl)) {
                 // Fetch links
-                val doc = app.get(url).document.select("script")
+                val doc = app.get(url).ksoupDocument.select("script")
                 doc.forEach {
                     val innerText = it.toString()
                     if (!innerText.isNullOrEmpty()) {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3.utils
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fleeksoft.ksoup.Ksoup
 import com.lagradost.cloudstream3.AudioFile
 import com.lagradost.cloudstream3.IDownloadableMinimum
 import com.lagradost.cloudstream3.SubtitleFile
@@ -311,7 +312,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import me.xdrop.fuzzywuzzy.FuzzySearch
-import org.jsoup.Jsoup
 import java.net.URI
 import java.util.UUID
 import kotlin.coroutines.cancellation.CancellationException
@@ -1259,7 +1259,7 @@ fun httpsify(url: String): String {
 }
 
 suspend fun getPostForm(requestUrl: String, html: String): String? {
-    val document = Jsoup.parse(html)
+    val document = Ksoup.parse(html)
     val inputs = document.select("Form > input")
     if (inputs.size < 4) return null
     var op: String? = null

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/UnshortenUrl.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/UnshortenUrl.kt
@@ -2,6 +2,7 @@ package com.lagradost.cloudstream3.utils
 
 import com.lagradost.cloudstream3.app
 import com.lagradost.cloudstream3.base64Decode
+import com.lagradost.cloudstream3.ksoupDocument
 import com.lagradost.nicehttp.NiceResponse
 import java.net.URI
 import java.net.URLDecoder
@@ -172,7 +173,7 @@ object ShortLink {
     }
 
     suspend fun unshortenNuovoLink(uri: String): String {
-        return app.get(uri, allowRedirects = true).document.selectFirst("a")!!.attr("href")
+        return app.get(uri, allowRedirects = true).ksoupDocument.selectFirst("a")!!.attr("href")
 
     }
 
@@ -193,7 +194,7 @@ object ShortLink {
     }
 
     suspend fun unshortenIsecure(uri: String): String {
-        val doc = app.get(uri).document
+        val doc = app.get(uri).ksoupDocument
         return doc.selectFirst("iframe")?.attr("src")?.trim() ?: uri
     }
 }


### PR DESCRIPTION
This is just a test right now and is not ready for merging at all. At the minimum, before merging, `ksoupDocument` needs to be moved to NiceHttp directly and an alternative for `documentLarge` with Ksoup added also.