### PR TITLE
AppDebug: use kotlin.concurrent.Volatile

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/AppDebug.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/AppDebug.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3.utils
 
 import com.lagradost.cloudstream3.InternalAPI
+import kotlin.concurrent.Volatile
 
 @InternalAPI
 object AppDebug {


### PR DESCRIPTION
By default this uses kotlin.jvm.Volatile, which we should be using kotlin.concurrent.Volatile instead.