### PR TITLE
Replace ArrayList in extractor

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userload.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Userload.kt
@@ -6,8 +6,6 @@ import com.lagradost.cloudstream3.utils.*
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.EvaluatorException
 import org.mozilla.javascript.Scriptable
-import java.util.*
-
 
 open class Userload : ExtractorApi() {
     override var name = "Userload"
@@ -16,7 +14,7 @@ open class Userload : ExtractorApi() {
 
     private fun splitInput(input: String): List<String> {
         var counter = 0
-        val array = ArrayList<String>()
+        val array = mutableListOf<String>()
         var buffer = ""
         for (c in input) {
             when (c) {


### PR DESCRIPTION
Although ArrayList itself does exist in Kotlin collections, this explicitly used java.util.ArrayList, and this way just seemed cleaner and more consistent with the rest of this extractor to me.