### PR TITLE
TraktProvider: use text rather than toString for app.get

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/metaproviders/TraktProvider.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/metaproviders/TraktProvider.kt
@@ -289,7 +289,7 @@ open class TraktProvider : MainAPI() {
                 "trakt-api-version" to "2",
                 "trakt-api-key" to traktClientId,
             )
-        ).toString()
+        ).text
     }
 
     private fun isUpcoming(dateString: String?): Boolean {


### PR DESCRIPTION
toString is just an alias to text at the moment, but isn't really clear, and isn't really what it is meant for.