### PR TITLE
fix not auto selecting subtitle

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1732,11 +1732,11 @@ class GeneratorPlayer : FullScreenPlayer() {
     ): SubtitleData? {
         val langCode = preferredAutoSelectSubtitles ?: return null
         if (downloads) {
-            return sortSubs(subtitles).firstOrNull {
+            sortSubs(subtitles).firstOrNull {
                 it.origin == SubtitleOrigin.DOWNLOADED_FILE && it.matchesLanguageCode(
                     langCode
                 )
-            }
+            }?.let { return it }
         }
 
         if (!settings) return null


### PR DESCRIPTION
player auto selecting subtitle is not working after the refactor commit [a45f1d9ab1edc165941d01996cda92954f99852e](https://github.com/recloudstream/cloudstream/tree/a45f1d9ab1edc165941d01996cda92954f99852e)