### PR TITLE
CryptoJS: replace array copies with Kotlin stdlib equivalents

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/CryptoJSHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/CryptoJSHelper.kt
@@ -46,9 +46,9 @@ object CryptoJS {
         // Create CryptoJS-like encrypted!
         val sBytes     = APPEND.toByteArray()
         val b          = ByteArray(sBytes.size + saltBytes.size + cipherText.size)
-        System.arraycopy(sBytes, 0, b, 0, sBytes.size)
-        System.arraycopy(saltBytes, 0, b, sBytes.size, saltBytes.size)
-        System.arraycopy(cipherText, 0, b, sBytes.size + saltBytes.size, cipherText.size)
+        sBytes.copyInto(destination = b, destinationOffset = 0)
+        saltBytes.copyInto(destination = b, destinationOffset = sBytes.size)
+        cipherText.copyInto(destination = b, destinationOffset = sBytes.size + saltBytes.size)
 
         return base64Encode(b)
     }
@@ -105,16 +105,18 @@ object CryptoJS {
                 hash.reset()
             }
 
-            System.arraycopy(
-                block!!, 0, derivedBytes, numberOfDerivedWords * 4,
-                min(block.size, (targetKeySize - numberOfDerivedWords) * 4)
+            block!!.copyInto(
+                destination = derivedBytes,
+                destinationOffset = numberOfDerivedWords * 4,
+                startIndex = 0,
+                endIndex = min(block.size, (targetKeySize - numberOfDerivedWords) * 4)
             )
 
             numberOfDerivedWords += block.size / 4
         }
 
-        System.arraycopy(derivedBytes, 0, resultKey, 0, keySize * 4)
-        System.arraycopy(derivedBytes, keySize * 4, resultIv, 0, ivSize * 4)
+        derivedBytes.copyInto(destination = resultKey, destinationOffset = 0, startIndex = 0, endIndex = keySize * 4)
+        derivedBytes.copyInto(destination = resultIv, destinationOffset = 0, startIndex = keySize * 4, endIndex = (keySize * 4) + (ivSize * 4))
 
         return derivedBytes // key + iv
     }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/CryptoJSHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/CryptoJSHelper.kt
@@ -2,7 +2,6 @@ package com.lagradost.cloudstream3.extractors.helper
 
 import com.lagradost.cloudstream3.base64DecodeArray
 import com.lagradost.cloudstream3.base64Encode
-import java.util.Arrays
 import java.security.MessageDigest
 import java.security.SecureRandom
 import javax.crypto.Cipher
@@ -63,8 +62,8 @@ object CryptoJS {
      */
     fun decrypt(password: String, cipherText: String): String {
         val ctBytes         = base64DecodeArray(cipherText)
-        val saltBytes       = Arrays.copyOfRange(ctBytes, 8, 16)
-        val cipherTextBytes = Arrays.copyOfRange(ctBytes, 16, ctBytes.size)
+        val saltBytes       = ctBytes.copyOfRange(8, 16)
+        val cipherTextBytes = ctBytes.copyOfRange(16, ctBytes.size)
 
         val key = ByteArray(KEY_SIZE / 8)
         val iv  = ByteArray(IV_SIZE / 8)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/CryptoJSHelper.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/helper/CryptoJSHelper.kt
@@ -7,7 +7,6 @@ import java.security.SecureRandom
 import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
 import javax.crypto.spec.IvParameterSpec
-import java.nio.charset.StandardCharsets
 import kotlin.math.min
 
 /**


### PR DESCRIPTION
The next step will be to replace Java crypto primitives (MessageDigest, Cipher,
SecureRandom, etc...) with `cryptography-kotlin` here, as well as in AesHelper, GogoHelper, M3u8Helper, and the ByseSX, Rabbitstream, and VidStack extractors, but this kinda just starts migrating this a bit.