### PR TITLE
HlsPlaylistParser: don't use java.lang.StringBuilder directly

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/HlsPlaylistParser.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/HlsPlaylistParser.kt
@@ -234,7 +234,7 @@ object HlsPlaylistParser {
             if (codecArray.isEmpty()) {
                 return null
             }
-            val builder = java.lang.StringBuilder()
+            val builder = StringBuilder()
             for (codec in codecArray) {
                 if (trackType == MimeTypes.getTrackTypeOfCodec(codec)) {
                     if (builder.isNotEmpty()) {
@@ -263,7 +263,7 @@ object HlsPlaylistParser {
             if (codecArray.isEmpty()) {
                 return null
             }
-            val builder = java.lang.StringBuilder()
+            val builder = StringBuilder()
             for (codec in codecArray) {
                 if (trackType != MimeTypes.getTrackTypeOfCodec(codec)) {
                     if (builder.isNotEmpty()) {
@@ -425,7 +425,7 @@ object HlsPlaylistParser {
          * @param limit The limit (exclusive) of the path in `uri`.
          */
         private fun removeDotSegments(
-            uri: java.lang.StringBuilder,
+            uri: StringBuilder,
             offset: Int,
             limit: Int
         ): String {


### PR DESCRIPTION
Just using StringBuilder will allow it to use kotlin.text.StringBuilder from Kotlin instead, which it already does in some places, making using java.lang.StringBuilder in here very inconsistent with other parts of the same class.