### PR TITLE
Use abiValidation to prevent breaking changes in extension library

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,11 @@ jobs:
         cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
         cache-read-only: false
 
+    - name: Ensure binary compatibility
+      # This is to ensure that your code is backwards compatible.
+      # If this fails you need to add a @Prerelease annotation to new code.
+      run: ./gradlew library:checkKotlinAbi
+
     - name: Run Gradle
       run: ./gradlew assemblePrereleaseDebug lint
 

--- a/library/README.md
+++ b/library/README.md
@@ -4,7 +4,7 @@ This is the official API surface for all CloudStream plugins.
 
 To ensure that all plugins work on both the stable release and pre-release we must have
 binary compatibility on all changes. All new changes must be marked with `@Prerelease` to
-restrict usage among extension developers.
+prevent accidental usage among extension developers.
 
 We use Kotlin binary compatibility validation using:
 

--- a/library/README.md
+++ b/library/README.md
@@ -1,0 +1,15 @@
+## CloudStream extension library
+
+This is the official API surface for all CloudStream plugins.
+
+To ensure that all plugins work on both the stable release and pre-release we must have
+binary compatibility on all changes. All new changes must be marked with `@Prerelease` to
+restrict usage among extension developers.
+
+We use Kotlin binary compatibility validation using:
+
+``./gradlew checkKotlinAbi``
+
+If you for some reason must update the binary compatibility then manually edit `api/jvm/library.api` or use:
+
+``./gradlew updateKotlinAbi``

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -1,6 +1,7 @@
 public final class com/lagradost/api/BuildConfig {
 	public static final field INSTANCE Lcom/lagradost/api/BuildConfig;
 	public final fun getMDL_API_KEY ()Ljava/lang/String;
+	public final fun getTRAKT_CLIENT_ID ()Ljava/lang/String;
 }
 
 public final class com/lagradost/api/ContextHelper_jvmKt {
@@ -20,11 +21,11 @@ public final class com/lagradost/cloudstream3/APIHolder {
 	public static final field INSTANCE Lcom/lagradost/cloudstream3/APIHolder;
 	public final fun addPluginMapping (Lcom/lagradost/cloudstream3/MainAPI;)V
 	public final fun capitalize (Ljava/lang/String;)Ljava/lang/String;
-	public final fun getAllProviders ()Ljava/util/List;
+	public final fun getAllProviders ()Lcom/lagradost/cloudstream3/utils/AtomicMutableList;
 	public final fun getApiFromNameNull (Ljava/lang/String;)Lcom/lagradost/cloudstream3/MainAPI;
 	public final fun getApiFromUrlNull (Ljava/lang/String;)Lcom/lagradost/cloudstream3/MainAPI;
 	public final fun getApiMap ()Ljava/util/Map;
-	public final fun getApis ()Ljava/util/List;
+	public final fun getApis ()Lcom/lagradost/cloudstream3/utils/AtomicList;
 	public final fun getCaptchaToken (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getCaptchaToken$default (Lcom/lagradost/cloudstream3/APIHolder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getTracker (Ljava/util/List;Ljava/util/Set;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -34,7 +35,7 @@ public final class com/lagradost/cloudstream3/APIHolder {
 	public final fun initAll ()V
 	public final fun removePluginMapping (Lcom/lagradost/cloudstream3/MainAPI;)V
 	public final fun setApiMap (Ljava/util/Map;)V
-	public final fun setApis (Ljava/util/List;)V
+	public final fun setApis (Lcom/lagradost/cloudstream3/utils/AtomicList;)V
 }
 
 public final class com/lagradost/cloudstream3/Actor {
@@ -79,6 +80,7 @@ public final class com/lagradost/cloudstream3/ActorRole : java/lang/Enum {
 }
 
 public final class com/lagradost/cloudstream3/AniSearch {
+	public static final field Companion Lcom/lagradost/cloudstream3/AniSearch$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data;)V
 	public synthetic fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -92,7 +94,23 @@ public final class com/lagradost/cloudstream3/AniSearch {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/AniSearch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/AniSearch$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/AniSearch;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/AniSearch;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/AniSearch$Data {
+	public static final field Companion Lcom/lagradost/cloudstream3/AniSearch$Data$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data$Page;)V
 	public synthetic fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data$Page;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -106,7 +124,23 @@ public final class com/lagradost/cloudstream3/AniSearch$Data {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/AniSearch$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/AniSearch$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/AniSearch$Data;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/AniSearch$Data;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/AniSearch$Data$Page {
+	public static final field Companion Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/ArrayList;)V
 	public synthetic fun <init> (Ljava/util/ArrayList;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -120,7 +154,23 @@ public final class com/lagradost/cloudstream3/AniSearch$Data$Page {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/AniSearch$Data$Page$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/AniSearch$Data$Page$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/AniSearch$Data$Page;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media {
+	public static final field Companion Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -152,7 +202,23 @@ public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage {
+	public static final field Companion Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -169,7 +235,23 @@ public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverIma
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title {
+	public static final field Companion Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -185,6 +267,21 @@ public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title {
 	public final fun setEnglish (Ljava/lang/String;)V
 	public final fun setRomaji (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/AnimeLoadResponse : com/lagradost/cloudstream3/EpisodeResponse, com/lagradost/cloudstream3/LoadResponse {
@@ -283,10 +380,8 @@ public final class com/lagradost/cloudstream3/AnimeLoadResponse : com/lagradost/
 }
 
 public final class com/lagradost/cloudstream3/AnimeSearchResponse : com/lagradost/cloudstream3/SearchResponse {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/Integer;
 	public final fun component11 ()Lcom/lagradost/cloudstream3/SearchQuality;
@@ -297,14 +392,14 @@ public final class com/lagradost/cloudstream3/AnimeSearchResponse : com/lagrados
 	public final fun component4 ()Lcom/lagradost/cloudstream3/TvType;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/Integer;
-	public final fun component7 ()Ljava/util/EnumSet;
+	public final fun component7 ()Ljava/util/Set;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)Lcom/lagradost/cloudstream3/AnimeSearchResponse;
-	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AnimeSearchResponse;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)Lcom/lagradost/cloudstream3/AnimeSearchResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AnimeSearchResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getApiName ()Ljava/lang/String;
-	public final fun getDubStatus ()Ljava/util/EnumSet;
+	public final fun getDubStatus ()Ljava/util/Set;
 	public final fun getEpisodes ()Ljava/util/Map;
 	public fun getId ()Ljava/lang/Integer;
 	public fun getName ()Ljava/lang/String;
@@ -317,7 +412,7 @@ public final class com/lagradost/cloudstream3/AnimeSearchResponse : com/lagrados
 	public fun getUrl ()Ljava/lang/String;
 	public final fun getYear ()Ljava/lang/Integer;
 	public fun hashCode ()I
-	public final fun setDubStatus (Ljava/util/EnumSet;)V
+	public final fun setDubStatus (Ljava/util/Set;)V
 	public final fun setEpisodes (Ljava/util/Map;)V
 	public fun setId (Ljava/lang/Integer;)V
 	public final fun setOtherName (Ljava/lang/String;)V
@@ -331,6 +426,7 @@ public final class com/lagradost/cloudstream3/AnimeSearchResponse : com/lagrados
 }
 
 public final class com/lagradost/cloudstream3/AudioFile {
+	public static final field Companion Lcom/lagradost/cloudstream3/AudioFile$Companion;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/Map;
 	public fun equals (Ljava/lang/Object;)Z
@@ -340,6 +436,21 @@ public final class com/lagradost/cloudstream3/AudioFile {
 	public final fun setHeaders (Ljava/util/Map;)V
 	public final fun setUrl (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/lagradost/cloudstream3/AudioFile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/AudioFile$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/AudioFile;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/AudioFile;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/AudioFile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/AutoDownloadMode : java/lang/Enum {
@@ -744,6 +855,8 @@ public final class com/lagradost/cloudstream3/MainAPIKt {
 	public static final field USER_AGENT Ljava/lang/String;
 	public static final fun addDate (Lcom/lagradost/cloudstream3/Episode;Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun addDate (Lcom/lagradost/cloudstream3/Episode;Ljava/util/Date;)V
+	public static final fun addDate (Lcom/lagradost/cloudstream3/Episode;Lkotlin/time/Instant;)V
+	public static final fun addDate (Lcom/lagradost/cloudstream3/Episode;Lkotlinx/datetime/LocalDate;)V
 	public static synthetic fun addDate$default (Lcom/lagradost/cloudstream3/Episode;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static final fun addDub (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Ljava/lang/Integer;)V
 	public static final fun addDubStatus (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Lcom/lagradost/cloudstream3/DubStatus;Ljava/lang/Integer;)V
@@ -774,6 +887,7 @@ public final class com/lagradost/cloudstream3/MainAPIKt {
 	public static final fun fixUrlNull (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun getDurationFromString (Ljava/lang/String;)Ljava/lang/Integer;
 	public static final fun getFolderPrefix (Lcom/lagradost/cloudstream3/TvType;)Ljava/lang/String;
+	public static final fun getJson ()Lkotlinx/serialization/json/Json;
 	public static final fun getMapper ()Lcom/fasterxml/jackson/databind/json/JsonMapper;
 	public static final fun getQualityFromString (Ljava/lang/String;)Lcom/lagradost/cloudstream3/SearchQuality;
 	public static final fun getRhinoContext (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -786,6 +900,7 @@ public final class com/lagradost/cloudstream3/MainAPIKt {
 	public static final fun isEpisodeBased (Lcom/lagradost/cloudstream3/TvType;)Z
 	public static final fun isLiveStream (Lcom/lagradost/cloudstream3/TvType;)Z
 	public static final fun isMovieType (Lcom/lagradost/cloudstream3/TvType;)Z
+	public static final fun isUpcoming (Ljava/lang/String;)Z
 	public static final fun mainPage (Ljava/lang/String;Ljava/lang/String;Z)Lcom/lagradost/cloudstream3/MainPageData;
 	public static synthetic fun mainPage$default (Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/MainPageData;
 	public static final fun mainPageOf ([Lcom/lagradost/cloudstream3/MainPageData;)Ljava/util/List;
@@ -839,7 +954,9 @@ public final class com/lagradost/cloudstream3/MainAPIKt {
 
 public final class com/lagradost/cloudstream3/MainActivityKt {
 	public static final fun getApp ()Lcom/lagradost/nicehttp/Requests;
+	public static final fun getInsecureApp ()Lcom/lagradost/nicehttp/Requests;
 	public static final fun setApp (Lcom/lagradost/nicehttp/Requests;)V
+	public static final fun setInsecureApp (Lcom/lagradost/nicehttp/Requests;)V
 }
 
 public final class com/lagradost/cloudstream3/MainPageData {
@@ -1026,6 +1143,7 @@ public final class com/lagradost/cloudstream3/ProviderType : java/lang/Enum {
 }
 
 public final class com/lagradost/cloudstream3/ProvidersInfoJson {
+	public static final field Companion Lcom/lagradost/cloudstream3/ProvidersInfoJson$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -1045,6 +1163,21 @@ public final class com/lagradost/cloudstream3/ProvidersInfoJson {
 	public final fun setStatus (I)V
 	public final fun setUrl (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/lagradost/cloudstream3/ProvidersInfoJson$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/ProvidersInfoJson$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/ProvidersInfoJson;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/ProvidersInfoJson;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/ProvidersInfoJson$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/Score {
@@ -1072,6 +1205,17 @@ public final class com/lagradost/cloudstream3/Score {
 	public static synthetic fun toStringNull$default (Lcom/lagradost/cloudstream3/Score;DIIZCILjava/lang/Object;)Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/Score$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/Score$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/Score;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/Score;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/Score$Companion {
 	public final fun from (Ljava/lang/Double;I)Lcom/lagradost/cloudstream3/Score;
 	public final fun from (Ljava/lang/Float;I)Lcom/lagradost/cloudstream3/Score;
@@ -1090,6 +1234,7 @@ public final class com/lagradost/cloudstream3/Score$Companion {
 	public final fun from5 (Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/Score;
 	public final fun from5 (Ljava/lang/String;)Lcom/lagradost/cloudstream3/Score;
 	public final fun fromOld (Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/Score;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/SearchQuality : java/lang/Enum {
@@ -1147,6 +1292,7 @@ public final class com/lagradost/cloudstream3/SearchResponseList {
 }
 
 public final class com/lagradost/cloudstream3/SeasonData {
+	public static final field Companion Lcom/lagradost/cloudstream3/SeasonData$Companion;
 	public fun <init> (ILjava/lang/String;Ljava/lang/Integer;)V
 	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
@@ -1162,7 +1308,23 @@ public final class com/lagradost/cloudstream3/SeasonData {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/SeasonData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/SeasonData$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/SeasonData;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/SeasonData;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/SeasonData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/SettingsJson {
+	public static final field Companion Lcom/lagradost/cloudstream3/SettingsJson$Companion;
 	public fun <init> ()V
 	public fun <init> (Z)V
 	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -1174,6 +1336,21 @@ public final class com/lagradost/cloudstream3/SettingsJson {
 	public fun hashCode ()I
 	public final fun setEnableAdult (Z)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/lagradost/cloudstream3/SettingsJson$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/SettingsJson$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/SettingsJson;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/SettingsJson;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/SettingsJson$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/ShowStatus : java/lang/Enum {
@@ -1532,6 +1709,7 @@ public final class com/lagradost/cloudstream3/TvType : java/lang/Enum {
 	public static final field Podcast Lcom/lagradost/cloudstream3/TvType;
 	public static final field Torrent Lcom/lagradost/cloudstream3/TvType;
 	public static final field TvSeries Lcom/lagradost/cloudstream3/TvType;
+	public static final field Video Lcom/lagradost/cloudstream3/TvType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/TvType;
 	public static fun values ()[Lcom/lagradost/cloudstream3/TvType;
@@ -2081,8 +2259,6 @@ public class com/lagradost/cloudstream3/extractors/EmturbovidExtractor : com/lag
 	public fun getName ()Ljava/lang/String;
 	public fun getRequiresReferer ()Z
 	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun setMainUrl (Ljava/lang/String;)V
-	public fun setName (Ljava/lang/String;)V
 }
 
 public class com/lagradost/cloudstream3/extractors/Evoload : com/lagradost/cloudstream3/utils/ExtractorApi {
@@ -2193,10 +2369,28 @@ public class com/lagradost/cloudstream3/extractors/Filesim : com/lagradost/cloud
 	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/lagradost/cloudstream3/extractors/Firestream : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getExtractorUrl (Ljava/lang/String;)Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/lagradost/cloudstream3/extractors/FlaswishCom : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
 	public fun <init> ()V
 	public fun getMainUrl ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Flyfile : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getApiUrl ()Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/lagradost/cloudstream3/extractors/FourCX : com/lagradost/cloudstream3/extractors/ContentX {
@@ -2514,6 +2708,12 @@ public final class com/lagradost/cloudstream3/extractors/Habetar : com/lagradost
 }
 
 public final class com/lagradost/cloudstream3/extractors/Haxloppd : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Hgcloudto : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
 	public fun <init> ()V
 	public fun getMainUrl ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
@@ -3256,6 +3456,12 @@ public final class com/lagradost/cloudstream3/extractors/Playerwish : com/lagrad
 	public fun getName ()Ljava/lang/String;
 }
 
+public final class com/lagradost/cloudstream3/extractors/Playmogo : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
 public class com/lagradost/cloudstream3/extractors/Rabbitstream : com/lagradost/cloudstream3/utils/ExtractorApi {
 	public fun <init> ()V
 	public fun extractRealKey (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3772,6 +3978,15 @@ public class com/lagradost/cloudstream3/extractors/StreamWishExtractor : com/lag
 	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public class com/lagradost/cloudstream3/extractors/Streamcash : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getCdnUrl ()Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/lagradost/cloudstream3/extractors/StreamhideCom : com/lagradost/cloudstream3/extractors/Filesim {
 	public fun <init> ()V
 	public fun getMainUrl ()Ljava/lang/String;
@@ -3803,12 +4018,6 @@ public final class com/lagradost/cloudstream3/extractors/Streamhub2 : com/lagrad
 	public fun getName ()Ljava/lang/String;
 	public fun setMainUrl (Ljava/lang/String;)V
 	public fun setName (Ljava/lang/String;)V
-}
-
-public final class com/lagradost/cloudstream3/extractors/Streamix : com/lagradost/cloudstream3/extractors/Streamup {
-	public fun <init> ()V
-	public fun getMainUrl ()Ljava/lang/String;
-	public fun getName ()Ljava/lang/String;
 }
 
 public final class com/lagradost/cloudstream3/extractors/Streamlare : com/lagradost/cloudstream3/extractors/Slmaxed {
@@ -3851,15 +4060,6 @@ public final class com/lagradost/cloudstream3/extractors/Streamsss : com/lagrado
 	public fun <init> ()V
 	public fun getMainUrl ()Ljava/lang/String;
 	public fun setMainUrl (Ljava/lang/String;)V
-}
-
-public class com/lagradost/cloudstream3/extractors/Streamup : com/lagradost/cloudstream3/utils/ExtractorApi {
-	public fun <init> ()V
-	public fun getApiPath ()Ljava/lang/String;
-	public fun getMainUrl ()Ljava/lang/String;
-	public fun getName ()Ljava/lang/String;
-	public fun getRequiresReferer ()Z
-	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/lagradost/cloudstream3/extractors/Streamwish2 : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
@@ -4223,11 +4423,52 @@ public class com/lagradost/cloudstream3/extractors/VidStack : com/lagradost/clou
 	public fun setName (Ljava/lang/String;)V
 }
 
-public final class com/lagradost/cloudstream3/extractors/Vidara : com/lagradost/cloudstream3/extractors/Streamup {
+public final class com/lagradost/cloudstream3/extractors/VidaaraxCom : com/lagradost/cloudstream3/extractors/Vidara {
 	public fun <init> ()V
-	public fun getApiPath ()Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidaaraxNet : com/lagradost/cloudstream3/extractors/Vidara {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Vidara : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
 	public fun getMainUrl ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidaraSo : com/lagradost/cloudstream3/extractors/Vidara {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidaraa : com/lagradost/cloudstream3/extractors/Vidara {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidaratem : com/lagradost/cloudstream3/extractors/Vidara {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidaraw : com/lagradost/cloudstream3/extractors/Vidara {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidarax : com/lagradost/cloudstream3/extractors/Vidara {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidavaca : com/lagradost/cloudstream3/extractors/Vidara {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
 }
 
 public final class com/lagradost/cloudstream3/extractors/Vide0Net : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
@@ -4364,6 +4605,14 @@ public final class com/lagradost/cloudstream3/extractors/Vido : com/lagradost/cl
 }
 
 public class com/lagradost/cloudstream3/extractors/Vidoza : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/Vids : com/lagradost/cloudstream3/utils/ExtractorApi {
 	public fun <init> ()V
 	public fun getMainUrl ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
@@ -4567,9 +4816,11 @@ public final class com/lagradost/cloudstream3/extractors/Ztreamhub : com/lagrado
 public final class com/lagradost/cloudstream3/extractors/helper/AesHelper {
 	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/AesHelper;
 	public final fun cryptoAESHandler (Ljava/lang/String;[BZLjava/lang/String;)Ljava/lang/String;
+	public final fun cryptoAESHandler (Ljava/lang/String;[BZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun cryptoAESHandler$default (Lcom/lagradost/cloudstream3/extractors/helper/AesHelper;Ljava/lang/String;[BZLjava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
-	public final fun generateKeyAndIv ([B[BLjava/lang/String;IIII)Lkotlin/Pair;
-	public static synthetic fun generateKeyAndIv$default (Lcom/lagradost/cloudstream3/extractors/helper/AesHelper;[B[BLjava/lang/String;IIIIILjava/lang/Object;)Lkotlin/Pair;
+	public static synthetic fun cryptoAESHandler$default (Lcom/lagradost/cloudstream3/extractors/helper/AesHelper;Ljava/lang/String;[BZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun generateKeyAndIv ([B[BIIII)Lkotlin/Pair;
+	public static synthetic fun generateKeyAndIv$default (Lcom/lagradost/cloudstream3/extractors/helper/AesHelper;[B[BIIIIILjava/lang/Object;)Lkotlin/Pair;
 	public final fun hexToByteArray (Ljava/lang/String;)[B
 }
 
@@ -4595,6 +4846,7 @@ public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper {
 }
 
 public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4607,7 +4859,23 @@ public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJ
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -4625,7 +4893,23 @@ public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoS
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources$Companion;
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
@@ -4638,7 +4922,30 @@ public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoS
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/JwPlayerHelper {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/JwPlayerHelper;
+	public final fun canParseJwScript (Ljava/lang/String;)Z
+	public final fun extractStreamLinks (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun extractStreamLinks$default (Lcom/lagradost/cloudstream3/extractors/helper/JwPlayerHelper;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4653,6 +4960,21 @@ public final class com/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$T
 	public final fun getLabel ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/extractors/helper/NineAnimeHelper {
@@ -4684,6 +5006,7 @@ public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Compan
 }
 
 public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4698,7 +5021,23 @@ public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Compan
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4713,6 +5052,21 @@ public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Compan
 	public final fun getMainKey ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/metaproviders/CrossTmdbProvider : com/lagradost/cloudstream3/metaproviders/TmdbProvider {
@@ -4731,6 +5085,7 @@ public final class com/lagradost/cloudstream3/metaproviders/CrossTmdbProvider : 
 }
 
 public final class com/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData$Companion;
 	public fun <init> (ZLjava/util/List;)V
 	public synthetic fun <init> (ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
@@ -4742,6 +5097,21 @@ public final class com/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$Cr
 	public fun hashCode ()I
 	public final fun isSuccess ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public abstract class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI : com/lagradost/cloudstream3/MainAPI {
@@ -4762,6 +5132,7 @@ public abstract class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI : 
 }
 
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast$Companion;
 	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()J
 	public final fun component2 ()Ljava/lang/String;
@@ -4784,11 +5155,27 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast 
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Companion {
 	public final fun getAPI_KEY ()Ljava/lang/String;
 }
 
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits$Companion;
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
@@ -4801,7 +5188,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credi
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew$Companion;
 	public fun <init> (JLjava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/lang/String;)V
 	public final fun component1 ()J
 	public final fun component2 ()Ljava/lang/String;
@@ -4820,7 +5223,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew 
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)V
 	public synthetic fun <init> (Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4835,7 +5254,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data 
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre$Companion;
 	public fun <init> (JLjava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()J
 	public final fun component2 ()Ljava/lang/String;
@@ -4850,7 +5285,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4867,7 +5318,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Image
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4898,7 +5365,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkD
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media$Companion;
 	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IJDLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;JJJJJJJLjava/lang/String;Ljava/lang/String;ZLjava/util/List;J)V
 	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IJDLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;JJJJJJJLjava/lang/String;Ljava/lang/String;ZLjava/util/List;JIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
@@ -4978,7 +5461,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary$Companion;
 	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;)V
 	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
@@ -5010,39 +5509,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Recommendations : java/util/ArrayList {
-	public fun <init> ()V
-	public fun contains (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)Z
-	public final fun contains (Ljava/lang/Object;)Z
-	public fun getSize ()I
-	public fun indexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)I
-	public final fun indexOf (Ljava/lang/Object;)I
-	public fun lastIndexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)I
-	public final fun lastIndexOf (Ljava/lang/Object;)I
-	public final fun remove (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
-	public fun remove (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)Z
-	public final fun remove (Ljava/lang/Object;)Z
-	public fun removeAt (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
-	public final fun size ()I
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$SearchResult : java/util/ArrayList {
-	public fun <init> ()V
-	public fun contains (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)Z
-	public final fun contains (Ljava/lang/Object;)Z
-	public fun getSize ()I
-	public fun indexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)I
-	public final fun indexOf (Ljava/lang/Object;)I
-	public fun lastIndexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)I
-	public final fun lastIndexOf (Ljava/lang/Object;)I
-	public final fun remove (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
-	public fun remove (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)Z
-	public final fun remove (Ljava/lang/Object;)Z
-	public fun removeAt (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
-	public final fun size ()I
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode$Companion;
 	public fun <init> (IIDILjava/lang/String;)V
 	public final fun component1 ()I
 	public final fun component2 ()I
@@ -5061,23 +5544,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowE
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodes : java/util/ArrayList {
-	public fun <init> ()V
-	public fun contains (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;)Z
-	public final fun contains (Ljava/lang/Object;)Z
-	public fun getSize ()I
-	public fun indexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;)I
-	public final fun indexOf (Ljava/lang/Object;)I
-	public fun lastIndexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;)I
-	public final fun lastIndexOf (Ljava/lang/Object;)I
-	public final fun remove (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;
-	public fun remove (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;)Z
-	public final fun remove (Ljava/lang/Object;)Z
-	public fun removeAt (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;
-	public final fun size ()I
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;I)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -5096,7 +5579,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowE
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -5117,7 +5616,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Sourc
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag$Companion;
 	public fun <init> (JLjava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()J
 	public final fun component2 ()Ljava/lang/String;
@@ -5132,7 +5647,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Long;)V
 	public synthetic fun <init> (Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -5145,7 +5676,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trail
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails$Companion;
 	public fun <init> (JLjava/lang/String;)V
 	public final fun component1 ()J
 	public final fun component2 ()Ljava/lang/String;
@@ -5158,7 +5705,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trail
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode$Companion;
 	public fun <init> (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;)V
 	public final fun component1 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;
 	public final fun copy (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;
@@ -5169,7 +5732,23 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trail
 	public fun toString ()Ljava/lang/String;
 }
 
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot {
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot$Companion;
 	public fun <init> (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;)V
 	public final fun component1 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;
 	public final fun copy (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot;
@@ -5178,6 +5757,21 @@ public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trail
 	public final fun getTrailer ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/metaproviders/SyncRedirector {
@@ -5676,6 +6270,7 @@ public abstract class com/lagradost/cloudstream3/plugins/BasePlugin {
 }
 
 public final class com/lagradost/cloudstream3/plugins/BasePlugin$Manifest {
+	public static final field Companion Lcom/lagradost/cloudstream3/plugins/BasePlugin$Manifest$Companion;
 	public fun <init> ()V
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPluginClassName ()Ljava/lang/String;
@@ -5685,6 +6280,21 @@ public final class com/lagradost/cloudstream3/plugins/BasePlugin$Manifest {
 	public final fun setPluginClassName (Ljava/lang/String;)V
 	public final fun setRequiresResources (Z)V
 	public final fun setVersion (Ljava/lang/Integer;)V
+}
+
+public final synthetic class com/lagradost/cloudstream3/plugins/BasePlugin$Manifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/plugins/BasePlugin$Manifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/plugins/BasePlugin$Manifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/plugins/BasePlugin$Manifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/plugins/BasePlugin$Manifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/plugins/BasePluginKt {
@@ -5712,8 +6322,67 @@ public final class com/lagradost/cloudstream3/utils/AppUtils {
 	public final fun toJson (Ljava/lang/Object;)Ljava/lang/String;
 }
 
+public class com/lagradost/cloudstream3/utils/AtomicList : java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun add (ILjava/lang/Object;)V
+	public fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public final fun distinctBy (Lkotlin/jvm/functions/Function1;)Lcom/lagradost/cloudstream3/utils/AtomicList;
+	public final fun filter (Lkotlin/jvm/functions/Function1;)Lcom/lagradost/cloudstream3/utils/AtomicList;
+	public fun get (I)Ljava/lang/Object;
+	public fun getSize ()I
+	public fun indexOf (Ljava/lang/Object;)I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public fun lastIndexOf (Ljava/lang/Object;)I
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public final fun plus (Ljava/lang/Object;)Lcom/lagradost/cloudstream3/utils/AtomicList;
+	public final fun plus (Ljava/util/Collection;)Lcom/lagradost/cloudstream3/utils/AtomicList;
+	public fun remove (I)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun size ()I
+	public fun sort (Ljava/util/Comparator;)V
+	public fun subList (II)Ljava/util/List;
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public final fun withLock (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/utils/AtomicMutableList : com/lagradost/cloudstream3/utils/AtomicList, java/util/List, kotlin/jvm/internal/markers/KMutableList {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun add (ILjava/lang/Object;)V
+	public fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun iterator ()Ljava/util/Iterator;
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public final fun remove (I)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun removeAt (I)Ljava/lang/Object;
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public fun subList (II)Ljava/util/List;
+}
+
 public final class com/lagradost/cloudstream3/utils/Coroutines {
 	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/Coroutines;
+	public final fun atomicListOf ([Ljava/lang/Object;)Lcom/lagradost/cloudstream3/utils/AtomicMutableList;
 	public final fun ioSafe (Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/Job;
 	public final fun ioWork (Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ioWorkSafe (Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -5728,10 +6397,10 @@ public final class com/lagradost/cloudstream3/utils/Coroutines_jvmKt {
 }
 
 public class com/lagradost/cloudstream3/utils/DrmExtractorLink : com/lagradost/cloudstream3/utils/ExtractorLink {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/uuid/Uuid;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/uuid/Uuid;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/uuid/Uuid;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/uuid/Uuid;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAudioTracks ()Ljava/util/List;
 	public fun getExtractorData ()Ljava/lang/String;
 	public fun getHeaders ()Ljava/util/Map;
@@ -5746,7 +6415,8 @@ public class com/lagradost/cloudstream3/utils/DrmExtractorLink : com/lagradost/c
 	public fun getSource ()Ljava/lang/String;
 	public fun getType ()Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
 	public fun getUrl ()Ljava/lang/String;
-	public fun getUuid ()Ljava/util/UUID;
+	public final synthetic fun getUuid ()Ljava/util/UUID;
+	public fun getUuid ()Lkotlin/uuid/Uuid;
 	public fun setAudioTracks (Ljava/util/List;)V
 	public fun setExtractorData (Ljava/lang/String;)V
 	public fun setHeaders (Ljava/util/Map;)V
@@ -5758,7 +6428,8 @@ public class com/lagradost/cloudstream3/utils/DrmExtractorLink : com/lagradost/c
 	public fun setQuality (I)V
 	public fun setReferer (Ljava/lang/String;)V
 	public fun setType (Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;)V
-	public fun setUuid (Ljava/util/UUID;)V
+	public final synthetic fun setUuid (Ljava/util/UUID;)V
+	public fun setUuid (Lkotlin/uuid/Uuid;)V
 }
 
 public abstract class com/lagradost/cloudstream3/utils/ExtractorApi {
@@ -5782,7 +6453,7 @@ public final class com/lagradost/cloudstream3/utils/ExtractorApiKt {
 	public static final fun getAndUnpack (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun getCLEARKEY_UUID ()Ljava/util/UUID;
 	public static final fun getExtractorApiFromName (Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/ExtractorApi;
-	public static final fun getExtractorApis ()Ljava/util/List;
+	public static final fun getExtractorApis ()Lcom/lagradost/cloudstream3/utils/AtomicMutableList;
 	public static final fun getINFER_TYPE ()Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
 	public static final fun getPLAYREADY_UUID ()Ljava/util/UUID;
 	public static final fun getPacked (Ljava/lang/String;)Ljava/lang/String;
@@ -5804,6 +6475,8 @@ public final class com/lagradost/cloudstream3/utils/ExtractorApiKt {
 }
 
 public class com/lagradost/cloudstream3/utils/ExtractorLink : com/lagradost/cloudstream3/IDownloadableMinimum {
+	public static final field Companion Lcom/lagradost/cloudstream3/utils/ExtractorLink$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/List;)V
@@ -5835,6 +6508,22 @@ public class com/lagradost/cloudstream3/utils/ExtractorLink : com/lagradost/clou
 	public fun setReferer (Ljava/lang/String;)V
 	public fun setType (Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;)V
 	public fun toString ()Ljava/lang/String;
+	public static final synthetic fun write$Self (Lcom/lagradost/cloudstream3/utils/ExtractorLink;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final synthetic class com/lagradost/cloudstream3/utils/ExtractorLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/ExtractorLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/lagradost/cloudstream3/utils/ExtractorLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/lagradost/cloudstream3/utils/ExtractorLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/lagradost/cloudstream3/utils/ExtractorLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/lagradost/cloudstream3/utils/ExtractorLinkPlayList : com/lagradost/cloudstream3/utils/ExtractorLink {
@@ -6197,18 +6886,18 @@ public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$PsshAtomUt
 }
 
 public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition {
-	public fun <init> (Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/net/URI;
+	public fun <init> (Lio/ktor/http/Url;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Lio/ktor/http/Url;
 	public final fun component2 ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition;
-	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition;Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition;
+	public final fun copy (Lio/ktor/http/Url;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition;Lio/ktor/http/Url;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFormat ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
 	public final fun getGroupId ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getUrl ()Ljava/net/URI;
+	public final fun getUrl ()Lio/ktor/http/Url;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -6231,9 +6920,9 @@ public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$UriUtil {
-	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$UriUtil;
-	public final fun resolveToUri (Ljava/lang/String;Ljava/lang/String;)Ljava/net/URI;
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$UrlUtil {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$UrlUtil;
+	public final fun resolveToUrl (Ljava/lang/String;Ljava/lang/String;)Lio/ktor/http/Url;
 }
 
 public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Util {
@@ -6246,21 +6935,21 @@ public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Util {
 }
 
 public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant {
-	public fun <init> (Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/net/URI;
+	public fun <init> (Lio/ktor/http/Url;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Lio/ktor/http/Url;
 	public final fun component2 ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant;
-	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant;Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant;
+	public final fun copy (Lio/ktor/http/Url;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant;Lio/ktor/http/Url;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAudioGroupId ()Ljava/lang/String;
 	public final fun getCaptionGroupId ()Ljava/lang/String;
 	public final fun getFormat ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
 	public final fun getSubtitleGroupId ()Ljava/lang/String;
-	public final fun getUrl ()Ljava/net/URI;
+	public final fun getUrl ()Lio/ktor/http/Url;
 	public final fun getVideoGroupId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun isPlayableStandalone (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$HlsMultivariantPlaylist;)Z
@@ -6291,10 +6980,29 @@ public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$VariantInf
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/lagradost/cloudstream3/utils/JsContext {
+	public synthetic fun <init> (JJLkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun eval (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun get (Ljava/lang/String;)Ljava/lang/Object;
+	public final fun getMaxExecutionTime-UwyO8pc ()J
+	public final fun getMaxInstructions ()J
+	public final fun set (Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun setMaxExecutionTime-LRDsOJo (J)V
+	public final fun setMaxInstructions (J)V
+}
+
 public final class com/lagradost/cloudstream3/utils/JsHunter {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun dehunt ()Ljava/lang/String;
 	public final fun detect ()Z
+}
+
+public final class com/lagradost/cloudstream3/utils/JsInterpreterKt {
+	public static final fun evalJs-1Y68eR8 (Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun evalJs-1Y68eR8$default (Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun jsValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun newJsContext (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newJsContext$default (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/lagradost/cloudstream3/utils/JsUnpacker {
@@ -6308,6 +7016,14 @@ public final class com/lagradost/cloudstream3/utils/JsUnpacker$Companion {
 	public final fun getC ()Ljava/util/List;
 	public final fun getZ ()Ljava/util/List;
 	public final fun load (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/Levenshtein {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/Levenshtein;
+	public final fun partialRatio (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)I
+	public static synthetic fun partialRatio$default (Lcom/lagradost/cloudstream3/utils/Levenshtein;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)I
+	public final fun ratio (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)I
+	public static synthetic fun ratio$default (Lcom/lagradost/cloudstream3/utils/Levenshtein;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)I
 }
 
 public final class com/lagradost/cloudstream3/utils/M3u8Helper {
@@ -6457,7 +7173,9 @@ public final class com/lagradost/cloudstream3/utils/ShortLink$ShortUrl {
 public final class com/lagradost/cloudstream3/utils/StringUtils {
 	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/StringUtils;
 	public final fun decodeUri (Ljava/lang/String;)Ljava/lang/String;
+	public final fun decodeUrl (Ljava/lang/String;)Ljava/lang/String;
 	public final fun encodeUri (Ljava/lang/String;)Ljava/lang/String;
+	public final fun encodeUrl (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class com/lagradost/cloudstream3/utils/SubtitleHelper {
@@ -6539,5 +7257,15 @@ public final class com/lagradost/cloudstream3/utils/SubtitleHelper$LanguageMetad
 
 public final class com/lagradost/cloudstream3/utils/SubtitleHelperKt {
 	public static final fun getCurrentLocale ()Ljava/lang/String;
+}
+
+public abstract class com/lagradost/cloudstream3/utils/serializers/NonEmptySerializer : kotlinx/serialization/json/JsonTransformingSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	protected fun transformSerialize (Lkotlinx/serialization/json/JsonElement;)Lkotlinx/serialization/json/JsonElement;
+}
+
+public abstract class com/lagradost/cloudstream3/utils/serializers/WriteOnlySerializer : kotlinx/serialization/json/JsonTransformingSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;Ljava/util/Set;)V
+	protected fun transformSerialize (Lkotlinx/serialization/json/JsonElement;)Lkotlinx/serialization/json/JsonElement;
 }
 

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -1,0 +1,6549 @@
+public final class com/lagradost/api/BuildConfig {
+	public static final field INSTANCE Lcom/lagradost/api/BuildConfig;
+	public final fun getMDL_API_KEY ()Ljava/lang/String;
+}
+
+public final class com/lagradost/api/ContextHelper_jvmKt {
+	public static final fun getContext ()Ljava/lang/Object;
+	public static final fun setContext (Ljava/lang/ref/WeakReference;)V
+}
+
+public final class com/lagradost/api/Log {
+	public static final field INSTANCE Lcom/lagradost/api/Log;
+	public final fun d (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun e (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun i (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun w (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/APIHolder {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/APIHolder;
+	public final fun addPluginMapping (Lcom/lagradost/cloudstream3/MainAPI;)V
+	public final fun capitalize (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getAllProviders ()Ljava/util/List;
+	public final fun getApiFromNameNull (Ljava/lang/String;)Lcom/lagradost/cloudstream3/MainAPI;
+	public final fun getApiFromUrlNull (Ljava/lang/String;)Lcom/lagradost/cloudstream3/MainAPI;
+	public final fun getApiMap ()Ljava/util/Map;
+	public final fun getApis ()Ljava/util/List;
+	public final fun getCaptchaToken (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getCaptchaToken$default (Lcom/lagradost/cloudstream3/APIHolder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getTracker (Ljava/util/List;Ljava/util/Set;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getTracker (Ljava/util/List;Ljava/util/Set;Ljava/lang/Integer;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getUnixTime ()J
+	public final fun getUnixTimeMS ()J
+	public final fun initAll ()V
+	public final fun removePluginMapping (Lcom/lagradost/cloudstream3/MainAPI;)V
+	public final fun setApiMap (Ljava/util/Map;)V
+	public final fun setApis (Ljava/util/List;)V
+}
+
+public final class com/lagradost/cloudstream3/Actor {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/Actor;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/Actor;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/Actor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/ActorData {
+	public fun <init> (Lcom/lagradost/cloudstream3/Actor;Lcom/lagradost/cloudstream3/ActorRole;Ljava/lang/String;Lcom/lagradost/cloudstream3/Actor;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/Actor;Lcom/lagradost/cloudstream3/ActorRole;Ljava/lang/String;Lcom/lagradost/cloudstream3/Actor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/Actor;
+	public final fun component2 ()Lcom/lagradost/cloudstream3/ActorRole;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/Actor;
+	public final fun copy (Lcom/lagradost/cloudstream3/Actor;Lcom/lagradost/cloudstream3/ActorRole;Ljava/lang/String;Lcom/lagradost/cloudstream3/Actor;)Lcom/lagradost/cloudstream3/ActorData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/ActorData;Lcom/lagradost/cloudstream3/Actor;Lcom/lagradost/cloudstream3/ActorRole;Ljava/lang/String;Lcom/lagradost/cloudstream3/Actor;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/ActorData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor ()Lcom/lagradost/cloudstream3/Actor;
+	public final fun getRole ()Lcom/lagradost/cloudstream3/ActorRole;
+	public final fun getRoleString ()Ljava/lang/String;
+	public final fun getVoiceActor ()Lcom/lagradost/cloudstream3/Actor;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/ActorRole : java/lang/Enum {
+	public static final field Background Lcom/lagradost/cloudstream3/ActorRole;
+	public static final field Main Lcom/lagradost/cloudstream3/ActorRole;
+	public static final field Supporting Lcom/lagradost/cloudstream3/ActorRole;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/ActorRole;
+	public static fun values ()[Lcom/lagradost/cloudstream3/ActorRole;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch {
+	public fun <init> ()V
+	public fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/AniSearch$Data;
+	public final fun copy (Lcom/lagradost/cloudstream3/AniSearch$Data;)Lcom/lagradost/cloudstream3/AniSearch;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AniSearch;Lcom/lagradost/cloudstream3/AniSearch$Data;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AniSearch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lcom/lagradost/cloudstream3/AniSearch$Data;
+	public fun hashCode ()I
+	public final fun setData (Lcom/lagradost/cloudstream3/AniSearch$Data;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data {
+	public fun <init> ()V
+	public fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data$Page;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data$Page;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/AniSearch$Data$Page;
+	public final fun copy (Lcom/lagradost/cloudstream3/AniSearch$Data$Page;)Lcom/lagradost/cloudstream3/AniSearch$Data;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AniSearch$Data;Lcom/lagradost/cloudstream3/AniSearch$Data$Page;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AniSearch$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPage ()Lcom/lagradost/cloudstream3/AniSearch$Data$Page;
+	public fun hashCode ()I
+	public final fun setPage (Lcom/lagradost/cloudstream3/AniSearch$Data$Page;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data$Page {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/ArrayList;)V
+	public synthetic fun <init> (Ljava/util/ArrayList;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/ArrayList;
+	public final fun copy (Ljava/util/ArrayList;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AniSearch$Data$Page;Ljava/util/ArrayList;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMedia ()Ljava/util/ArrayList;
+	public fun hashCode ()I
+	public final fun setMedia (Ljava/util/ArrayList;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media {
+	public fun <init> ()V
+	public fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;Ljava/lang/String;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBannerImage ()Ljava/lang/String;
+	public final fun getCoverImage ()Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/Integer;
+	public final fun getIdMal ()Ljava/lang/Integer;
+	public final fun getSeasonYear ()Ljava/lang/Integer;
+	public final fun getTitle ()Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;
+	public fun hashCode ()I
+	public final fun setBannerImage (Ljava/lang/String;)V
+	public final fun setCoverImage (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;)V
+	public final fun setFormat (Ljava/lang/String;)V
+	public final fun setId (Ljava/lang/Integer;)V
+	public final fun setIdMal (Ljava/lang/Integer;)V
+	public final fun setSeasonYear (Ljava/lang/Integer;)V
+	public final fun setTitle (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$CoverImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtraLarge ()Ljava/lang/String;
+	public final fun getLarge ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setExtraLarge (Ljava/lang/String;)V
+	public final fun setLarge (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AniSearch$Data$Page$Media$Title;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnglish ()Ljava/lang/String;
+	public final fun getRomaji ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isMatchingTitles (Ljava/lang/String;)Z
+	public final fun setEnglish (Ljava/lang/String;)V
+	public final fun setRomaji (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/AnimeLoadResponse : com/lagradost/cloudstream3/EpisodeResponse, com/lagradost/cloudstream3/LoadResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Lcom/lagradost/cloudstream3/ShowStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lcom/lagradost/cloudstream3/Score;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Lcom/lagradost/cloudstream3/NextAiring;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Lcom/lagradost/cloudstream3/ShowStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lcom/lagradost/cloudstream3/Score;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Lcom/lagradost/cloudstream3/NextAiring;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/lagradost/cloudstream3/ShowStatus;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun component15 ()Ljava/lang/Integer;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/util/Map;
+	public final fun component21 ()Ljava/util/Map;
+	public final fun component22 ()Lcom/lagradost/cloudstream3/NextAiring;
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Ljava/lang/String;
+	public final fun component25 ()Ljava/lang/String;
+	public final fun component26 ()Ljava/lang/String;
+	public final fun component27 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Lcom/lagradost/cloudstream3/ShowStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lcom/lagradost/cloudstream3/Score;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Lcom/lagradost/cloudstream3/NextAiring;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/AnimeLoadResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AnimeLoadResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Lcom/lagradost/cloudstream3/ShowStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lcom/lagradost/cloudstream3/Score;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Lcom/lagradost/cloudstream3/NextAiring;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AnimeLoadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getActors ()Ljava/util/List;
+	public fun getApiName ()Ljava/lang/String;
+	public fun getBackgroundPosterUrl ()Ljava/lang/String;
+	public fun getComingSoon ()Z
+	public fun getContentRating ()Ljava/lang/String;
+	public fun getDuration ()Ljava/lang/Integer;
+	public final fun getEngName ()Ljava/lang/String;
+	public final fun getEpisodes ()Ljava/util/Map;
+	public final fun getJapName ()Ljava/lang/String;
+	public fun getLatestEpisodes ()Ljava/util/Map;
+	public fun getLogoUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getNextAiring ()Lcom/lagradost/cloudstream3/NextAiring;
+	public fun getPlot ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getRating ()Ljava/lang/Integer;
+	public fun getRecommendations ()Ljava/util/List;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getSeasonNames ()Ljava/util/List;
+	public fun getShowStatus ()Lcom/lagradost/cloudstream3/ShowStatus;
+	public fun getSyncData ()Ljava/util/Map;
+	public final fun getSynonyms ()Ljava/util/List;
+	public fun getTags ()Ljava/util/List;
+	public fun getTotalEpisodeIndex (II)I
+	public fun getTrailers ()Ljava/util/List;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUniqueUrl ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun setActors (Ljava/util/List;)V
+	public fun setApiName (Ljava/lang/String;)V
+	public fun setBackgroundPosterUrl (Ljava/lang/String;)V
+	public fun setComingSoon (Z)V
+	public fun setContentRating (Ljava/lang/String;)V
+	public fun setDuration (Ljava/lang/Integer;)V
+	public final fun setEngName (Ljava/lang/String;)V
+	public final fun setEpisodes (Ljava/util/Map;)V
+	public final fun setJapName (Ljava/lang/String;)V
+	public fun setLogoUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setNextAiring (Lcom/lagradost/cloudstream3/NextAiring;)V
+	public fun setPlot (Ljava/lang/String;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setRating (Ljava/lang/Integer;)V
+	public fun setRecommendations (Ljava/util/List;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setSeasonNames (Ljava/util/List;)V
+	public fun setShowStatus (Lcom/lagradost/cloudstream3/ShowStatus;)V
+	public fun setSyncData (Ljava/util/Map;)V
+	public final fun setSynonyms (Ljava/util/List;)V
+	public fun setTags (Ljava/util/List;)V
+	public fun setTrailers (Ljava/util/List;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public fun setUniqueUrl (Ljava/lang/String;)V
+	public fun setUrl (Ljava/lang/String;)V
+	public fun setYear (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/AnimeSearchResponse : com/lagradost/cloudstream3/SearchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Integer;
+	public final fun component11 ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public final fun component12 ()Ljava/util/Map;
+	public final fun component13 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/util/EnumSet;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)Lcom/lagradost/cloudstream3/AnimeSearchResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/EnumSet;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AnimeSearchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getApiName ()Ljava/lang/String;
+	public final fun getDubStatus ()Ljava/util/EnumSet;
+	public final fun getEpisodes ()Ljava/util/Map;
+	public fun getId ()Ljava/lang/Integer;
+	public fun getName ()Ljava/lang/String;
+	public final fun getOtherName ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getQuality ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUrl ()Ljava/lang/String;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun setDubStatus (Ljava/util/EnumSet;)V
+	public final fun setEpisodes (Ljava/util/Map;)V
+	public fun setId (Ljava/lang/Integer;)V
+	public final fun setOtherName (Ljava/lang/String;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setQuality (Lcom/lagradost/cloudstream3/SearchQuality;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public final fun setYear (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/AudioFile {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setHeaders (Ljava/util/Map;)V
+	public final fun setUrl (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/AutoDownloadMode : java/lang/Enum {
+	public static final field All Lcom/lagradost/cloudstream3/AutoDownloadMode;
+	public static final field Companion Lcom/lagradost/cloudstream3/AutoDownloadMode$Companion;
+	public static final field Disable Lcom/lagradost/cloudstream3/AutoDownloadMode;
+	public static final field FilterByLang Lcom/lagradost/cloudstream3/AutoDownloadMode;
+	public static final field NsfwOnly Lcom/lagradost/cloudstream3/AutoDownloadMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/AutoDownloadMode;
+	public static fun values ()[Lcom/lagradost/cloudstream3/AutoDownloadMode;
+}
+
+public final class com/lagradost/cloudstream3/AutoDownloadMode$Companion {
+	public final fun getEnum (I)Lcom/lagradost/cloudstream3/AutoDownloadMode;
+}
+
+public final class com/lagradost/cloudstream3/DubStatus : java/lang/Enum {
+	public static final field Dubbed Lcom/lagradost/cloudstream3/DubStatus;
+	public static final field None Lcom/lagradost/cloudstream3/DubStatus;
+	public static final field Subbed Lcom/lagradost/cloudstream3/DubStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getId ()I
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/DubStatus;
+	public static fun values ()[Lcom/lagradost/cloudstream3/DubStatus;
+}
+
+public final class com/lagradost/cloudstream3/Episode {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/Episode;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/Episode;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/Episode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public final fun getDate ()Ljava/lang/Long;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEpisode ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPosterUrl ()Ljava/lang/String;
+	public final fun getRating ()Ljava/lang/Integer;
+	public final fun getRunTime ()Ljava/lang/Integer;
+	public final fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public final fun getSeason ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun setData (Ljava/lang/String;)V
+	public final fun setDate (Ljava/lang/Long;)V
+	public final fun setDescription (Ljava/lang/String;)V
+	public final fun setEpisode (Ljava/lang/Integer;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setPosterUrl (Ljava/lang/String;)V
+	public final fun setRating (Ljava/lang/Integer;)V
+	public final fun setRunTime (Ljava/lang/Integer;)V
+	public final fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public final fun setSeason (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/lagradost/cloudstream3/EpisodeResponse {
+	public abstract fun getLatestEpisodes ()Ljava/util/Map;
+	public abstract fun getNextAiring ()Lcom/lagradost/cloudstream3/NextAiring;
+	public abstract fun getSeasonNames ()Ljava/util/List;
+	public abstract fun getShowStatus ()Lcom/lagradost/cloudstream3/ShowStatus;
+	public abstract fun getTotalEpisodeIndex (II)I
+	public abstract fun setNextAiring (Lcom/lagradost/cloudstream3/NextAiring;)V
+	public abstract fun setSeasonNames (Ljava/util/List;)V
+	public abstract fun setShowStatus (Lcom/lagradost/cloudstream3/ShowStatus;)V
+}
+
+public final class com/lagradost/cloudstream3/ErrorLoadingException : java/lang/Exception {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/lagradost/cloudstream3/HomePageList {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Z)Lcom/lagradost/cloudstream3/HomePageList;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/HomePageList;Ljava/lang/String;Ljava/util/List;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/HomePageList;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getList ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isHorizontalImages ()Z
+	public final fun setList (Ljava/util/List;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/HomePageResponse {
+	public fun <init> (Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/util/List;Z)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/HomePageResponse;Ljava/util/List;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHasNext ()Z
+	public final fun getItems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/lagradost/cloudstream3/IDownloadableMinimum {
+	public abstract fun getHeaders ()Ljava/util/Map;
+	public abstract fun getReferer ()Ljava/lang/String;
+	public abstract fun getUrl ()Ljava/lang/String;
+}
+
+public abstract interface annotation class com/lagradost/cloudstream3/InternalAPI : java/lang/annotation/Annotation {
+}
+
+public final class com/lagradost/cloudstream3/LiveSearchResponse : com/lagradost/cloudstream3/SearchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;)Lcom/lagradost/cloudstream3/LiveSearchResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/LiveSearchResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/LiveSearchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getApiName ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/Integer;
+	public final fun getLang ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getQuality ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun setId (Ljava/lang/Integer;)V
+	public final fun setLang (Ljava/lang/String;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setQuality (Lcom/lagradost/cloudstream3/SearchQuality;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/LiveStreamLoadResponse : com/lagradost/cloudstream3/LoadResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Z
+	public final fun component16 ()Ljava/util/Map;
+	public final fun component17 ()Ljava/util/Map;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component9 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/LiveStreamLoadResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/LiveStreamLoadResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/LiveStreamLoadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getActors ()Ljava/util/List;
+	public fun getApiName ()Ljava/lang/String;
+	public fun getBackgroundPosterUrl ()Ljava/lang/String;
+	public fun getComingSoon ()Z
+	public fun getContentRating ()Ljava/lang/String;
+	public final fun getDataUrl ()Ljava/lang/String;
+	public fun getDuration ()Ljava/lang/Integer;
+	public fun getLogoUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getPlot ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getRating ()Ljava/lang/Integer;
+	public fun getRecommendations ()Ljava/util/List;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getSyncData ()Ljava/util/Map;
+	public fun getTags ()Ljava/util/List;
+	public fun getTrailers ()Ljava/util/List;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUniqueUrl ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun setActors (Ljava/util/List;)V
+	public fun setApiName (Ljava/lang/String;)V
+	public fun setBackgroundPosterUrl (Ljava/lang/String;)V
+	public fun setComingSoon (Z)V
+	public fun setContentRating (Ljava/lang/String;)V
+	public final fun setDataUrl (Ljava/lang/String;)V
+	public fun setDuration (Ljava/lang/Integer;)V
+	public fun setLogoUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setPlot (Ljava/lang/String;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setRating (Ljava/lang/Integer;)V
+	public fun setRecommendations (Ljava/util/List;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setSyncData (Ljava/util/Map;)V
+	public fun setTags (Ljava/util/List;)V
+	public fun setTrailers (Ljava/util/List;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public fun setUniqueUrl (Ljava/lang/String;)V
+	public fun setUrl (Ljava/lang/String;)V
+	public fun setYear (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/lagradost/cloudstream3/LoadResponse {
+	public static final field Companion Lcom/lagradost/cloudstream3/LoadResponse$Companion;
+	public abstract fun getActors ()Ljava/util/List;
+	public abstract fun getApiName ()Ljava/lang/String;
+	public abstract fun getBackgroundPosterUrl ()Ljava/lang/String;
+	public abstract fun getComingSoon ()Z
+	public abstract fun getContentRating ()Ljava/lang/String;
+	public abstract fun getDuration ()Ljava/lang/Integer;
+	public abstract fun getLogoUrl ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getPlot ()Ljava/lang/String;
+	public abstract fun getPosterHeaders ()Ljava/util/Map;
+	public abstract fun getPosterUrl ()Ljava/lang/String;
+	public fun getRating ()Ljava/lang/Integer;
+	public abstract fun getRecommendations ()Ljava/util/List;
+	public abstract fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public abstract fun getSyncData ()Ljava/util/Map;
+	public abstract fun getTags ()Ljava/util/List;
+	public abstract fun getTrailers ()Ljava/util/List;
+	public abstract fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public abstract fun getUniqueUrl ()Ljava/lang/String;
+	public abstract fun getUrl ()Ljava/lang/String;
+	public abstract fun getYear ()Ljava/lang/Integer;
+	public abstract fun setActors (Ljava/util/List;)V
+	public abstract fun setApiName (Ljava/lang/String;)V
+	public abstract fun setBackgroundPosterUrl (Ljava/lang/String;)V
+	public abstract fun setComingSoon (Z)V
+	public abstract fun setContentRating (Ljava/lang/String;)V
+	public abstract fun setDuration (Ljava/lang/Integer;)V
+	public abstract fun setLogoUrl (Ljava/lang/String;)V
+	public abstract fun setName (Ljava/lang/String;)V
+	public abstract fun setPlot (Ljava/lang/String;)V
+	public abstract fun setPosterHeaders (Ljava/util/Map;)V
+	public abstract fun setPosterUrl (Ljava/lang/String;)V
+	public fun setRating (Ljava/lang/Integer;)V
+	public abstract fun setRecommendations (Ljava/util/List;)V
+	public abstract fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public abstract fun setSyncData (Ljava/util/Map;)V
+	public abstract fun setTags (Ljava/util/List;)V
+	public abstract fun setTrailers (Ljava/util/List;)V
+	public abstract fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public abstract fun setUniqueUrl (Ljava/lang/String;)V
+	public abstract fun setUrl (Ljava/lang/String;)V
+	public abstract fun setYear (Ljava/lang/Integer;)V
+}
+
+public final class com/lagradost/cloudstream3/LoadResponse$Companion {
+	public final fun addActorNames (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/util/List;)V
+	public final fun addActors (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/util/List;)V
+	public final fun addActorsOnly (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/util/List;)V
+	public final fun addActorsRole (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/util/List;)V
+	public final fun addAniListId (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/Integer;)V
+	public final fun addDuration (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;)V
+	public final fun addIdToString (Ljava/lang/String;Lcom/lagradost/cloudstream3/SimklSyncServices;Ljava/lang/String;)Ljava/lang/String;
+	public final fun addImdbId (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;)V
+	public final fun addImdbUrl (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;)V
+	public final fun addKitsuId (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/Integer;)V
+	public final fun addKitsuId (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;)V
+	public final fun addMalId (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/Integer;)V
+	public final fun addRating (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/Integer;)V
+	public final fun addRating (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;)V
+	public final fun addScore (Lcom/lagradost/cloudstream3/LoadResponse;Lcom/lagradost/cloudstream3/Score;)V
+	public final fun addScore (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;I)V
+	public static synthetic fun addScore$default (Lcom/lagradost/cloudstream3/LoadResponse$Companion;Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;IILjava/lang/Object;)V
+	public final fun addSimklId (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/Integer;)V
+	public final fun addTMDbId (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;)V
+	public final fun addTrailer (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun addTrailer (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun addTrailer (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/util/List;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addTrailer$default (Lcom/lagradost/cloudstream3/LoadResponse$Companion;Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun addTrailer$default (Lcom/lagradost/cloudstream3/LoadResponse$Companion;Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun addTrailer$default (Lcom/lagradost/cloudstream3/LoadResponse$Companion;Lcom/lagradost/cloudstream3/LoadResponse;Ljava/util/List;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun addTraktId (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;)V
+	public final fun getAniListId (Lcom/lagradost/cloudstream3/LoadResponse;)Ljava/lang/String;
+	public final fun getAniListIdPrefix ()Ljava/lang/String;
+	public final fun getImdbId (Lcom/lagradost/cloudstream3/LoadResponse;)Ljava/lang/String;
+	public final fun getKitsuId (Lcom/lagradost/cloudstream3/LoadResponse;)Ljava/lang/String;
+	public final fun getKitsuIdPrefix ()Ljava/lang/String;
+	public final fun getMalId (Lcom/lagradost/cloudstream3/LoadResponse;)Ljava/lang/String;
+	public final fun getMalIdPrefix ()Ljava/lang/String;
+	public final fun getSimklIdPrefix ()Ljava/lang/String;
+	public final fun getTMDbId (Lcom/lagradost/cloudstream3/LoadResponse;)Ljava/lang/String;
+	public final fun isMovie (Lcom/lagradost/cloudstream3/LoadResponse;)Z
+	public final fun isTrailersEnabled ()Z
+	public final fun readIdFromString (Ljava/lang/String;)Ljava/util/Map;
+	public final fun setAniListIdPrefix (Ljava/lang/String;)V
+	public final fun setKitsuIdPrefix (Ljava/lang/String;)V
+	public final fun setMalIdPrefix (Ljava/lang/String;)V
+	public final fun setSimklIdPrefix (Ljava/lang/String;)V
+	public final fun setTrailersEnabled (Z)V
+}
+
+public final class com/lagradost/cloudstream3/LoadResponse$DefaultImpls {
+	public static fun getRating (Lcom/lagradost/cloudstream3/LoadResponse;)Ljava/lang/Integer;
+	public static fun setRating (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/Integer;)V
+}
+
+public abstract class com/lagradost/cloudstream3/MainAPI {
+	public static final field Companion Lcom/lagradost/cloudstream3/MainAPI$Companion;
+	public fun <init> ()V
+	public fun extractorVerifierJob (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getCanBeOverridden ()Z
+	public fun getGetMainPageTimeoutMs ()Ljava/lang/Long;
+	public fun getHasChromecastSupport ()Z
+	public fun getHasDownloadSupport ()Z
+	public fun getHasMainPage ()Z
+	public fun getHasQuickSearch ()Z
+	public fun getInstantLinkLoading ()Z
+	public fun getLang ()Ljava/lang/String;
+	public final fun getLastHomepageRequest ()J
+	public fun getLoadLinksTimeoutMs ()Ljava/lang/Long;
+	public fun getLoadTimeoutMs ()Ljava/lang/Long;
+	public fun getLoadUrl (Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMainPage ()Ljava/util/List;
+	public fun getMainPage (ILcom/lagradost/cloudstream3/MainPageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getProviderType ()Lcom/lagradost/cloudstream3/ProviderType;
+	public fun getQuickSearchTimeoutMs ()Ljava/lang/Long;
+	public fun getSearchTimeoutMs ()Ljava/lang/Long;
+	public fun getSequentialMainPage ()Z
+	public fun getSequentialMainPageDelay ()J
+	public fun getSequentialMainPageScrollDelay ()J
+	public final fun getSourcePlugin ()Ljava/lang/String;
+	public fun getStoredCredentials ()Ljava/lang/String;
+	public fun getSupportedSyncNames ()Ljava/util/Set;
+	public fun getSupportedTypes ()Ljava/util/Set;
+	public fun getUsesWebView ()Z
+	public fun getVideoInterceptor (Lcom/lagradost/cloudstream3/utils/ExtractorLink;)Lokhttp3/Interceptor;
+	public fun getVpnStatus ()Lcom/lagradost/cloudstream3/VPNStatus;
+	public final fun init ()V
+	public fun load (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun loadLinks (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun overrideWithNewData (Lcom/lagradost/cloudstream3/ProvidersInfoJson;)V
+	public fun quickSearch (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun search (Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun search (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setCanBeOverridden (Z)V
+	public fun setLang (Ljava/lang/String;)V
+	public final fun setLastHomepageRequest (J)V
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setSequentialMainPage (Z)V
+	public fun setSequentialMainPageDelay (J)V
+	public fun setSequentialMainPageScrollDelay (J)V
+	public final fun setSourcePlugin (Ljava/lang/String;)V
+	public fun setStoredCredentials (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/MainAPI$Companion {
+	public final fun getOverrideData ()Ljava/util/HashMap;
+	public final fun getSettingsForProvider ()Lcom/lagradost/cloudstream3/SettingsJson;
+	public final fun setOverrideData (Ljava/util/HashMap;)V
+	public final fun setSettingsForProvider (Lcom/lagradost/cloudstream3/SettingsJson;)V
+}
+
+public final class com/lagradost/cloudstream3/MainAPIKt {
+	public static final field AllLanguagesName Ljava/lang/String;
+	public static final field PROVIDER_STATUS_BETA_ONLY I
+	public static final field PROVIDER_STATUS_DOWN I
+	public static final field PROVIDER_STATUS_KEY Ljava/lang/String;
+	public static final field PROVIDER_STATUS_OK I
+	public static final field PROVIDER_STATUS_SLOW I
+	public static final field USER_AGENT Ljava/lang/String;
+	public static final fun addDate (Lcom/lagradost/cloudstream3/Episode;Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun addDate (Lcom/lagradost/cloudstream3/Episode;Ljava/util/Date;)V
+	public static synthetic fun addDate$default (Lcom/lagradost/cloudstream3/Episode;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun addDub (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Ljava/lang/Integer;)V
+	public static final fun addDubStatus (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Lcom/lagradost/cloudstream3/DubStatus;Ljava/lang/Integer;)V
+	public static final fun addDubStatus (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Ljava/lang/String;Ljava/lang/Integer;)V
+	public static final fun addDubStatus (Lcom/lagradost/cloudstream3/AnimeSearchResponse;ZLjava/lang/Integer;)V
+	public static final fun addDubStatus (Lcom/lagradost/cloudstream3/AnimeSearchResponse;ZZLjava/lang/Integer;Ljava/lang/Integer;)V
+	public static synthetic fun addDubStatus$default (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Lcom/lagradost/cloudstream3/DubStatus;Ljava/lang/Integer;ILjava/lang/Object;)V
+	public static synthetic fun addDubStatus$default (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)V
+	public static synthetic fun addDubStatus$default (Lcom/lagradost/cloudstream3/AnimeSearchResponse;ZLjava/lang/Integer;ILjava/lang/Object;)V
+	public static synthetic fun addDubStatus$default (Lcom/lagradost/cloudstream3/AnimeSearchResponse;ZZLjava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)V
+	public static final fun addEpisodes (Lcom/lagradost/cloudstream3/AnimeLoadResponse;Lcom/lagradost/cloudstream3/DubStatus;Ljava/util/List;)V
+	public static final fun addPoster (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;Ljava/util/Map;)V
+	public static final fun addPoster (Lcom/lagradost/cloudstream3/SearchResponse;Ljava/lang/String;Ljava/util/Map;)V
+	public static synthetic fun addPoster$default (Lcom/lagradost/cloudstream3/LoadResponse;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun addPoster$default (Lcom/lagradost/cloudstream3/SearchResponse;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static final fun addQuality (Lcom/lagradost/cloudstream3/SearchResponse;Ljava/lang/String;)V
+	public static final fun addSeasonNamesSeasonData (Lcom/lagradost/cloudstream3/EpisodeResponse;Ljava/util/List;)V
+	public static final fun addSeasonNamesString (Lcom/lagradost/cloudstream3/EpisodeResponse;Ljava/util/List;)V
+	public static final fun addSub (Lcom/lagradost/cloudstream3/AnimeSearchResponse;Ljava/lang/Integer;)V
+	public static final fun base64Decode (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun base64DecodeArray (Ljava/lang/String;)[B
+	public static final fun base64Encode ([B)Ljava/lang/String;
+	public static final fun capitalizeString (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun capitalizeStringNullable (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun fetchUrls (Ljava/lang/String;)Ljava/util/List;
+	public static final fun fixTitle (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun fixUrl (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun fixUrlNull (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun getDurationFromString (Ljava/lang/String;)Ljava/lang/Integer;
+	public static final fun getFolderPrefix (Lcom/lagradost/cloudstream3/TvType;)Ljava/lang/String;
+	public static final fun getMapper ()Lcom/fasterxml/jackson/databind/json/JsonMapper;
+	public static final fun getQualityFromString (Ljava/lang/String;)Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final fun getRhinoContext (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun imdbUrlToId (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun imdbUrlToIdNullable (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun isAnimeBased (Lcom/lagradost/cloudstream3/LoadResponse;)Z
+	public static final fun isAnimeOp (Lcom/lagradost/cloudstream3/TvType;)Z
+	public static final fun isAudioType (Lcom/lagradost/cloudstream3/TvType;)Z
+	public static final fun isEpisodeBased (Lcom/lagradost/cloudstream3/LoadResponse;)Z
+	public static final fun isEpisodeBased (Lcom/lagradost/cloudstream3/TvType;)Z
+	public static final fun isLiveStream (Lcom/lagradost/cloudstream3/TvType;)Z
+	public static final fun isMovieType (Lcom/lagradost/cloudstream3/TvType;)Z
+	public static final fun mainPage (Ljava/lang/String;Ljava/lang/String;Z)Lcom/lagradost/cloudstream3/MainPageData;
+	public static synthetic fun mainPage$default (Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/MainPageData;
+	public static final fun mainPageOf ([Lcom/lagradost/cloudstream3/MainPageData;)Ljava/util/List;
+	public static final fun mainPageOf ([Lkotlin/Pair;)Ljava/util/List;
+	public static final fun newAnimeLoadResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newAnimeLoadResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newAnimeSearchResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;)Lcom/lagradost/cloudstream3/AnimeSearchResponse;
+	public static synthetic fun newAnimeSearchResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/AnimeSearchResponse;
+	public static final fun newAudioFile (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newAudioFile$default (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newEpisode (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lcom/lagradost/cloudstream3/Episode;
+	public static final fun newEpisode (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Z)Lcom/lagradost/cloudstream3/Episode;
+	public static synthetic fun newEpisode$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/Episode;
+	public static synthetic fun newEpisode$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/Episode;
+	public static final fun newHomePageResponse (Lcom/lagradost/cloudstream3/HomePageList;Ljava/lang/Boolean;)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public static final fun newHomePageResponse (Lcom/lagradost/cloudstream3/MainPageRequest;Ljava/util/List;Ljava/lang/Boolean;)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public static final fun newHomePageResponse (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public static final fun newHomePageResponse (Ljava/util/List;Ljava/lang/Boolean;)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public static synthetic fun newHomePageResponse$default (Lcom/lagradost/cloudstream3/HomePageList;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public static synthetic fun newHomePageResponse$default (Lcom/lagradost/cloudstream3/MainPageRequest;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public static synthetic fun newHomePageResponse$default (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public static synthetic fun newHomePageResponse$default (Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/HomePageResponse;
+	public static final fun newLiveSearchResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;)Lcom/lagradost/cloudstream3/LiveSearchResponse;
+	public static synthetic fun newLiveSearchResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/LiveSearchResponse;
+	public static final fun newLiveStreamLoadResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newLiveStreamLoadResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newMovieLoadResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun newMovieLoadResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newMovieLoadResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun newMovieLoadResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newMovieSearchResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;)Lcom/lagradost/cloudstream3/MovieSearchResponse;
+	public static synthetic fun newMovieSearchResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/MovieSearchResponse;
+	public static final fun newSearchResponseList (Ljava/util/List;Ljava/lang/Boolean;)Lcom/lagradost/cloudstream3/SearchResponseList;
+	public static synthetic fun newSearchResponseList$default (Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/SearchResponseList;
+	public static final fun newSubtitleFile (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newSubtitleFile$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newTorrentLoadResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newTorrentLoadResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newTorrentSearchResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;)Lcom/lagradost/cloudstream3/TorrentSearchResponse;
+	public static synthetic fun newTorrentSearchResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/TorrentSearchResponse;
+	public static final fun newTvSeriesLoadResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newTvSeriesLoadResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newTvSeriesSearchResponse (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;)Lcom/lagradost/cloudstream3/TvSeriesSearchResponse;
+	public static synthetic fun newTvSeriesSearchResponse$default (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/TvSeriesSearchResponse;
+	public static final fun sortUrls (Ljava/util/Set;)Ljava/util/List;
+	public static final fun toNewSearchResponseList (Ljava/util/List;Ljava/lang/Boolean;)Lcom/lagradost/cloudstream3/SearchResponseList;
+	public static synthetic fun toNewSearchResponseList$default (Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/SearchResponseList;
+	public static final fun toRatingInt (Ljava/lang/String;)Ljava/lang/Integer;
+	public static final fun updateUrl (Lcom/lagradost/cloudstream3/MainAPI;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/MainActivityKt {
+	public static final fun getApp ()Lcom/lagradost/nicehttp/Requests;
+	public static final fun setApp (Lcom/lagradost/nicehttp/Requests;)V
+}
+
+public final class com/lagradost/cloudstream3/MainPageData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Z)Lcom/lagradost/cloudstream3/MainPageData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/MainPageData;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/MainPageData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public final fun getHorizontalImages ()Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/MainPageRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Z)Lcom/lagradost/cloudstream3/MainPageRequest;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/MainPageRequest;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/MainPageRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public final fun getHorizontalImages ()Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/MovieLoadResponse : com/lagradost/cloudstream3/LoadResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Z
+	public final fun component16 ()Ljava/util/Map;
+	public final fun component17 ()Ljava/util/Map;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/MovieLoadResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/MovieLoadResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/MovieLoadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getActors ()Ljava/util/List;
+	public fun getApiName ()Ljava/lang/String;
+	public fun getBackgroundPosterUrl ()Ljava/lang/String;
+	public fun getComingSoon ()Z
+	public fun getContentRating ()Ljava/lang/String;
+	public final fun getDataUrl ()Ljava/lang/String;
+	public fun getDuration ()Ljava/lang/Integer;
+	public fun getLogoUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getPlot ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getRating ()Ljava/lang/Integer;
+	public fun getRecommendations ()Ljava/util/List;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getSyncData ()Ljava/util/Map;
+	public fun getTags ()Ljava/util/List;
+	public fun getTrailers ()Ljava/util/List;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUniqueUrl ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun setActors (Ljava/util/List;)V
+	public fun setApiName (Ljava/lang/String;)V
+	public fun setBackgroundPosterUrl (Ljava/lang/String;)V
+	public fun setComingSoon (Z)V
+	public fun setContentRating (Ljava/lang/String;)V
+	public final fun setDataUrl (Ljava/lang/String;)V
+	public fun setDuration (Ljava/lang/Integer;)V
+	public fun setLogoUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setPlot (Ljava/lang/String;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setRating (Ljava/lang/Integer;)V
+	public fun setRecommendations (Ljava/util/List;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setSyncData (Ljava/util/Map;)V
+	public fun setTags (Ljava/util/List;)V
+	public fun setTrailers (Ljava/util/List;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public fun setUniqueUrl (Ljava/lang/String;)V
+	public fun setUrl (Ljava/lang/String;)V
+	public fun setYear (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/MovieSearchResponse : com/lagradost/cloudstream3/SearchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)Lcom/lagradost/cloudstream3/MovieSearchResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/MovieSearchResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/MovieSearchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getApiName ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/Integer;
+	public fun getName ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getQuality ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUrl ()Ljava/lang/String;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun setId (Ljava/lang/Integer;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setQuality (Lcom/lagradost/cloudstream3/SearchQuality;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public final fun setYear (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/NextAiring {
+	public fun <init> (IJLjava/lang/Integer;)V
+	public synthetic fun <init> (IJLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (IJLjava/lang/Integer;)Lcom/lagradost/cloudstream3/NextAiring;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/NextAiring;IJLjava/lang/Integer;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/NextAiring;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEpisode ()I
+	public final fun getSeason ()Ljava/lang/Integer;
+	public final fun getUnixTime ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/ParCollectionsKt {
+	public static final fun amap (Ljava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun amap (Ljava/util/Map;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun amapIndexed (Ljava/util/List;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun apmap (Ljava/util/List;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun apmap (Ljava/util/Map;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun apmapIndexed (Ljava/util/List;Lkotlin/jvm/functions/Function3;)Ljava/util/List;
+	public static final fun argamap ([Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static final fun runAllAsync ([Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface annotation class com/lagradost/cloudstream3/Prerelease : java/lang/annotation/Annotation {
+}
+
+public final class com/lagradost/cloudstream3/ProviderType : java/lang/Enum {
+	public static final field DirectProvider Lcom/lagradost/cloudstream3/ProviderType;
+	public static final field MetaProvider Lcom/lagradost/cloudstream3/ProviderType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/ProviderType;
+	public static fun values ()[Lcom/lagradost/cloudstream3/ProviderType;
+}
+
+public final class com/lagradost/cloudstream3/ProvidersInfoJson {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Lcom/lagradost/cloudstream3/ProvidersInfoJson;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/ProvidersInfoJson;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Lcom/lagradost/cloudstream3/ProvidersInfoJson;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCredentials ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStatus ()I
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setCredentials (Ljava/lang/String;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setStatus (I)V
+	public final fun setUrl (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/Score {
+	public static final field Companion Lcom/lagradost/cloudstream3/Score$Companion;
+	public static final field MAX I
+	public static final field MAX_ZEROS I
+	public static final field MIN I
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun toByte (I)B
+	public final fun toDouble (I)D
+	public static synthetic fun toDouble$default (Lcom/lagradost/cloudstream3/Score;IILjava/lang/Object;)D
+	public final fun toFloat (I)F
+	public static synthetic fun toFloat$default (Lcom/lagradost/cloudstream3/Score;IILjava/lang/Object;)F
+	public final fun toInt (I)I
+	public static synthetic fun toInt$default (Lcom/lagradost/cloudstream3/Score;IILjava/lang/Object;)I
+	public final fun toLong (I)J
+	public static synthetic fun toLong$default (Lcom/lagradost/cloudstream3/Score;IILjava/lang/Object;)J
+	public final fun toOld ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun toString (IIZC)Ljava/lang/String;
+	public static synthetic fun toString$default (Lcom/lagradost/cloudstream3/Score;IIZCILjava/lang/Object;)Ljava/lang/String;
+	public final fun toStringNull (DIIZC)Ljava/lang/String;
+	public static synthetic fun toStringNull$default (Lcom/lagradost/cloudstream3/Score;DIIZCILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/Score$Companion {
+	public final fun from (Ljava/lang/Double;I)Lcom/lagradost/cloudstream3/Score;
+	public final fun from (Ljava/lang/Float;I)Lcom/lagradost/cloudstream3/Score;
+	public final fun from (Ljava/lang/Integer;I)Lcom/lagradost/cloudstream3/Score;
+	public final fun from (Ljava/lang/String;I)Lcom/lagradost/cloudstream3/Score;
+	public final fun from10 (Ljava/lang/Double;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from10 (Ljava/lang/Float;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from10 (Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from10 (Ljava/lang/String;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from100 (Ljava/lang/Double;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from100 (Ljava/lang/Float;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from100 (Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from100 (Ljava/lang/String;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from5 (Ljava/lang/Double;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from5 (Ljava/lang/Float;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from5 (Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/Score;
+	public final fun from5 (Ljava/lang/String;)Lcom/lagradost/cloudstream3/Score;
+	public final fun fromOld (Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/Score;
+}
+
+public final class com/lagradost/cloudstream3/SearchQuality : java/lang/Enum {
+	public static final field BlueRay Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field Cam Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field CamRip Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field DVD Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field FourK Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field HD Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field HDR Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field HQ Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field HdCam Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field SD Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field SDR Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field Telecine Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field Telesync Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field UHD Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field WebRip Lcom/lagradost/cloudstream3/SearchQuality;
+	public static final field WorkPrint Lcom/lagradost/cloudstream3/SearchQuality;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/SearchQuality;
+	public static fun values ()[Lcom/lagradost/cloudstream3/SearchQuality;
+}
+
+public abstract interface class com/lagradost/cloudstream3/SearchResponse {
+	public abstract fun getApiName ()Ljava/lang/String;
+	public abstract fun getId ()Ljava/lang/Integer;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getPosterHeaders ()Ljava/util/Map;
+	public abstract fun getPosterUrl ()Ljava/lang/String;
+	public abstract fun getQuality ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public abstract fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public abstract fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public abstract fun getUrl ()Ljava/lang/String;
+	public abstract fun setId (Ljava/lang/Integer;)V
+	public abstract fun setPosterHeaders (Ljava/util/Map;)V
+	public abstract fun setPosterUrl (Ljava/lang/String;)V
+	public abstract fun setQuality (Lcom/lagradost/cloudstream3/SearchQuality;)V
+	public abstract fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public abstract fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+}
+
+public final class com/lagradost/cloudstream3/SearchResponseList {
+	public fun <init> (Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/util/List;Z)Lcom/lagradost/cloudstream3/SearchResponseList;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/SearchResponseList;Ljava/util/List;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/SearchResponseList;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHasNext ()Z
+	public final fun getItems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/SeasonData {
+	public fun <init> (ILjava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (ILjava/lang/String;Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/SeasonData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/SeasonData;ILjava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/SeasonData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisplaySeason ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSeason ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/SettingsJson {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/lagradost/cloudstream3/SettingsJson;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/SettingsJson;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/SettingsJson;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnableAdult ()Z
+	public fun hashCode ()I
+	public final fun setEnableAdult (Z)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/ShowStatus : java/lang/Enum {
+	public static final field Completed Lcom/lagradost/cloudstream3/ShowStatus;
+	public static final field Ongoing Lcom/lagradost/cloudstream3/ShowStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/ShowStatus;
+	public static fun values ()[Lcom/lagradost/cloudstream3/ShowStatus;
+}
+
+public final class com/lagradost/cloudstream3/SimklSyncServices : java/lang/Enum {
+	public static final field AniList Lcom/lagradost/cloudstream3/SimklSyncServices;
+	public static final field Imdb Lcom/lagradost/cloudstream3/SimklSyncServices;
+	public static final field Mal Lcom/lagradost/cloudstream3/SimklSyncServices;
+	public static final field Simkl Lcom/lagradost/cloudstream3/SimklSyncServices;
+	public static final field Tmdb Lcom/lagradost/cloudstream3/SimklSyncServices;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getOriginalName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/SimklSyncServices;
+	public static fun values ()[Lcom/lagradost/cloudstream3/SimklSyncServices;
+}
+
+public final class com/lagradost/cloudstream3/SubtitleFile {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/SubtitleFile;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/SubtitleFile;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/SubtitleFile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getLang ()Ljava/lang/String;
+	public final fun getLangTag ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setHeaders (Ljava/util/Map;)V
+	public final fun setLang (Ljava/lang/String;)V
+	public final fun setUrl (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/TorrentLoadResponse : com/lagradost/cloudstream3/LoadResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Z
+	public final fun component17 ()Ljava/util/Map;
+	public final fun component18 ()Ljava/util/Map;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/TorrentLoadResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/TorrentLoadResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/TorrentLoadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getActors ()Ljava/util/List;
+	public fun getApiName ()Ljava/lang/String;
+	public fun getBackgroundPosterUrl ()Ljava/lang/String;
+	public fun getComingSoon ()Z
+	public fun getContentRating ()Ljava/lang/String;
+	public fun getDuration ()Ljava/lang/Integer;
+	public fun getLogoUrl ()Ljava/lang/String;
+	public final fun getMagnet ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getPlot ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getRating ()Ljava/lang/Integer;
+	public fun getRecommendations ()Ljava/util/List;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getSyncData ()Ljava/util/Map;
+	public fun getTags ()Ljava/util/List;
+	public final fun getTorrent ()Ljava/lang/String;
+	public fun getTrailers ()Ljava/util/List;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUniqueUrl ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun setActors (Ljava/util/List;)V
+	public fun setApiName (Ljava/lang/String;)V
+	public fun setBackgroundPosterUrl (Ljava/lang/String;)V
+	public fun setComingSoon (Z)V
+	public fun setContentRating (Ljava/lang/String;)V
+	public fun setDuration (Ljava/lang/Integer;)V
+	public fun setLogoUrl (Ljava/lang/String;)V
+	public final fun setMagnet (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setPlot (Ljava/lang/String;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setRating (Ljava/lang/Integer;)V
+	public fun setRecommendations (Ljava/util/List;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setSyncData (Ljava/util/Map;)V
+	public fun setTags (Ljava/util/List;)V
+	public final fun setTorrent (Ljava/lang/String;)V
+	public fun setTrailers (Ljava/util/List;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public fun setUniqueUrl (Ljava/lang/String;)V
+	public fun setUrl (Ljava/lang/String;)V
+	public fun setYear (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/TorrentSearchResponse : com/lagradost/cloudstream3/SearchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)Lcom/lagradost/cloudstream3/TorrentSearchResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/TorrentSearchResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/TorrentSearchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getApiName ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/Integer;
+	public fun getName ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getQuality ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun setId (Ljava/lang/Integer;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setQuality (Lcom/lagradost/cloudstream3/SearchQuality;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/Tracker {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/Tracker;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/Tracker;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/Tracker;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAniId ()Ljava/lang/String;
+	public final fun getCover ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getKitsuId ()Ljava/lang/String;
+	public final fun getMalId ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/TrackerType : java/lang/Enum {
+	public static final field Companion Lcom/lagradost/cloudstream3/TrackerType$Companion;
+	public static final field MOVIE Lcom/lagradost/cloudstream3/TrackerType;
+	public static final field MUSIC Lcom/lagradost/cloudstream3/TrackerType;
+	public static final field ONA Lcom/lagradost/cloudstream3/TrackerType;
+	public static final field OVA Lcom/lagradost/cloudstream3/TrackerType;
+	public static final field SPECIAL Lcom/lagradost/cloudstream3/TrackerType;
+	public static final field TV Lcom/lagradost/cloudstream3/TrackerType;
+	public static final field TV_SHORT Lcom/lagradost/cloudstream3/TrackerType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/TrackerType;
+	public static fun values ()[Lcom/lagradost/cloudstream3/TrackerType;
+}
+
+public final class com/lagradost/cloudstream3/TrackerType$Companion {
+	public final fun getTypes (Lcom/lagradost/cloudstream3/TvType;)Ljava/util/Set;
+}
+
+public final class com/lagradost/cloudstream3/TrailerData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;)Lcom/lagradost/cloudstream3/TrailerData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/TrailerData;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/TrailerData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtractorUrl ()Ljava/lang/String;
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getRaw ()Z
+	public final fun getReferer ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/TvSeriesLoadResponse : com/lagradost/cloudstream3/EpisodeResponse, com/lagradost/cloudstream3/LoadResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/ShowStatus;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Lcom/lagradost/cloudstream3/NextAiring;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/ShowStatus;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Lcom/lagradost/cloudstream3/NextAiring;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Z
+	public final fun component17 ()Ljava/util/Map;
+	public final fun component18 ()Ljava/util/Map;
+	public final fun component19 ()Lcom/lagradost/cloudstream3/NextAiring;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Ljava/lang/String;
+	public final fun component24 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lcom/lagradost/cloudstream3/ShowStatus;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/ShowStatus;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Lcom/lagradost/cloudstream3/NextAiring;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/TvSeriesLoadResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/TvSeriesLoadResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/ShowStatus;Lcom/lagradost/cloudstream3/Score;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLjava/util/Map;Ljava/util/Map;Lcom/lagradost/cloudstream3/NextAiring;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/TvSeriesLoadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getActors ()Ljava/util/List;
+	public fun getApiName ()Ljava/lang/String;
+	public fun getBackgroundPosterUrl ()Ljava/lang/String;
+	public fun getComingSoon ()Z
+	public fun getContentRating ()Ljava/lang/String;
+	public fun getDuration ()Ljava/lang/Integer;
+	public final fun getEpisodes ()Ljava/util/List;
+	public fun getLatestEpisodes ()Ljava/util/Map;
+	public fun getLogoUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getNextAiring ()Lcom/lagradost/cloudstream3/NextAiring;
+	public fun getPlot ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getRating ()Ljava/lang/Integer;
+	public fun getRecommendations ()Ljava/util/List;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getSeasonNames ()Ljava/util/List;
+	public fun getShowStatus ()Lcom/lagradost/cloudstream3/ShowStatus;
+	public fun getSyncData ()Ljava/util/Map;
+	public fun getTags ()Ljava/util/List;
+	public fun getTotalEpisodeIndex (II)I
+	public fun getTrailers ()Ljava/util/List;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUniqueUrl ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun setActors (Ljava/util/List;)V
+	public fun setApiName (Ljava/lang/String;)V
+	public fun setBackgroundPosterUrl (Ljava/lang/String;)V
+	public fun setComingSoon (Z)V
+	public fun setContentRating (Ljava/lang/String;)V
+	public fun setDuration (Ljava/lang/Integer;)V
+	public final fun setEpisodes (Ljava/util/List;)V
+	public fun setLogoUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setNextAiring (Lcom/lagradost/cloudstream3/NextAiring;)V
+	public fun setPlot (Ljava/lang/String;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setRating (Ljava/lang/Integer;)V
+	public fun setRecommendations (Ljava/util/List;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setSeasonNames (Ljava/util/List;)V
+	public fun setShowStatus (Lcom/lagradost/cloudstream3/ShowStatus;)V
+	public fun setSyncData (Ljava/util/Map;)V
+	public fun setTags (Ljava/util/List;)V
+	public fun setTrailers (Ljava/util/List;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public fun setUniqueUrl (Ljava/lang/String;)V
+	public fun setUrl (Ljava/lang/String;)V
+	public fun setYear (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/TvSeriesSearchResponse : com/lagradost/cloudstream3/SearchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component11 ()Lcom/lagradost/cloudstream3/Score;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;)Lcom/lagradost/cloudstream3/TvSeriesSearchResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/TvSeriesSearchResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/TvType;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/SearchQuality;Ljava/util/Map;Lcom/lagradost/cloudstream3/Score;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/TvSeriesSearchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getApiName ()Ljava/lang/String;
+	public final fun getEpisodes ()Ljava/lang/Integer;
+	public fun getId ()Ljava/lang/Integer;
+	public fun getName ()Ljava/lang/String;
+	public fun getPosterHeaders ()Ljava/util/Map;
+	public fun getPosterUrl ()Ljava/lang/String;
+	public fun getQuality ()Lcom/lagradost/cloudstream3/SearchQuality;
+	public fun getScore ()Lcom/lagradost/cloudstream3/Score;
+	public fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun getUrl ()Ljava/lang/String;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun setEpisodes (Ljava/lang/Integer;)V
+	public fun setId (Ljava/lang/Integer;)V
+	public fun setPosterHeaders (Ljava/util/Map;)V
+	public fun setPosterUrl (Ljava/lang/String;)V
+	public fun setQuality (Lcom/lagradost/cloudstream3/SearchQuality;)V
+	public fun setScore (Lcom/lagradost/cloudstream3/Score;)V
+	public fun setType (Lcom/lagradost/cloudstream3/TvType;)V
+	public final fun setYear (Ljava/lang/Integer;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/TvType : java/lang/Enum {
+	public static final field Anime Lcom/lagradost/cloudstream3/TvType;
+	public static final field AnimeMovie Lcom/lagradost/cloudstream3/TvType;
+	public static final field AsianDrama Lcom/lagradost/cloudstream3/TvType;
+	public static final field Audio Lcom/lagradost/cloudstream3/TvType;
+	public static final field AudioBook Lcom/lagradost/cloudstream3/TvType;
+	public static final field Cartoon Lcom/lagradost/cloudstream3/TvType;
+	public static final field CustomMedia Lcom/lagradost/cloudstream3/TvType;
+	public static final field Documentary Lcom/lagradost/cloudstream3/TvType;
+	public static final field Live Lcom/lagradost/cloudstream3/TvType;
+	public static final field Movie Lcom/lagradost/cloudstream3/TvType;
+	public static final field Music Lcom/lagradost/cloudstream3/TvType;
+	public static final field NSFW Lcom/lagradost/cloudstream3/TvType;
+	public static final field OVA Lcom/lagradost/cloudstream3/TvType;
+	public static final field Others Lcom/lagradost/cloudstream3/TvType;
+	public static final field Podcast Lcom/lagradost/cloudstream3/TvType;
+	public static final field Torrent Lcom/lagradost/cloudstream3/TvType;
+	public static final field TvSeries Lcom/lagradost/cloudstream3/TvType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/TvType;
+	public static fun values ()[Lcom/lagradost/cloudstream3/TvType;
+}
+
+public abstract interface annotation class com/lagradost/cloudstream3/UnsafeSSL : java/lang/annotation/Annotation {
+}
+
+public final class com/lagradost/cloudstream3/VPNStatus : java/lang/Enum {
+	public static final field MightBeNeeded Lcom/lagradost/cloudstream3/VPNStatus;
+	public static final field None Lcom/lagradost/cloudstream3/VPNStatus;
+	public static final field Torrent Lcom/lagradost/cloudstream3/VPNStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/VPNStatus;
+	public static fun values ()[Lcom/lagradost/cloudstream3/VPNStatus;
+}
+
+public class com/lagradost/cloudstream3/extractors/Acefile : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Acefile$Source {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Acefile$Source;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Acefile$Source;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Acefile$Source;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/AesHelper {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/AesHelper;
+	public final fun decryptAES (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Ahvsh : com/lagradost/cloudstream3/extractors/Filesim {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Aico : com/lagradost/cloudstream3/extractors/Hxfile {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Asnwish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Auvexiug : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Awish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/BgwpCC : com/lagradost/cloudstream3/extractors/BigwarpIO {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/BigwarpArt : com/lagradost/cloudstream3/extractors/BigwarpIO {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/BigwarpIO : com/lagradost/cloudstream3/extractors/JWPlayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Blogger : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/ByseBuho : com/lagradost/cloudstream3/extractors/ByseSX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/ByseQekaho : com/lagradost/cloudstream3/extractors/ByseSX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/ByseSX : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/ByseVepoin : com/lagradost/cloudstream3/extractors/ByseSX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Bysezejataos : com/lagradost/cloudstream3/extractors/ByseSX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Cavanhabg : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Cda : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Cda$PlayerData {
+	public fun <init> (Lcom/lagradost/cloudstream3/extractors/Cda$VideoPlayerData;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/extractors/Cda$VideoPlayerData;
+	public final fun copy (Lcom/lagradost/cloudstream3/extractors/Cda$VideoPlayerData;)Lcom/lagradost/cloudstream3/extractors/Cda$PlayerData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Cda$PlayerData;Lcom/lagradost/cloudstream3/extractors/Cda$VideoPlayerData;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Cda$PlayerData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getVideo ()Lcom/lagradost/cloudstream3/extractors/Cda$VideoPlayerData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Cda$VideoPlayerData {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Cda$VideoPlayerData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Cda$VideoPlayerData;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Cda$VideoPlayerData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getHash2 ()Ljava/lang/String;
+	public final fun getQualities ()Ljava/util/Map;
+	public final fun getQuality ()Ljava/lang/String;
+	public final fun getTs ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Cdnplayer : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/CdnwishCom : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public abstract class com/lagradost/cloudstream3/extractors/CineMMRedirect : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/CloudMailRu : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/ContentX : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/CsstOnline : com/lagradost/cloudstream3/extractors/SecvideoOnline {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/D0000d : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/D000dCom : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DBfilm : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Dailymotion : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dailymotion$MetaData {
+	public fun <init> (Ljava/util/Map;Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitlesWrapper;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitlesWrapper;
+	public final fun copy (Ljava/util/Map;Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitlesWrapper;)Lcom/lagradost/cloudstream3/extractors/Dailymotion$MetaData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Dailymotion$MetaData;Ljava/util/Map;Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitlesWrapper;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Dailymotion$MetaData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getQualities ()Ljava/util/Map;
+	public final fun getSubtitles ()Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitlesWrapper;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dailymotion$Quality {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Dailymotion$Quality;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Dailymotion$Quality;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Dailymotion$Quality;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dailymotion$SubtitleData {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitleData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitleData;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitleData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getUrls ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dailymotion$SubtitlesWrapper {
+	public fun <init> (ZLjava/util/Map;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (ZLjava/util/Map;)Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitlesWrapper;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitlesWrapper;ZLjava/util/Map;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Dailymotion$SubtitlesWrapper;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/util/Map;
+	public final fun getEnable ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/DatabaseGdrive : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DatabaseGdrive2 : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DecryptKeys {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/DecryptKeys;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/DecryptKeys;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/DecryptKeys;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEdge1 ()Ljava/lang/String;
+	public final fun getEdge2 ()Ljava/lang/String;
+	public final fun getLegacyFallback ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/DesuArcg : com/lagradost/cloudstream3/extractors/JWPlayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/DesuDrive : com/lagradost/cloudstream3/extractors/JWPlayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/DesuOdchan : com/lagradost/cloudstream3/extractors/JWPlayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/DesuOdvip : com/lagradost/cloudstream3/extractors/JWPlayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/DetailsRoot {
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lcom/lagradost/cloudstream3/extractors/DetailsRoot;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/DetailsRoot;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/DetailsRoot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEmbedFrameUrl ()Ljava/lang/String;
+	public final fun getId ()J
+	public final fun getOwnerPrivate ()Z
+	public final fun getPosterUrl ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dhcplay : com/lagradost/cloudstream3/extractors/CineMMRedirect {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dhtpre : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dokicloud : com/lagradost/cloudstream3/extractors/Rabbitstream {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodCxExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/DoodLaExtractor : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodLiExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodPmExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodShExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodSoExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodToExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodWatchExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodWfExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodWsExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodYtExtractor : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Doodporn : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Doodspro : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DoodstreamCom : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dooood : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Ds2play : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Ds2video : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/DsstOnline : com/lagradost/cloudstream3/extractors/SecvideoOnline {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dsvplay : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dumbalag : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Dwish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Embedgram : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/EmturbovidExtractor : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Evoload : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Evoload1 : com/lagradost/cloudstream3/extractors/Evoload {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Ewish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/FEmbed : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/FEnet : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Fastream : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/FeHD : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getDomainUrl ()Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setDomainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Fembed9hd : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/FileMoon : com/lagradost/cloudstream3/extractors/FilemoonV2 {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/FileMoonIn : com/lagradost/cloudstream3/extractors/FilemoonV2 {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/FileMoonSx : com/lagradost/cloudstream3/extractors/FilemoonV2 {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Filegram : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/FilemoonV2 : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Filesim : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/FlaswishCom : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/FourCX : com/lagradost/cloudstream3/extractors/ContentX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/FourPichive : com/lagradost/cloudstream3/extractors/ContentX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/FourPlayRu : com/lagradost/cloudstream3/extractors/ContentX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Fplayer : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/FsstOnline : com/lagradost/cloudstream3/extractors/SecvideoOnline {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/GDMirrorbot : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/GUpload : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/GamoVideo : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/Gdriveplayer : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayer$Tracks {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Gdriveplayer$Tracks;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Gdriveplayer$Tracks;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Gdriveplayer$Tracks;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayerapi : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayerapp : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayerbiz : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayerco : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayerfun : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayerio : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayerme : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayerorg : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gdriveplayerus : com/lagradost/cloudstream3/extractors/Gdriveplayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/GenericM3U8 : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Geodailymotion : com/lagradost/cloudstream3/extractors/Dailymotion {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Gofile : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gofile$AccountData {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Gofile$AccountData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Gofile$AccountData;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Gofile$AccountData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gofile$AccountResponse {
+	public fun <init> ()V
+	public fun <init> (Lcom/lagradost/cloudstream3/extractors/Gofile$AccountData;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/extractors/Gofile$AccountData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/extractors/Gofile$AccountData;
+	public final fun copy (Lcom/lagradost/cloudstream3/extractors/Gofile$AccountData;)Lcom/lagradost/cloudstream3/extractors/Gofile$AccountResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Gofile$AccountResponse;Lcom/lagradost/cloudstream3/extractors/Gofile$AccountData;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Gofile$AccountResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lcom/lagradost/cloudstream3/extractors/Gofile$AccountData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gofile$GofileData {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lcom/lagradost/cloudstream3/extractors/Gofile$GofileData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Gofile$GofileData;Ljava/util/Map;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Gofile$GofileData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gofile$GofileFile {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lcom/lagradost/cloudstream3/extractors/Gofile$GofileFile;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Gofile$GofileFile;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Gofile$GofileFile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLink ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSize ()Ljava/lang/Long;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Gofile$GofileResponse {
+	public fun <init> ()V
+	public fun <init> (Lcom/lagradost/cloudstream3/extractors/Gofile$GofileData;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/extractors/Gofile$GofileData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/extractors/Gofile$GofileData;
+	public final fun copy (Lcom/lagradost/cloudstream3/extractors/Gofile$GofileData;)Lcom/lagradost/cloudstream3/extractors/Gofile$GofileResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Gofile$GofileResponse;Lcom/lagradost/cloudstream3/extractors/Gofile$GofileData;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Gofile$GofileResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lcom/lagradost/cloudstream3/extractors/Gofile$GofileData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/GoodstreamExtractor : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Guccihide : com/lagradost/cloudstream3/extractors/Filesim {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Guxhag : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/HDMomPlayer : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/HDMomPlayer$Track {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/HDMomPlayer$Track;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/HDMomPlayer$Track;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/HDMomPlayer$Track;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/String;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/HDPlayerSystem : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/HDPlayerSystem$SystemResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/HDPlayerSystem$SystemResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/HDPlayerSystem$SystemResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/HDPlayerSystem$SystemResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHls ()Ljava/lang/String;
+	public final fun getSecuredLink ()Ljava/lang/String;
+	public final fun getVideoImage ()Ljava/lang/String;
+	public final fun getVideoSource ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/HDStreamAble : com/lagradost/cloudstream3/extractors/PeaceMakerst {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Habetar : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Haxloppd : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/HglinkTo : com/lagradost/cloudstream3/extractors/CineMMRedirect {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/HgplayCDN : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/HlsWish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Hotlinger : com/lagradost/cloudstream3/extractors/ContentX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/HubCloud : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public final fun cleanTitle (Ljava/lang/String;)Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/Hxfile : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRedirect ()Z
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/InternetArchive : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/InternetArchive$Companion;
+	public fun <init> ()V
+	public fun getExtractorUrl (Ljava/lang/String;)Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/InternetArchive$Companion {
+}
+
+public class com/lagradost/cloudstream3/extractors/JWPlayer : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/Jeniusplay : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Jeniusplay$ResponseSource {
+	public fun <init> (ZLjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Jeniusplay$ResponseSource;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Jeniusplay$ResponseSource;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Jeniusplay$ResponseSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHls ()Z
+	public final fun getSecuredLink ()Ljava/lang/String;
+	public final fun getVideoSource ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Jodwish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Keephealth : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/KotakAnimeid : com/lagradost/cloudstream3/extractors/Hxfile {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+}
+
+public final class com/lagradost/cloudstream3/extractors/Kotakajair : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Krakenfiles : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Kswplayer : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/LayarKaca : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Linkbox : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Linkbox$Data {
+	public fun <init> ()V
+	public fun <init> (Lcom/lagradost/cloudstream3/extractors/Linkbox$ItemInfo;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/extractors/Linkbox$ItemInfo;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/extractors/Linkbox$ItemInfo;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lcom/lagradost/cloudstream3/extractors/Linkbox$ItemInfo;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Linkbox$Data;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Linkbox$Data;Lcom/lagradost/cloudstream3/extractors/Linkbox$ItemInfo;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Linkbox$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getItemId ()Ljava/lang/String;
+	public final fun getItemInfo ()Lcom/lagradost/cloudstream3/extractors/Linkbox$ItemInfo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Linkbox$ItemInfo {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/ArrayList;)V
+	public synthetic fun <init> (Ljava/util/ArrayList;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/ArrayList;
+	public final fun copy (Ljava/util/ArrayList;)Lcom/lagradost/cloudstream3/extractors/Linkbox$ItemInfo;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Linkbox$ItemInfo;Ljava/util/ArrayList;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Linkbox$ItemInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResolutionList ()Ljava/util/ArrayList;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Linkbox$Resolutions {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Linkbox$Resolutions;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Linkbox$Resolutions;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Linkbox$Resolutions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResolution ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Linkbox$Responses {
+	public fun <init> ()V
+	public fun <init> (Lcom/lagradost/cloudstream3/extractors/Linkbox$Data;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/extractors/Linkbox$Data;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/extractors/Linkbox$Data;
+	public final fun copy (Lcom/lagradost/cloudstream3/extractors/Linkbox$Data;)Lcom/lagradost/cloudstream3/extractors/Linkbox$Responses;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Linkbox$Responses;Lcom/lagradost/cloudstream3/extractors/Linkbox$Data;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Linkbox$Responses;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lcom/lagradost/cloudstream3/extractors/Linkbox$Data;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/LuluStream : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Lulustream1 : com/lagradost/cloudstream3/extractors/LuluStream {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Lulustream2 : com/lagradost/cloudstream3/extractors/LuluStream {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Luluvdoo : com/lagradost/cloudstream3/extractors/LuluStream {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Luxubu : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Lvturbo : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/M3u8Manifest {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/M3u8Manifest;
+	public final fun extractLinks (Ljava/lang/String;)Ljava/util/ArrayList;
+}
+
+public class com/lagradost/cloudstream3/extractors/MailRu : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/MailRu$MailRuData {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/lagradost/cloudstream3/extractors/MailRu$MailRuData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/MailRu$MailRuData;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/MailRu$MailRuData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProvider ()Ljava/lang/String;
+	public final fun getVideos ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/MailRu$MailRuVideoData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/MailRu$MailRuVideoData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/MailRu$MailRuVideoData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/MailRu$MailRuVideoData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Maxstream : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Mdy : com/lagradost/cloudstream3/extractors/MixDrop {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Mediafire : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Megacloud : com/lagradost/cloudstream3/extractors/Rabbitstream {
+	public fun <init> ()V
+	public fun extractRealKey (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmbed ()Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Meownime : com/lagradost/cloudstream3/extractors/JWPlayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/MetaGnathTuggers : com/lagradost/cloudstream3/extractors/Voe {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/MixDrop : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getExtractorUrl (Ljava/lang/String;)Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/MixDropAg : com/lagradost/cloudstream3/extractors/MixDrop {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/MixDropBz : com/lagradost/cloudstream3/extractors/MixDrop {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/MixDropCh : com/lagradost/cloudstream3/extractors/MixDrop {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/MixDropPs : com/lagradost/cloudstream3/extractors/MixDrop {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/MixDropSi : com/lagradost/cloudstream3/extractors/MixDrop {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/MixDropTo : com/lagradost/cloudstream3/extractors/MixDrop {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Movhide : com/lagradost/cloudstream3/extractors/Filesim {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Moviehab : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/MoviehabNet : com/lagradost/cloudstream3/extractors/Moviehab {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Moviesm4u : com/lagradost/cloudstream3/extractors/Filesim {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Mp4Upload : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Multimovies : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Multimoviesshg : com/lagradost/cloudstream3/extractors/Filesim {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Mvidoo : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Mwish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/MxDropTo : com/lagradost/cloudstream3/extractors/MixDrop {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/MyVidPlay : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/NathanFromSubject : com/lagradost/cloudstream3/extractors/Voe {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Nekostream : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Nekowish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Neonime7n : com/lagradost/cloudstream3/extractors/Hxfile {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRedirect ()Z
+}
+
+public final class com/lagradost/cloudstream3/extractors/Neonime8n : com/lagradost/cloudstream3/extractors/Hxfile {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRedirect ()Z
+}
+
+public final class com/lagradost/cloudstream3/extractors/Obeywish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Odnoklassniki : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Odnoklassniki$OkRuVideo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Odnoklassniki$OkRuVideo;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Odnoklassniki$OkRuVideo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Odnoklassniki$OkRuVideo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/OkRuHTTP : com/lagradost/cloudstream3/extractors/Odnoklassniki {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/OkRuHTTPMobile : com/lagradost/cloudstream3/extractors/OkRuHTTP {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/OkRuSSL : com/lagradost/cloudstream3/extractors/Odnoklassniki {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/OkRuSSLMobile : com/lagradost/cloudstream3/extractors/OkRuSSL {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/PeaceMakerst : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PeaceMakerst$PeaceResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$PeaceResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$PeaceResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$PeaceResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSIndex ()Ljava/lang/String;
+	public final fun getSourceList ()Ljava/util/Map;
+	public final fun getVideoImage ()Ljava/lang/String;
+	public final fun getVideoSources ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2ApiResponse {
+	public fun <init> (Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Media;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Media;
+	public final fun copy (Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Media;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2ApiResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2ApiResponse;Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Media;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2ApiResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMedia ()Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Media;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Link {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Link;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Link;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Link;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSecurePath ()Ljava/lang/String;
+	public final fun getServiceUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Media {
+	public fun <init> (Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Link;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Link;
+	public final fun copy (Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Link;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Media;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Media;Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Link;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Media;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLink ()Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$Teve2Link;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PeaceMakerst$VideoSource {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$VideoSource;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$VideoSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/PeaceMakerst$VideoSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Peytonepre : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Pichive : com/lagradost/cloudstream3/extractors/ContentX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/PixelDrain : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PixelDrainDev : com/lagradost/cloudstream3/extractors/PixelDrain {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/PlayLtXyz : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PlayRu : com/lagradost/cloudstream3/extractors/ContentX {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Playback {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lcom/lagradost/cloudstream3/extractors/DecryptKeys;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lcom/lagradost/cloudstream3/extractors/DecryptKeys;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lcom/lagradost/cloudstream3/extractors/DecryptKeys;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Playback;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Playback;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lcom/lagradost/cloudstream3/extractors/DecryptKeys;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Playback;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlgorithm ()Ljava/lang/String;
+	public final fun getDecryptKeys ()Lcom/lagradost/cloudstream3/extractors/DecryptKeys;
+	public final fun getExpiresAt ()Ljava/lang/String;
+	public final fun getIv ()Ljava/lang/String;
+	public final fun getIv2 ()Ljava/lang/String;
+	public final fun getKeyParts ()Ljava/util/List;
+	public final fun getPayload ()Ljava/lang/String;
+	public final fun getPayload2 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PlaybackDecrypt {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/lagradost/cloudstream3/extractors/PlaybackDecrypt;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/PlaybackDecrypt;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/PlaybackDecrypt;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSources ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PlaybackDecryptSource {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()J
+	public final fun component6 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/PlaybackDecryptSource;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/PlaybackDecryptSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/Object;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/PlaybackDecryptSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBitrateKbps ()J
+	public final fun getHeight ()Ljava/lang/Object;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getQuality ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/PlaybackRoot {
+	public fun <init> (Lcom/lagradost/cloudstream3/extractors/Playback;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/extractors/Playback;
+	public final fun copy (Lcom/lagradost/cloudstream3/extractors/Playback;)Lcom/lagradost/cloudstream3/extractors/PlaybackRoot;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/PlaybackRoot;Lcom/lagradost/cloudstream3/extractors/Playback;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/PlaybackRoot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlayback ()Lcom/lagradost/cloudstream3/extractors/Playback;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/PlayerVoxzer : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Playerwish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Rabbitstream : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun extractRealKey (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getEmbed ()Ljava/lang/String;
+	public fun getKey ()Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Rabbitstream$Sources {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Rabbitstream$Sources;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Rabbitstream$Sources;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Rabbitstream$Sources;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Rabbitstream$SourcesEncrypted {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;)Lcom/lagradost/cloudstream3/extractors/Rabbitstream$SourcesEncrypted;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Rabbitstream$SourcesEncrypted;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Rabbitstream$SourcesEncrypted;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEncrypted ()Ljava/lang/Boolean;
+	public final fun getSources ()Ljava/lang/String;
+	public final fun getTracks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Rabbitstream$SourcesResponses {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/lagradost/cloudstream3/extractors/Rabbitstream$SourcesResponses;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Rabbitstream$SourcesResponses;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Rabbitstream$SourcesResponses;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSources ()Ljava/util/List;
+	public final fun getTracks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Rabbitstream$Tracks {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Rabbitstream$Tracks;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Rabbitstream$Tracks;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Rabbitstream$Tracks;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/RapidVid : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Rasacintaku : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Ryderjet : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/SBPlay : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/SBfull : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sbasian : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sbface : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sbflix : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sblona : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sblongvu : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sbnet : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sbrapid : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sbsonic : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sbspeed : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sbthe : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/SecvideoOnline : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/Sendvid : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Server1uns : com/lagradost/cloudstream3/extractors/VidStack {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setRequiresReferer (Z)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/SfastwishCom : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/ShaveTape : com/lagradost/cloudstream3/extractors/StreamTape {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/SibNet : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Simpulumlamerop : com/lagradost/cloudstream3/extractors/Voe {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Slmaxed : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public final fun getEmbedRegex ()Lkotlin/text/Regex;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Slmaxed$JsonResponse {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/lagradost/cloudstream3/extractors/Slmaxed$JsonResponse;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Slmaxed$JsonResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Slmaxed$JsonResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getResult ()Ljava/util/Map;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getToken ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Slmaxed$Result {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Slmaxed$Result;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Slmaxed$Result;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Slmaxed$Result;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Smoothpre : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Sobreatsesuyp : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Sobreatsesuyp$SobreatsesuypVideoData {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Sobreatsesuyp$SobreatsesuypVideoData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Sobreatsesuyp$SobreatsesuypVideoData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Sobreatsesuyp$SobreatsesuypVideoData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Ssbstream : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/StreamEmbed : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamHLS : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamM4u : com/lagradost/cloudstream3/extractors/XStreamCdn {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/StreamSB : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB$Main {
+	public fun <init> (Lcom/lagradost/cloudstream3/extractors/StreamSB$StreamData;I)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/extractors/StreamSB$StreamData;
+	public final fun component2 ()I
+	public final fun copy (Lcom/lagradost/cloudstream3/extractors/StreamSB$StreamData;I)Lcom/lagradost/cloudstream3/extractors/StreamSB$Main;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/StreamSB$Main;Lcom/lagradost/cloudstream3/extractors/StreamSB$StreamData;IILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/StreamSB$Main;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStatusCode ()I
+	public final fun getStreamData ()Lcom/lagradost/cloudstream3/extractors/StreamSB$StreamData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB$StreamData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/ArrayList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/ArrayList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/ArrayList;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/ArrayList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/StreamSB$StreamData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/StreamSB$StreamData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/ArrayList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/StreamSB$StreamData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackup ()Ljava/lang/String;
+	public final fun getCdnImg ()Ljava/lang/String;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getHash ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLength ()Ljava/lang/String;
+	public final fun getSubs ()Ljava/util/ArrayList;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB$Subs {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/StreamSB$Subs;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/StreamSB$Subs;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/StreamSB$Subs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB1 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB10 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB11 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB2 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB3 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB4 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB5 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB6 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB7 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB8 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamSB9 : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/StreamSilk : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/StreamTape : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamTapeNet : com/lagradost/cloudstream3/extractors/StreamTape {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamTapeXyz : com/lagradost/cloudstream3/extractors/StreamTape {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/StreamWishExtractor : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamhideCom : com/lagradost/cloudstream3/extractors/Filesim {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/StreamhideTo : com/lagradost/cloudstream3/extractors/Filesim {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Streamhub : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getExtractorUrl (Ljava/lang/String;)Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Streamhub2 : com/lagradost/cloudstream3/extractors/ZplayerV2 {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Streamix : com/lagradost/cloudstream3/extractors/Streamup {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Streamlare : com/lagradost/cloudstream3/extractors/Slmaxed {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/StreamoUpload : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/Streamplay : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Streamplay$Source {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Streamplay$Source;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Streamplay$Source;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Streamplay$Source;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Streamsss : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Streamup : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getApiPath ()Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Streamwish2 : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Strwish : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Strwish2 : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Supervideo : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Swdyu : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Swhoi : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/TRsTX : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/TRsTX$TrstxVideoData {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/TRsTX$TrstxVideoData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/TRsTX$TrstxVideoData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/TRsTX$TrstxVideoData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Tantifilm : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Tantifilm$TantifilmData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Tantifilm$TantifilmData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Tantifilm$TantifilmData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Tantifilm$TantifilmData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Tantifilm$TantifilmJsonData {
+	public fun <init> (ZLjava/util/List;Ljava/util/List;Z)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Z
+	public final fun copy (ZLjava/util/List;Ljava/util/List;Z)Lcom/lagradost/cloudstream3/extractors/Tantifilm$TantifilmJsonData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Tantifilm$TantifilmJsonData;ZLjava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Tantifilm$TantifilmJsonData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptions ()Ljava/util/List;
+	public final fun getData ()Ljava/util/List;
+	public final fun getSuccess ()Z
+	public fun hashCode ()I
+	public final fun is_vr ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/TauVideo : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/TauVideo$TauVideoData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/TauVideo$TauVideoData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/TauVideo$TauVideoData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/TauVideo$TauVideoData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/TauVideo$TauVideoUrls {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/lagradost/cloudstream3/extractors/TauVideo$TauVideoUrls;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/TauVideo$TauVideoUrls;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/TauVideo$TauVideoUrls;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrls ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Techinmind : com/lagradost/cloudstream3/extractors/GDMirrorbot {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setRequiresReferer (Z)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Tubeless : com/lagradost/cloudstream3/extractors/Voe {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Uasopt : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Up4FunTop : com/lagradost/cloudstream3/extractors/Up4Stream {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Up4Stream : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Upstream : com/lagradost/cloudstream3/extractors/ZplayerV2 {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/UpstreamExtractor : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/Uqload : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Uqload1 : com/lagradost/cloudstream3/extractors/Uqload {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Uqload2 : com/lagradost/cloudstream3/extractors/Uqload {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Uqloadbz : com/lagradost/cloudstream3/extractors/Uqload {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Uqloadcx : com/lagradost/cloudstream3/extractors/Uqload {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/UqloadsXyz : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Urochsunloath : com/lagradost/cloudstream3/extractors/Voe {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Userload : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Userscloud : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/Uservideo : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Uservideo$Sources {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/Uservideo$Sources;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/Uservideo$Sources;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/Uservideo$Sources;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getSrc ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Vicloud : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidHideHub : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/VidHidePro : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidHidePro1 : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidHidePro2 : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidHidePro3 : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidHidePro4 : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidHidePro5 : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidHidePro6 : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/VidMoxy : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VidNest : com/lagradost/cloudstream3/extractors/JWPlayer {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/VidStack : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidara : com/lagradost/cloudstream3/extractors/Streamup {
+	public fun <init> ()V
+	public fun getApiPath ()Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vide0Net : com/lagradost/cloudstream3/extractors/DoodLaExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Videa : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/VideoSeyred : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VideoSeyred$VSSource {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/VideoSeyred$VSSource;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/VideoSeyred$VSSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/VideoSeyred$VSSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/String;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VideoSeyred$VSTrack {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/VideoSeyred$VSTrack;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/VideoSeyred$VSTrack;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/VideoSeyred$VSTrack;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/String;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VideoSeyred$VideoSeyredSource {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lcom/lagradost/cloudstream3/extractors/VideoSeyred$VideoSeyredSource;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/VideoSeyred$VideoSeyredSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/VideoSeyred$VideoSeyredSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getSources ()Ljava/util/List;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTracks ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Videzz : com/lagradost/cloudstream3/extractors/Vidoza {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidgomunime : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidgomunimesb : com/lagradost/cloudstream3/extractors/StreamSB {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/VidhideExtractor : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Vidmoly : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidmolybiz : com/lagradost/cloudstream3/extractors/Vidmoly {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidmolyme : com/lagradost/cloudstream3/extractors/Vidmoly {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidmolyto : com/lagradost/cloudstream3/extractors/Vidmoly {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vido : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Vidoza : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Vidsonic : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/VinovoSi : com/lagradost/cloudstream3/extractors/VinovoTo {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/VinovoTo : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/VkExtractor : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/Voe : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Voe1 : com/lagradost/cloudstream3/extractors/Voe {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Voe2 : com/lagradost/cloudstream3/extractors/Voe {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/Vtbe : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/WatchSB : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Watchadsontape : com/lagradost/cloudstream3/extractors/StreamTape {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/Wibufile : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/WishembedPro : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Wishfast : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Wishonly : com/lagradost/cloudstream3/extractors/StreamWishExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/extractors/XStreamCdn : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getDomainUrl ()Ljava/lang/String;
+	public fun getExtractorUrl (Ljava/lang/String;)Ljava/lang/String;
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setDomainUrl (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Xenolyzb : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Yipsu : com/lagradost/cloudstream3/extractors/Voe {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/YourUpload : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/extractors/YoutubeExtractor : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/YoutubeMobileExtractor : com/lagradost/cloudstream3/extractors/YoutubeExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/YoutubeNoCookieExtractor : com/lagradost/cloudstream3/extractors/YoutubeExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/YoutubeShortLinkExtractor : com/lagradost/cloudstream3/extractors/YoutubeExtractor {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Yufiles : com/lagradost/cloudstream3/extractors/Hxfile {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Yuguaab : com/lagradost/cloudstream3/extractors/VidHidePro {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/Zplayer : com/lagradost/cloudstream3/extractors/ZplayerV2 {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public class com/lagradost/cloudstream3/extractors/ZplayerV2 : com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRequiresReferer ()Z
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMainUrl (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/extractors/Ztreamhub : com/lagradost/cloudstream3/extractors/Filesim {
+	public fun <init> ()V
+	public fun getMainUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/AesHelper {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/AesHelper;
+	public final fun cryptoAESHandler (Ljava/lang/String;[BZLjava/lang/String;)Ljava/lang/String;
+	public static synthetic fun cryptoAESHandler$default (Lcom/lagradost/cloudstream3/extractors/helper/AesHelper;Ljava/lang/String;[BZLjava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun generateKeyAndIv ([B[BLjava/lang/String;IIII)Lkotlin/Pair;
+	public static synthetic fun generateKeyAndIv$default (Lcom/lagradost/cloudstream3/extractors/helper/AesHelper;[B[BLjava/lang/String;IIIIILjava/lang/Object;)Lkotlin/Pair;
+	public final fun hexToByteArray (Ljava/lang/String;)[B
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/AsianEmbedHelper {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/helper/AsianEmbedHelper$Companion;
+	public fun <init> ()V
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/AsianEmbedHelper$Companion {
+	public final fun getUrls (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/CryptoJS {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/CryptoJS;
+	public final fun decrypt (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun encrypt (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper;
+	public final fun extractVidstream (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLorg/jsoup/nodes/Document;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun extractVidstream$default (Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLorg/jsoup/nodes/Document;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoJsonData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/String;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/helper/GogoHelper$GogoSources;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSource ()Ljava/util/List;
+	public final fun getSourceBk ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/helper/JwPlayerHelper$Track;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/NineAnimeHelper {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/extractors/helper/NineAnimeHelper;
+	public final fun cipher (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun decodeVrf (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun encode (Ljava/lang/String;)Ljava/lang/String;
+	public final fun encodeVrf (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun encrypt (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/VstreamhubHelper {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/helper/VstreamhubHelper$Companion;
+	public fun <init> ()V
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/VstreamhubHelper$Companion {
+	public final fun getUrls (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper {
+	public static final field Companion Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion;
+	public fun <init> ()V
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion {
+	public final fun getNewWcoKey (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getWcoKey (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$ExternalKeys;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWcoKey ()Ljava/lang/String;
+	public final fun getWcocipher ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/extractors/helper/WcoHelper$Companion$NewExternalKeys;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCipherkey ()Ljava/lang/String;
+	public final fun getEncryptKey ()Ljava/lang/String;
+	public final fun getMainKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/CrossTmdbProvider : com/lagradost/cloudstream3/metaproviders/TmdbProvider {
+	public fun <init> ()V
+	public fun getApiName ()Ljava/lang/String;
+	public fun getLang ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getSupportedTypes ()Ljava/util/Set;
+	public fun getUseMetaLoadResponse ()Z
+	public fun getUsesWebView ()Z
+	public fun load (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun loadLinks (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun search (Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setLang (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData {
+	public fun <init> (ZLjava/util/List;)V
+	public synthetic fun <init> (ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (ZLjava/util/List;)Lcom/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData;ZLjava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/CrossTmdbProvider$CrossMetaData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMovies ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isSuccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI : com/lagradost/cloudstream3/MainAPI {
+	public static final field API_HOST Ljava/lang/String;
+	public static final field Companion Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Companion;
+	public static final field SITE_HOST Ljava/lang/String;
+	public static final field TAG Ljava/lang/String;
+	public fun <init> ()V
+	public fun getHasMainPage ()Z
+	public fun getMainPage ()Ljava/util/List;
+	public fun getMainPage (ILcom/lagradost/cloudstream3/MainPageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getName ()Ljava/lang/String;
+	public fun getProviderType ()Lcom/lagradost/cloudstream3/ProviderType;
+	public fun getSupportedTypes ()Ljava/util/Set;
+	public fun load (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun search (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast {
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Cast;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCharacterName ()Ljava/lang/String;
+	public final fun getId ()J
+	public final fun getImages ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getSlug ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Companion {
+	public final fun getAPI_KEY ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Credits;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCast ()Ljava/util/List;
+	public final fun getCrew ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew {
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew;JLjava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Crew;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getImages ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public final fun getJob ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSlug ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data {
+	public fun <init> ()V
+	public fun <init> (Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component2 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
+	public final fun copy (Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data;Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMedia ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
+	public final fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre {
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre;JLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Genre;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSlug ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMedium ()Ljava/lang/String;
+	public final fun getPoster ()Ljava/lang/String;
+	public final fun getThumb ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$LinkData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiredDate ()Ljava/lang/String;
+	public final fun getDate ()Ljava/lang/String;
+	public final fun getEpisode ()Ljava/lang/Integer;
+	public final fun getId ()Ljava/lang/Long;
+	public final fun getLastSeason ()Ljava/lang/Integer;
+	public final fun getOrgTitle ()Ljava/lang/String;
+	public final fun getSeason ()Ljava/lang/Integer;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media {
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IJDLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;JJJJJJJLjava/lang/String;Ljava/lang/String;ZLjava/util/List;J)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IJDLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;JJJJJJJLjava/lang/String;Ljava/lang/String;ZLjava/util/List;JIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/lang/Long;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;
+	public final fun component22 ()J
+	public final fun component23 ()J
+	public final fun component24 ()J
+	public final fun component25 ()J
+	public final fun component26 ()J
+	public final fun component27 ()J
+	public final fun component28 ()J
+	public final fun component29 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component30 ()Ljava/lang/String;
+	public final fun component31 ()Z
+	public final fun component32 ()Ljava/util/List;
+	public final fun component33 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun component6 ()J
+	public final fun component7 ()D
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IJDLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;JJJJJJJLjava/lang/String;Ljava/lang/String;ZLjava/util/List;J)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;IJDLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;JJJJJJJLjava/lang/String;Ljava/lang/String;ZLjava/util/List;JIILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Media;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun fetchCredits (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fetchRecommendations (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fetchTrailer (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fixGenres ()Ljava/util/List;
+	public final fun getAiredStart ()Ljava/lang/String;
+	public final fun getAltTitles ()Ljava/util/List;
+	public final fun getCertification ()Ljava/lang/String;
+	public final fun getCommentsCount ()J
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getEnableAds ()Z
+	public final fun getEpisodes ()J
+	public final fun getGenres ()Ljava/util/List;
+	public final fun getId ()J
+	public final fun getImages ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getMediaRating ()D
+	public final fun getMediaType ()Ljava/lang/String;
+	public final fun getMediaYear ()I
+	public final fun getOriginalTitle ()Ljava/lang/String;
+	public final fun getPermalink ()Ljava/lang/String;
+	public final fun getPopularity ()J
+	public final fun getRanked ()J
+	public final fun getRecsCount ()J
+	public final fun getReleaseDatesFmt ()Ljava/lang/String;
+	public final fun getReleased ()Ljava/lang/String;
+	public final fun getReviewsCount ()J
+	public final fun getRuntime ()J
+	public final fun getSlug ()Ljava/lang/String;
+	public final fun getSources ()Ljava/util/List;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getSynopsis ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTrailer ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()J
+	public final fun getVotes ()Ljava/lang/Long;
+	public final fun getWatchers ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary {
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Double;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;JLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getId ()J
+	public final fun getImages ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Images;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getMediaType ()Ljava/lang/String;
+	public final fun getOriginalTitle ()Ljava/lang/String;
+	public final fun getPermalink ()Ljava/lang/String;
+	public final fun getRating ()Ljava/lang/Double;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Recommendations : java/util/ArrayList {
+	public fun <init> ()V
+	public fun contains (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)Z
+	public final fun contains (Ljava/lang/Object;)Z
+	public fun getSize ()I
+	public fun indexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)I
+	public final fun indexOf (Ljava/lang/Object;)I
+	public fun lastIndexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)I
+	public final fun lastIndexOf (Ljava/lang/Object;)I
+	public final fun remove (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
+	public fun remove (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)Z
+	public final fun remove (Ljava/lang/Object;)Z
+	public fun removeAt (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
+	public final fun size ()I
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$SearchResult : java/util/ArrayList {
+	public fun <init> ()V
+	public fun contains (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)Z
+	public final fun contains (Ljava/lang/Object;)Z
+	public fun getSize ()I
+	public fun indexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)I
+	public final fun indexOf (Ljava/lang/Object;)I
+	public fun lastIndexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)I
+	public final fun lastIndexOf (Ljava/lang/Object;)I
+	public final fun remove (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
+	public fun remove (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;)Z
+	public final fun remove (Ljava/lang/Object;)Z
+	public fun removeAt (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$MediaSummary;
+	public final fun size ()I
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode {
+	public fun <init> (IIDILjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()D
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (IIDILjava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode;IIDILjava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEpisodeNumber ()I
+	public final fun getId ()I
+	public final fun getRating ()D
+	public final fun getReleasedAt ()Ljava/lang/String;
+	public final fun getVotes ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodes : java/util/ArrayList {
+	public fun <init> ()V
+	public fun contains (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;)Z
+	public final fun contains (Ljava/lang/Object;)Z
+	public fun getSize ()I
+	public fun indexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;)I
+	public final fun indexOf (Ljava/lang/Object;)I
+	public fun lastIndexOf (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;)I
+	public final fun lastIndexOf (Ljava/lang/Object;)I
+	public final fun remove (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;
+	public fun remove (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;)Z
+	public final fun remove (Ljava/lang/Object;)Z
+	public fun removeAt (I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;
+	public final fun size ()I
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;I)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;IILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$ShowEpisodesItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEpisodes ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getReleaseDate ()Ljava/lang/String;
+	public final fun getTimezone ()Ljava/lang/String;
+	public final fun getTotal ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Source;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getLink ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getSourceType ()Ljava/lang/String;
+	public final fun getXid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag {
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag;JLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Tag;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSlug ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/Long;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;Ljava/lang/Long;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$Trailer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails {
+	public fun <init> (JLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;JLjava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getSource ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode {
+	public fun <init> (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;
+	public final fun copy (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTrailerDetails ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerDetails;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot {
+	public fun <init> (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;
+	public final fun copy (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot;Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerRoot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTrailer ()Lcom/lagradost/cloudstream3/metaproviders/MyDramaListAPI$TrailerNode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/SyncRedirector {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/metaproviders/SyncRedirector;
+	public final fun redirect (Ljava/lang/String;Lcom/lagradost/cloudstream3/MainAPI;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TmdbLink {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/TmdbLink;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TmdbLink;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TmdbLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEpisode ()Ljava/lang/Integer;
+	public final fun getImdbID ()Ljava/lang/String;
+	public final fun getMovieName ()Ljava/lang/String;
+	public final fun getSeason ()Ljava/lang/Integer;
+	public final fun getTmdbID ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/lagradost/cloudstream3/metaproviders/TmdbProvider : com/lagradost/cloudstream3/MainAPI {
+	public fun <init> ()V
+	public fun fetchContentRating (Ljava/lang/Integer;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getApiName ()Ljava/lang/String;
+	public fun getDisableSeasonZero ()Z
+	public fun getHasMainPage ()Z
+	public fun getIncludeAdult ()Z
+	public fun getMainPage (ILcom/lagradost/cloudstream3/MainPageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getProviderType ()Lcom/lagradost/cloudstream3/ProviderType;
+	public fun getUseMetaLoadResponse ()Z
+	public fun load (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun loadFromImdb (Ljava/lang/String;)Lcom/lagradost/cloudstream3/LoadResponse;
+	public fun loadFromImdb (Ljava/lang/String;Ljava/util/List;)Lcom/lagradost/cloudstream3/LoadResponse;
+	public fun loadFromTmdb (I)Lcom/lagradost/cloudstream3/LoadResponse;
+	public fun loadFromTmdb (ILjava/util/List;)Lcom/lagradost/cloudstream3/LoadResponse;
+	public fun search (Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/metaproviders/TraktProvider : com/lagradost/cloudstream3/MainAPI {
+	public fun <init> ()V
+	public fun getHasMainPage ()Z
+	public fun getMainPage ()Ljava/util/List;
+	public fun getMainPage (ILcom/lagradost/cloudstream3/MainPageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getName ()Ljava/lang/String;
+	public fun getProviderType ()Lcom/lagradost/cloudstream3/ProviderType;
+	public fun getSupportedTypes ()Ljava/util/Set;
+	public fun load (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun search (Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setName (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$Airs {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Airs;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Airs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Airs;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDay ()Ljava/lang/String;
+	public final fun getTime ()Ljava/lang/String;
+	public final fun getTimezone ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$Cast {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Person;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Person;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Person;
+	public final fun component5 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Person;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Cast;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Cast;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Person;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Cast;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCharacter ()Ljava/lang/String;
+	public final fun getCharacters ()Ljava/util/List;
+	public final fun getEpisodeCount ()Ljava/lang/Long;
+	public final fun getImages ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun getPerson ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Person;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$Data {
+	public fun <init> ()V
+	public fun <init> (Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;)V
+	public synthetic fun <init> (Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/lagradost/cloudstream3/TvType;
+	public final fun component2 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;
+	public final fun copy (Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Data;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Data;Lcom/lagradost/cloudstream3/TvType;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMediaDetails ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;
+	public final fun getType ()Lcom/lagradost/cloudstream3/TvType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$Ids {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImdb ()Ljava/lang/String;
+	public final fun getSlug ()Ljava/lang/String;
+	public final fun getTmdb ()Ljava/lang/Integer;
+	public final fun getTrakt ()Ljava/lang/Integer;
+	public final fun getTvdb ()Ljava/lang/Integer;
+	public final fun getTvrage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$Images {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBanner ()Ljava/util/List;
+	public final fun getClearArt ()Ljava/util/List;
+	public final fun getFanart ()Ljava/util/List;
+	public final fun getHeadshot ()Ljava/util/List;
+	public final fun getLogo ()Ljava/util/List;
+	public final fun getPoster ()Ljava/util/List;
+	public final fun getScreenshot ()Ljava/util/List;
+	public final fun getThumb ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$LinkData {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZ)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component10 ()Ljava/lang/Integer;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Z
+	public final fun component17 ()Ljava/lang/Integer;
+	public final fun component18 ()Ljava/lang/Integer;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Z
+	public final fun component24 ()Z
+	public final fun component25 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZ)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$LinkData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$LinkData;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ZLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZZILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$LinkData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiredDate ()Ljava/lang/String;
+	public final fun getAiredYear ()Ljava/lang/Integer;
+	public final fun getAniId ()Ljava/lang/String;
+	public final fun getAnimeId ()Ljava/lang/String;
+	public final fun getDate ()Ljava/lang/String;
+	public final fun getEpisode ()Ljava/lang/Integer;
+	public final fun getEpsTitle ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/Integer;
+	public final fun getImdbId ()Ljava/lang/String;
+	public final fun getJpTitle ()Ljava/lang/String;
+	public final fun getLastSeason ()Ljava/lang/Integer;
+	public final fun getOrgTitle ()Ljava/lang/String;
+	public final fun getSeason ()Ljava/lang/Integer;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTmdbId ()Ljava/lang/Integer;
+	public final fun getTraktId ()Ljava/lang/Integer;
+	public final fun getTraktSlug ()Ljava/lang/String;
+	public final fun getTvdbId ()Ljava/lang/Integer;
+	public final fun getTvrageId ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public final fun isAnime ()Z
+	public final fun isAsian ()Z
+	public final fun isBollywood ()Z
+	public final fun isCartoon ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Airs;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Airs;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/Double;
+	public final fun component14 ()Ljava/lang/Long;
+	public final fun component15 ()Ljava/lang/Long;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/Integer;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Airs;
+	public final fun component24 ()Ljava/lang/String;
+	public final fun component25 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun component26 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;
+	public final fun component3 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Airs;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Airs;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiredEpisodes ()Ljava/lang/Integer;
+	public final fun getAirs ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Airs;
+	public final fun getAvailableTranslations ()Ljava/util/List;
+	public final fun getCertification ()Ljava/lang/String;
+	public final fun getCommentCount ()Ljava/lang/Long;
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getFirstAired ()Ljava/lang/String;
+	public final fun getGenres ()Ljava/util/List;
+	public final fun getHomepage ()Ljava/lang/String;
+	public final fun getIds ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public final fun getImages ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getLanguages ()Ljava/util/List;
+	public final fun getMedia ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$MediaDetails;
+	public final fun getNetwork ()Ljava/lang/String;
+	public final fun getOverview ()Ljava/lang/String;
+	public final fun getRating ()Ljava/lang/Double;
+	public final fun getReleased ()Ljava/lang/String;
+	public final fun getRuntime ()Ljava/lang/Integer;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getTagline ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTrailer ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/lang/String;
+	public final fun getVotes ()Ljava/lang/Long;
+	public final fun getYear ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$People {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$People;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$People;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$People;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCast ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$Person {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public final fun component3 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun copy (Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Person;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Person;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Person;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIds ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public final fun getImages ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$Seasons {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component10 ()Ljava/lang/Double;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public final fun component6 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Seasons;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Seasons;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Seasons;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiredEpisodes ()Ljava/lang/Integer;
+	public final fun getEpisodeCount ()Ljava/lang/Integer;
+	public final fun getEpisodes ()Ljava/util/List;
+	public final fun getFirstAired ()Ljava/lang/String;
+	public final fun getIds ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public final fun getImages ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun getNetwork ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/Integer;
+	public final fun getOverview ()Ljava/lang/String;
+	public final fun getRating ()Ljava/lang/Double;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/lang/String;
+	public final fun getVotes ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/metaproviders/TraktProvider$TraktEpisode {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/Double;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public final fun component6 ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$TraktEpisode;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$TraktEpisode;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$TraktEpisode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailableTranslations ()Ljava/util/List;
+	public final fun getCommentCount ()Ljava/lang/Integer;
+	public final fun getEpisodeType ()Ljava/lang/String;
+	public final fun getFirstAired ()Ljava/lang/String;
+	public final fun getIds ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Ids;
+	public final fun getImages ()Lcom/lagradost/cloudstream3/metaproviders/TraktProvider$Images;
+	public final fun getNumber ()Ljava/lang/Integer;
+	public final fun getNumberAbs ()Ljava/lang/Integer;
+	public final fun getOverview ()Ljava/lang/String;
+	public final fun getRating ()Ljava/lang/Double;
+	public final fun getRuntime ()Ljava/lang/Integer;
+	public final fun getSeason ()Ljava/lang/Integer;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/lang/String;
+	public final fun getVotes ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/mvvm/ArchComponentExtKt {
+	public static final field DEBUG_EXCEPTION Ljava/lang/String;
+	public static final field DEBUG_PRINT Ljava/lang/String;
+	public static final fun debugAssert (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public static final fun debugException (Lkotlin/jvm/functions/Function0;)V
+	public static final fun debugPrint (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun debugPrint$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun debugWarning (Lkotlin/jvm/functions/Function0;)V
+	public static final fun debugWarning (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public static final fun getAllMessages (Ljava/lang/Throwable;)Ljava/lang/String;
+	public static final fun getStackTracePretty (Ljava/lang/Throwable;Z)Ljava/lang/String;
+	public static synthetic fun getStackTracePretty$default (Ljava/lang/Throwable;ZILjava/lang/Object;)Ljava/lang/String;
+	public static final fun launchSafe (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static synthetic fun launchSafe$default (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
+	public static final fun logError (Ljava/lang/Throwable;)V
+	public static final fun normalSafeApiCall (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun safe (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun safeApiCall (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun safeAsync (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun safeFail (Ljava/lang/Throwable;)Lcom/lagradost/cloudstream3/mvvm/Resource;
+	public static final fun suspendSafeApiCall (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun throwAbleToResource (Ljava/lang/Throwable;)Lcom/lagradost/cloudstream3/mvvm/Resource;
+}
+
+public final class com/lagradost/cloudstream3/mvvm/DebugException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract class com/lagradost/cloudstream3/mvvm/Resource {
+	public static final field Companion Lcom/lagradost/cloudstream3/mvvm/Resource$Companion;
+}
+
+public final class com/lagradost/cloudstream3/mvvm/Resource$Companion {
+	public final fun fromResult (Ljava/lang/Object;)Lcom/lagradost/cloudstream3/mvvm/Resource;
+}
+
+public final class com/lagradost/cloudstream3/mvvm/Resource$Failure : com/lagradost/cloudstream3/mvvm/Resource {
+	public fun <init> (ZLjava/lang/String;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;)Lcom/lagradost/cloudstream3/mvvm/Resource$Failure;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/mvvm/Resource$Failure;ZLjava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/mvvm/Resource$Failure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorString ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isNetworkError ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/mvvm/Resource$Loading : com/lagradost/cloudstream3/mvvm/Resource {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/lagradost/cloudstream3/mvvm/Resource$Loading;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/mvvm/Resource$Loading;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/mvvm/Resource$Loading;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/mvvm/Resource$Success : com/lagradost/cloudstream3/mvvm/Resource {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/lagradost/cloudstream3/mvvm/Resource$Success;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/mvvm/Resource$Success;Ljava/lang/Object;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/mvvm/Resource$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/network/WebViewResolver : okhttp3/Interceptor {
+	public static final field Companion Lcom/lagradost/cloudstream3/network/WebViewResolver$Companion;
+	public fun <init> (Lkotlin/text/Regex;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Lkotlin/jvm/functions/Function1;J)V
+	public synthetic fun <init> (Lkotlin/text/Regex;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Lkotlin/jvm/functions/Function1;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
+	public final fun resolveUsingWebView (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun resolveUsingWebView (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun resolveUsingWebView (Lokhttp3/Request;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun resolveUsingWebView$default (Lcom/lagradost/cloudstream3/network/WebViewResolver;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun resolveUsingWebView$default (Lcom/lagradost/cloudstream3/network/WebViewResolver;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun resolveUsingWebView$default (Lcom/lagradost/cloudstream3/network/WebViewResolver;Lokhttp3/Request;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/network/WebViewResolver$Companion {
+	public final fun getDEFAULT_TIMEOUT ()J
+	public final fun getWebViewUserAgent ()Ljava/lang/String;
+	public final fun setWebViewUserAgent (Ljava/lang/String;)V
+}
+
+public abstract class com/lagradost/cloudstream3/plugins/BasePlugin {
+	public fun <init> ()V
+	public fun beforeUnload ()V
+	public final fun getFilename ()Ljava/lang/String;
+	public final fun get__filename ()Ljava/lang/String;
+	public fun load ()V
+	public final fun registerExtractorAPI (Lcom/lagradost/cloudstream3/utils/ExtractorApi;)V
+	public final fun registerMainAPI (Lcom/lagradost/cloudstream3/MainAPI;)V
+	public final fun setFilename (Ljava/lang/String;)V
+	public final fun set__filename (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/plugins/BasePlugin$Manifest {
+	public fun <init> ()V
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPluginClassName ()Ljava/lang/String;
+	public final fun getRequiresResources ()Z
+	public final fun getVersion ()Ljava/lang/Integer;
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setPluginClassName (Ljava/lang/String;)V
+	public final fun setRequiresResources (Z)V
+	public final fun setVersion (Ljava/lang/Integer;)V
+}
+
+public final class com/lagradost/cloudstream3/plugins/BasePluginKt {
+	public static final field PLUGIN_TAG Ljava/lang/String;
+}
+
+public abstract interface annotation class com/lagradost/cloudstream3/plugins/CloudstreamPlugin : java/lang/annotation/Annotation {
+}
+
+public final class com/lagradost/cloudstream3/syncproviders/SyncIdName : java/lang/Enum {
+	public static final field Anilist Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
+	public static final field Imdb Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
+	public static final field Kitsu Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
+	public static final field LocalList Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
+	public static final field MyAnimeList Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
+	public static final field Simkl Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
+	public static final field Trakt Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
+	public static fun values ()[Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
+}
+
+public final class com/lagradost/cloudstream3/utils/AppDebug {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/AppDebug;
+	public final fun isDebug ()Z
+	public final fun setDebug (Z)V
+}
+
+public final class com/lagradost/cloudstream3/utils/AppUtils {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/AppUtils;
+	public final fun toJson (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/Coroutines {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/Coroutines;
+	public final fun ioSafe (Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/Job;
+	public final fun ioWork (Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun ioWorkSafe (Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun main (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public final fun mainWork (Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun runOnMainThread (Lkotlin/jvm/functions/Function0;)V
+	public final fun threadSafeListOf ([Ljava/lang/Object;)Ljava/util/List;
+}
+
+public final class com/lagradost/cloudstream3/utils/Coroutines_jvmKt {
+	public static final fun runOnMainThreadNative (Lkotlin/jvm/functions/Function0;)V
+}
+
+public class com/lagradost/cloudstream3/utils/DrmExtractorLink : com/lagradost/cloudstream3/utils/ExtractorLink {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/UUID;Ljava/lang/String;Ljava/util/HashMap;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getAudioTracks ()Ljava/util/List;
+	public fun getExtractorData ()Ljava/lang/String;
+	public fun getHeaders ()Ljava/util/Map;
+	public fun getKey ()Ljava/lang/String;
+	public fun getKeyRequestParameters ()Ljava/util/HashMap;
+	public fun getKid ()Ljava/lang/String;
+	public fun getKty ()Ljava/lang/String;
+	public fun getLicenseUrl ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getQuality ()I
+	public fun getReferer ()Ljava/lang/String;
+	public fun getSource ()Ljava/lang/String;
+	public fun getType ()Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public fun getUrl ()Ljava/lang/String;
+	public fun getUuid ()Ljava/util/UUID;
+	public fun setAudioTracks (Ljava/util/List;)V
+	public fun setExtractorData (Ljava/lang/String;)V
+	public fun setHeaders (Ljava/util/Map;)V
+	public fun setKey (Ljava/lang/String;)V
+	public fun setKeyRequestParameters (Ljava/util/HashMap;)V
+	public fun setKid (Ljava/lang/String;)V
+	public fun setKty (Ljava/lang/String;)V
+	public fun setLicenseUrl (Ljava/lang/String;)V
+	public fun setQuality (I)V
+	public fun setReferer (Ljava/lang/String;)V
+	public fun setType (Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;)V
+	public fun setUuid (Ljava/util/UUID;)V
+}
+
+public abstract class com/lagradost/cloudstream3/utils/ExtractorApi {
+	public fun <init> ()V
+	public fun getExtractorUrl (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getMainUrl ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getRequiresReferer ()Z
+	public final fun getSafeUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSafeUrl$default (Lcom/lagradost/cloudstream3/utils/ExtractorApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getSourcePlugin ()Ljava/lang/String;
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getUrl (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUrl$default (Lcom/lagradost/cloudstream3/utils/ExtractorApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getUrl$default (Lcom/lagradost/cloudstream3/utils/ExtractorApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun setSourcePlugin (Ljava/lang/String;)V
+}
+
+public final class com/lagradost/cloudstream3/utils/ExtractorApiKt {
+	public static final fun fixUrl (Lcom/lagradost/cloudstream3/utils/ExtractorApi;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun getAndUnpack (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun getCLEARKEY_UUID ()Ljava/util/UUID;
+	public static final fun getExtractorApiFromName (Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/ExtractorApi;
+	public static final fun getExtractorApis ()Ljava/util/List;
+	public static final fun getINFER_TYPE ()Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public static final fun getPLAYREADY_UUID ()Ljava/util/UUID;
+	public static final fun getPacked (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun getPostForm (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getQualityFromName (Ljava/lang/String;)I
+	public static final fun getSchemaStripRegex ()Lkotlin/text/Regex;
+	public static final fun getWIDEVINE_UUID ()Ljava/util/UUID;
+	public static final fun httpsify (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun loadExtractor (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun loadExtractor (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun loadExtractor$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newDrmExtractorLink (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/UUID;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newDrmExtractorLink$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/UUID;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newExtractorLink (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newExtractorLink$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun requireReferer (Ljava/lang/String;)Z
+	public static final fun toUs (J)J
+	public static final fun unshortenLinkSafe (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class com/lagradost/cloudstream3/utils/ExtractorLink : com/lagradost/cloudstream3/IDownloadableMinimum {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Map;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Map;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAllHeaders ()Ljava/util/Map;
+	public fun getAudioTracks ()Ljava/util/List;
+	public fun getExtractorData ()Ljava/lang/String;
+	public fun getHeaders ()Ljava/util/Map;
+	public fun getName ()Ljava/lang/String;
+	public fun getQuality ()I
+	public fun getReferer ()Ljava/lang/String;
+	public fun getSource ()Ljava/lang/String;
+	public fun getType ()Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public fun getUrl ()Ljava/lang/String;
+	public final fun getVideoSize (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getVideoSize$default (Lcom/lagradost/cloudstream3/utils/ExtractorLink;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun isDash ()Z
+	public final fun isM3u8 ()Z
+	public fun setAudioTracks (Ljava/util/List;)V
+	public fun setExtractorData (Ljava/lang/String;)V
+	public fun setHeaders (Ljava/util/Map;)V
+	public fun setQuality (I)V
+	public fun setReferer (Ljava/lang/String;)V
+	public fun setType (Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/ExtractorLinkPlayList : com/lagradost/cloudstream3/utils/ExtractorLink {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;IZLjava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;IZLjava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/List;)Lcom/lagradost/cloudstream3/utils/ExtractorLinkPlayList;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/ExtractorLinkPlayList;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;Ljava/lang/String;Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;Ljava/util/List;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/ExtractorLinkPlayList;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAudioTracks ()Ljava/util/List;
+	public fun getExtractorData ()Ljava/lang/String;
+	public fun getHeaders ()Ljava/util/Map;
+	public fun getName ()Ljava/lang/String;
+	public final fun getPlaylist ()Ljava/util/List;
+	public fun getQuality ()I
+	public fun getReferer ()Ljava/lang/String;
+	public fun getSource ()Ljava/lang/String;
+	public fun getType ()Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public fun hashCode ()I
+	public fun setAudioTracks (Ljava/util/List;)V
+	public fun setExtractorData (Ljava/lang/String;)V
+	public fun setHeaders (Ljava/util/Map;)V
+	public fun setQuality (I)V
+	public fun setReferer (Ljava/lang/String;)V
+	public fun setType (Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/ExtractorLinkType : java/lang/Enum {
+	public static final field DASH Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public static final field M3U8 Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public static final field MAGNET Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public static final field TORRENT Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public static final field VIDEO Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getMimeType ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+	public static fun values ()[Lcom/lagradost/cloudstream3/utils/ExtractorLinkType;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser;
+	public final fun parse (Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$HlsMultivariantPlaylist;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$C {
+	public static final field CENC_TYPE_cbc1 Ljava/lang/String;
+	public static final field CENC_TYPE_cbcs Ljava/lang/String;
+	public static final field CENC_TYPE_cenc Ljava/lang/String;
+	public static final field CENC_TYPE_cens Ljava/lang/String;
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$C;
+	public static final field ROLE_FLAG_ALTERNATE I
+	public static final field ROLE_FLAG_CAPTION I
+	public static final field ROLE_FLAG_COMMENTARY I
+	public static final field ROLE_FLAG_DESCRIBES_MUSIC_AND_SOUND I
+	public static final field ROLE_FLAG_DESCRIBES_VIDEO I
+	public static final field ROLE_FLAG_DUB I
+	public static final field ROLE_FLAG_EASY_TO_READ I
+	public static final field ROLE_FLAG_EMERGENCY I
+	public static final field ROLE_FLAG_ENHANCED_DIALOG_INTELLIGIBILITY I
+	public static final field ROLE_FLAG_MAIN I
+	public static final field ROLE_FLAG_SIGN I
+	public static final field ROLE_FLAG_SUBTITLE I
+	public static final field ROLE_FLAG_SUPPLEMENTARY I
+	public static final field ROLE_FLAG_TRANSCRIBES_DIALOG I
+	public static final field ROLE_FLAG_TRICK_PLAY I
+	public static final field SELECTION_FLAG_AUTOSELECT I
+	public static final field SELECTION_FLAG_DEFAULT I
+	public static final field SELECTION_FLAG_FORCED I
+	public static final field TRACK_TYPE_AUDIO I
+	public static final field TRACK_TYPE_CAMERA_MOTION I
+	public static final field TRACK_TYPE_DEFAULT I
+	public static final field TRACK_TYPE_IMAGE I
+	public static final field TRACK_TYPE_METADATA I
+	public static final field TRACK_TYPE_NONE I
+	public static final field TRACK_TYPE_TEXT I
+	public static final field TRACK_TYPE_UNKNOWN I
+	public static final field TRACK_TYPE_VIDEO I
+	public final fun getCLEARKEY_UUID ()Ljava/util/UUID;
+	public final fun getPLAYREADY_UUID ()Ljava/util/UUID;
+	public final fun getWIDEVINE_UUID ()Ljava/util/UUID;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$DrmInitData {
+	public fun <init> (Ljava/lang/String;[Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()[Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData;
+	public final fun copy (Ljava/lang/String;[Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$DrmInitData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$DrmInitData;Ljava/lang/String;[Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$DrmInitData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSchemeDatas ()[Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData;
+	public final fun getSchemeType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Format {
+	public static final field Companion Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format$Companion;
+	public static final field NO_VALUE I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIIIILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIFIFII)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIIIILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIFIFIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()I
+	public final fun component13 ()I
+	public final fun component14 ()F
+	public final fun component15 ()I
+	public final fun component16 ()F
+	public final fun component17 ()I
+	public final fun component18 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun component8 ()I
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIIIILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIFIFII)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIIIILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIFIFIIILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessibilityChannel ()I
+	public final fun getAverageBitrate ()I
+	public final fun getBitrate ()I
+	public final fun getChannelCount ()I
+	public final fun getCodecs ()Ljava/lang/String;
+	public final fun getContainerMimeType ()Ljava/lang/String;
+	public final fun getFrameRate ()F
+	public final fun getHeight ()I
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getPeakBitrate ()I
+	public final fun getPixelWidthHeightRatio ()F
+	public final fun getRoleFlags ()I
+	public final fun getRotationDegrees ()I
+	public final fun getSampleMimeType ()Ljava/lang/String;
+	public final fun getSelectionFlags ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Format$Companion {
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$HlsMultivariantPlaylist {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/util/List;Ljava/util/Map;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Z)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$HlsMultivariantPlaylist;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$HlsMultivariantPlaylist;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/util/List;Ljava/util/Map;Ljava/util/List;ZILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$HlsMultivariantPlaylist;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudios ()Ljava/util/List;
+	public final fun getBaseUri ()Ljava/lang/String;
+	public final fun getClosedCaptions ()Ljava/util/List;
+	public final fun getHasIndependentSegments ()Z
+	public final fun getMuxedAudioFormat ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
+	public final fun getMuxedCaptionFormats ()Ljava/util/List;
+	public final fun getSessionKeyDrmInitData ()Ljava/util/List;
+	public final fun getSubtitles ()Ljava/util/List;
+	public final fun getTags ()Ljava/util/List;
+	public final fun getVariableDefinitions ()Ljava/util/Map;
+	public final fun getVariants ()Ljava/util/List;
+	public final fun getVideos ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$MimeTypes {
+	public static final field APPLICATION_AIT Ljava/lang/String;
+	public static final field APPLICATION_CAMERA_MOTION Ljava/lang/String;
+	public static final field APPLICATION_CEA608 Ljava/lang/String;
+	public static final field APPLICATION_CEA708 Ljava/lang/String;
+	public static final field APPLICATION_DEPTH_METADATA Ljava/lang/String;
+	public static final field APPLICATION_DVBSUBS Ljava/lang/String;
+	public static final field APPLICATION_EMSG Ljava/lang/String;
+	public static final field APPLICATION_EXIF Ljava/lang/String;
+	public static final field APPLICATION_EXTERNALLY_LOADED_IMAGE Ljava/lang/String;
+	public static final field APPLICATION_ICY Ljava/lang/String;
+	public static final field APPLICATION_ID3 Ljava/lang/String;
+	public static final field APPLICATION_M3U8 Ljava/lang/String;
+	public static final field APPLICATION_MATROSKA Ljava/lang/String;
+	public static final field APPLICATION_MEDIA3_CUES Ljava/lang/String;
+	public static final field APPLICATION_MP4 Ljava/lang/String;
+	public static final field APPLICATION_MP4CEA608 Ljava/lang/String;
+	public static final field APPLICATION_MP4VTT Ljava/lang/String;
+	public static final field APPLICATION_MPD Ljava/lang/String;
+	public static final field APPLICATION_PGS Ljava/lang/String;
+	public static final field APPLICATION_RTSP Ljava/lang/String;
+	public static final field APPLICATION_SCTE35 Ljava/lang/String;
+	public static final field APPLICATION_SDP Ljava/lang/String;
+	public static final field APPLICATION_SS Ljava/lang/String;
+	public static final field APPLICATION_SUBRIP Ljava/lang/String;
+	public static final field APPLICATION_TTML Ljava/lang/String;
+	public static final field APPLICATION_TX3G Ljava/lang/String;
+	public static final field APPLICATION_VOBSUB Ljava/lang/String;
+	public static final field APPLICATION_WEBM Ljava/lang/String;
+	public static final field AUDIO_AAC Ljava/lang/String;
+	public static final field AUDIO_AC3 Ljava/lang/String;
+	public static final field AUDIO_AC4 Ljava/lang/String;
+	public static final field AUDIO_ALAC Ljava/lang/String;
+	public static final field AUDIO_ALAW Ljava/lang/String;
+	public static final field AUDIO_AMR Ljava/lang/String;
+	public static final field AUDIO_AMR_NB Ljava/lang/String;
+	public static final field AUDIO_AMR_WB Ljava/lang/String;
+	public static final field AUDIO_DTS Ljava/lang/String;
+	public static final field AUDIO_DTS_EXPRESS Ljava/lang/String;
+	public static final field AUDIO_DTS_HD Ljava/lang/String;
+	public static final field AUDIO_DTS_X Ljava/lang/String;
+	public static final field AUDIO_EXOPLAYER_MIDI Ljava/lang/String;
+	public static final field AUDIO_E_AC3 Ljava/lang/String;
+	public static final field AUDIO_E_AC3_JOC Ljava/lang/String;
+	public static final field AUDIO_FLAC Ljava/lang/String;
+	public static final field AUDIO_IAMF Ljava/lang/String;
+	public static final field AUDIO_MATROSKA Ljava/lang/String;
+	public static final field AUDIO_MIDI Ljava/lang/String;
+	public static final field AUDIO_MLAW Ljava/lang/String;
+	public static final field AUDIO_MP4 Ljava/lang/String;
+	public static final field AUDIO_MPEG Ljava/lang/String;
+	public static final field AUDIO_MPEGH_MHA1 Ljava/lang/String;
+	public static final field AUDIO_MPEGH_MHM1 Ljava/lang/String;
+	public static final field AUDIO_MPEG_L1 Ljava/lang/String;
+	public static final field AUDIO_MPEG_L2 Ljava/lang/String;
+	public static final field AUDIO_MSGSM Ljava/lang/String;
+	public static final field AUDIO_OGG Ljava/lang/String;
+	public static final field AUDIO_OPUS Ljava/lang/String;
+	public static final field AUDIO_RAW Ljava/lang/String;
+	public static final field AUDIO_TRUEHD Ljava/lang/String;
+	public static final field AUDIO_UNKNOWN Ljava/lang/String;
+	public static final field AUDIO_VORBIS Ljava/lang/String;
+	public static final field AUDIO_WAV Ljava/lang/String;
+	public static final field AUDIO_WEBM Ljava/lang/String;
+	public static final field BASE_TYPE_APPLICATION Ljava/lang/String;
+	public static final field BASE_TYPE_AUDIO Ljava/lang/String;
+	public static final field BASE_TYPE_IMAGE Ljava/lang/String;
+	public static final field BASE_TYPE_TEXT Ljava/lang/String;
+	public static final field BASE_TYPE_VIDEO Ljava/lang/String;
+	public static final field CODEC_E_AC3_JOC Ljava/lang/String;
+	public static final field IMAGE_AVIF Ljava/lang/String;
+	public static final field IMAGE_BMP Ljava/lang/String;
+	public static final field IMAGE_HEIC Ljava/lang/String;
+	public static final field IMAGE_HEIF Ljava/lang/String;
+	public static final field IMAGE_JPEG Ljava/lang/String;
+	public static final field IMAGE_JPEG_R Ljava/lang/String;
+	public static final field IMAGE_PNG Ljava/lang/String;
+	public static final field IMAGE_RAW Ljava/lang/String;
+	public static final field IMAGE_WEBP Ljava/lang/String;
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$MimeTypes;
+	public static final field TEXT_SSA Ljava/lang/String;
+	public static final field TEXT_UNKNOWN Ljava/lang/String;
+	public static final field TEXT_VTT Ljava/lang/String;
+	public static final field VIDEO_APV Ljava/lang/String;
+	public static final field VIDEO_AV1 Ljava/lang/String;
+	public static final field VIDEO_AVI Ljava/lang/String;
+	public static final field VIDEO_DIVX Ljava/lang/String;
+	public static final field VIDEO_DOLBY_VISION Ljava/lang/String;
+	public static final field VIDEO_FLV Ljava/lang/String;
+	public static final field VIDEO_H263 Ljava/lang/String;
+	public static final field VIDEO_H264 Ljava/lang/String;
+	public static final field VIDEO_H265 Ljava/lang/String;
+	public static final field VIDEO_MATROSKA Ljava/lang/String;
+	public static final field VIDEO_MJPEG Ljava/lang/String;
+	public static final field VIDEO_MP2T Ljava/lang/String;
+	public static final field VIDEO_MP4 Ljava/lang/String;
+	public static final field VIDEO_MP42 Ljava/lang/String;
+	public static final field VIDEO_MP43 Ljava/lang/String;
+	public static final field VIDEO_MP4V Ljava/lang/String;
+	public static final field VIDEO_MPEG Ljava/lang/String;
+	public static final field VIDEO_MPEG2 Ljava/lang/String;
+	public static final field VIDEO_MV_HEVC Ljava/lang/String;
+	public static final field VIDEO_OGG Ljava/lang/String;
+	public static final field VIDEO_PS Ljava/lang/String;
+	public static final field VIDEO_RAW Ljava/lang/String;
+	public static final field VIDEO_UNKNOWN Ljava/lang/String;
+	public static final field VIDEO_VC1 Ljava/lang/String;
+	public static final field VIDEO_VP8 Ljava/lang/String;
+	public static final field VIDEO_VP9 Ljava/lang/String;
+	public static final field VIDEO_WEBM Ljava/lang/String;
+	public final fun getMediaMimeType (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getMimeTypeFromMp4ObjectType (I)Ljava/lang/String;
+	public final fun getObjectTypeFromMp4aRFC6381CodecString (Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$MimeTypes$Mp4aObjectType;
+	public final fun getTrackType (Ljava/lang/String;)I
+	public final fun getTrackTypeOfCodec (Ljava/lang/String;)I
+	public final fun isAudio (Ljava/lang/String;)Z
+	public final fun isDolbyVisionCodec (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun isImage (Ljava/lang/String;)Z
+	public final fun isText (Ljava/lang/String;)Z
+	public final fun isVideo (Ljava/lang/String;)Z
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$MimeTypes$Mp4aObjectType {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$MimeTypes$Mp4aObjectType;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$MimeTypes$Mp4aObjectType;IIILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$MimeTypes$Mp4aObjectType;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioObjectTypeIndication ()I
+	public final fun getObjectTypeIndication ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Mp4Box {
+	public static final field FULL_HEADER_SIZE I
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Mp4Box;
+	public static final field TYPE_pssh I
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$ParserException : java/io/IOException {
+	public static final field Companion Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$ParserException$Companion;
+	public static final field DATA_TYPE_MANIFEST I
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ZI)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Throwable;
+	public final fun component3 ()Z
+	public final fun component4 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/Throwable;ZI)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$ParserException;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$ParserException;Ljava/lang/String;Ljava/lang/Throwable;ZIILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$ParserException;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCause ()Ljava/lang/Throwable;
+	public final fun getContentIsMalformed ()Z
+	public final fun getDataType ()I
+	public fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$ParserException$Companion {
+	public final fun createForMalformedManifest (Ljava/lang/String;Ljava/lang/Throwable;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$ParserException;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$PsshAtomUtil {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$PsshAtomUtil;
+	public final fun buildPsshAtom (Ljava/util/UUID;[Ljava/util/UUID;[B)[B
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition {
+	public fun <init> (Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/net/URI;
+	public final fun component2 ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition;Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Rendition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFormat ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
+	public final fun getGroupId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/net/URI;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData {
+	public fun <init> (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;[B)V
+	public synthetic fun <init> (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;[BILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/UUID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()[B
+	public final fun copy (Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;[B)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData;Ljava/util/UUID;Ljava/lang/String;Ljava/lang/String;[BILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$SchemeData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()[B
+	public final fun getLicenseServerUrl ()Ljava/lang/String;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getUuid ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$UriUtil {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$UriUtil;
+	public final fun resolveToUri (Ljava/lang/String;Ljava/lang/String;)Ljava/net/URI;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Util {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Util;
+	public final fun getCodecsOfType (Ljava/lang/String;I)Ljava/lang/String;
+	public final fun getCodecsWithoutType (Ljava/lang/String;I)Ljava/lang/String;
+	public final fun split (Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;
+	public final fun splitAtFirst (Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;
+	public final fun splitCodecs (Ljava/lang/String;)[Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant {
+	public fun <init> (Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/net/URI;
+	public final fun component2 ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant;Ljava/net/URI;Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Variant;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioGroupId ()Ljava/lang/String;
+	public final fun getCaptionGroupId ()Ljava/lang/String;
+	public final fun getFormat ()Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$Format;
+	public final fun getSubtitleGroupId ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/net/URI;
+	public final fun getVideoGroupId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isPlayableStandalone (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$HlsMultivariantPlaylist;)Z
+	public final fun isTrickPlay ()Z
+	public final fun mustContainAudio (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$HlsMultivariantPlaylist;)Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/HlsPlaylistParser$VariantInfo {
+	public fun <init> (IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$VariantInfo;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$VariantInfo;IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/HlsPlaylistParser$VariantInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudioGroupId ()Ljava/lang/String;
+	public final fun getAverageBitrate ()I
+	public final fun getCaptionGroupId ()Ljava/lang/String;
+	public final fun getPeakBitrate ()I
+	public final fun getSubtitleGroupId ()Ljava/lang/String;
+	public final fun getVideoGroupId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/JsHunter {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun dehunt ()Ljava/lang/String;
+	public final fun detect ()Z
+}
+
+public final class com/lagradost/cloudstream3/utils/JsUnpacker {
+	public static final field Companion Lcom/lagradost/cloudstream3/utils/JsUnpacker$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun detect ()Z
+	public final fun unpack ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/JsUnpacker$Companion {
+	public final fun getC ()Ljava/util/List;
+	public final fun getZ ()Ljava/util/List;
+	public final fun load (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/M3u8Helper {
+	public static final field Companion Lcom/lagradost/cloudstream3/utils/M3u8Helper$Companion;
+	public fun <init> ()V
+	public final fun m3u8Generation (Lcom/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun m3u8Generation$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper;Lcom/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/utils/M3u8Helper$Companion {
+	public final fun generateM3u8 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun generateM3u8$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;)Lcom/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getQuality ()Ljava/lang/Integer;
+	public final fun getStreamUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/M3u8Helper2 {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/M3u8Helper2;
+	public final fun generateM3u8 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun generateM3u8$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper2;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getDecrypted ([B[B[BI)[B
+	public static synthetic fun getDecrypted$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper2;[B[B[BIILjava/lang/Object;)[B
+	public final fun hslLazy (Lcom/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream;ZZILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun hslLazy$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper2;Lcom/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream;ZZILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun m3u8Generation (Lcom/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun m3u8Generation$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper2;Lcom/lagradost/cloudstream3/utils/M3u8Helper$M3u8Stream;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/utils/M3u8Helper2$LazyHlsDownloadData {
+	public fun <init> ([B[BZLjava/util/List;Ljava/lang/String;Ljava/util/Map;)V
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy ([B[BZLjava/util/List;Ljava/lang/String;Ljava/util/Map;)Lcom/lagradost/cloudstream3/utils/M3u8Helper2$LazyHlsDownloadData;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper2$LazyHlsDownloadData;[B[BZLjava/util/List;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/M3u8Helper2$LazyHlsDownloadData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllTsLinks ()Ljava/util/List;
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getRelativeUrl ()Ljava/lang/String;
+	public final fun getSize ()I
+	public fun hashCode ()I
+	public final fun isEncrypted ()Z
+	public final fun resolveLink (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun resolveLinkSafe (IIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun resolveLinkSafe$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper2$LazyHlsDownloadData;IIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun resolveLinkWhileSafe (IIJLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun resolveLinkWhileSafe$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper2$LazyHlsDownloadData;IIJLkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/M3u8Helper2$TsLink {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Double;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Double;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Double;)Lcom/lagradost/cloudstream3/utils/M3u8Helper2$TsLink;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/M3u8Helper2$TsLink;Ljava/lang/String;Ljava/lang/Double;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/M3u8Helper2$TsLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTime ()Ljava/lang/Double;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/PlayListItem {
+	public fun <init> (Ljava/lang/String;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun copy (Ljava/lang/String;J)Lcom/lagradost/cloudstream3/utils/PlayListItem;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/PlayListItem;Ljava/lang/String;JILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/PlayListItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDurationUs ()J
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/Qualities : java/lang/Enum {
+	public static final field Companion Lcom/lagradost/cloudstream3/utils/Qualities$Companion;
+	public static final field P1080 Lcom/lagradost/cloudstream3/utils/Qualities;
+	public static final field P144 Lcom/lagradost/cloudstream3/utils/Qualities;
+	public static final field P1440 Lcom/lagradost/cloudstream3/utils/Qualities;
+	public static final field P2160 Lcom/lagradost/cloudstream3/utils/Qualities;
+	public static final field P240 Lcom/lagradost/cloudstream3/utils/Qualities;
+	public static final field P360 Lcom/lagradost/cloudstream3/utils/Qualities;
+	public static final field P480 Lcom/lagradost/cloudstream3/utils/Qualities;
+	public static final field P720 Lcom/lagradost/cloudstream3/utils/Qualities;
+	public static final field Unknown Lcom/lagradost/cloudstream3/utils/Qualities;
+	public final fun getDefaultPriority ()I
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()I
+	public final fun setValue (I)V
+	public static fun valueOf (Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/Qualities;
+	public static fun values ()[Lcom/lagradost/cloudstream3/utils/Qualities;
+}
+
+public final class com/lagradost/cloudstream3/utils/Qualities$Companion {
+	public final fun getStringByInt (Ljava/lang/Integer;)Ljava/lang/String;
+	public final fun getStringByIntFull (I)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/ShortLink {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/ShortLink;
+	public final fun isShortLink (Ljava/lang/String;)Z
+	public final fun unshorten (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unshorten$default (Lcom/lagradost/cloudstream3/utils/ShortLink;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun unshortenAdfly (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unshortenDavisonbarker (Ljava/lang/String;)Ljava/lang/String;
+	public final fun unshortenIsecure (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unshortenLinksafe (Ljava/lang/String;)Ljava/lang/String;
+	public final fun unshortenLinkup (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unshortenNuovoIndirizzo (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unshortenNuovoLink (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unshortenUprot (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/lagradost/cloudstream3/utils/ShortLink$ShortUrl {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun <init> (Lkotlin/text/Regex;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public final fun component1 ()Lkotlin/text/Regex;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Lkotlin/text/Regex;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lcom/lagradost/cloudstream3/utils/ShortLink$ShortUrl;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/ShortLink$ShortUrl;Lkotlin/text/Regex;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/ShortLink$ShortUrl;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFunction ()Lkotlin/jvm/functions/Function2;
+	public final fun getRegex ()Lkotlin/text/Regex;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/StringUtils {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/StringUtils;
+	public final fun decodeUri (Ljava/lang/String;)Ljava/lang/String;
+	public final fun encodeUri (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/SubtitleHelper {
+	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/SubtitleHelper;
+	public final fun fromCodeToLangTagIETF (Ljava/lang/String;)Ljava/lang/String;
+	public final fun fromCodeToOpenSubtitlesTag (Ljava/lang/String;)Ljava/lang/String;
+	public final fun fromLanguageToTagIETF (Ljava/lang/String;Ljava/lang/Boolean;)Ljava/lang/String;
+	public static synthetic fun fromLanguageToTagIETF$default (Lcom/lagradost/cloudstream3/utils/SubtitleHelper;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun fromLanguageToThreeLetters (Ljava/lang/String;)Ljava/lang/String;
+	public final fun fromLanguageToTwoLetters (Ljava/lang/String;Z)Ljava/lang/String;
+	public final fun fromTagToEnglishLanguageName (Ljava/lang/String;)Ljava/lang/String;
+	public final fun fromTagToLanguageName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun fromTagToLanguageName$default (Lcom/lagradost/cloudstream3/utils/SubtitleHelper;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun fromThreeLettersToLanguage (Ljava/lang/String;)Ljava/lang/String;
+	public final fun fromTwoLettersToLanguage (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getFlagFromIso (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getIndexMapIETF_tag ()Ljava/util/Map;
+	public final fun getIndexMapISO_639_1 ()Ljava/util/Map;
+	public final fun getIndexMapISO_639_2_B ()Ljava/util/Map;
+	public final fun getIndexMapISO_639_3 ()Ljava/util/Map;
+	public final fun getIndexMapLanguageName ()Ljava/util/Map;
+	public final fun getIndexMapNativeName ()Ljava/util/Map;
+	public final fun getIndexMapOpenSubtitles ()Ljava/util/Map;
+	public final fun getLanguages ()Ljava/util/List;
+	public final fun getNameNextToFlagEmoji (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun getNameNextToFlagEmoji$default (Lcom/lagradost/cloudstream3/utils/SubtitleHelper;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun isWellFormedTagIETF (Ljava/lang/String;)Z
+}
+
+public final class com/lagradost/cloudstream3/utils/SubtitleHelper$Language639 {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/SubtitleHelper$Language639;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/SubtitleHelper$Language639;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/SubtitleHelper$Language639;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getISO_639_1 ()Ljava/lang/String;
+	public final fun getISO_639_2_B ()Ljava/lang/String;
+	public final fun getISO_639_2_T ()Ljava/lang/String;
+	public final fun getISO_639_3 ()Ljava/lang/String;
+	public final fun getISO_639_6 ()Ljava/lang/String;
+	public final fun getLanguageName ()Ljava/lang/String;
+	public final fun getNativeName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/SubtitleHelper$LanguageMetadata {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/lagradost/cloudstream3/utils/SubtitleHelper$LanguageMetadata;
+	public static synthetic fun copy$default (Lcom/lagradost/cloudstream3/utils/SubtitleHelper$LanguageMetadata;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/lagradost/cloudstream3/utils/SubtitleHelper$LanguageMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIETF_tag ()Ljava/lang/String;
+	public final fun getISO_639_1 ()Ljava/lang/String;
+	public final fun getISO_639_2_B ()Ljava/lang/String;
+	public final fun getISO_639_3 ()Ljava/lang/String;
+	public final fun getLanguageName ()Ljava/lang/String;
+	public final fun getNativeName ()Ljava/lang/String;
+	public final fun getOpenSubtitles ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun localizedName (Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun localizedName$default (Lcom/lagradost/cloudstream3/utils/SubtitleHelper$LanguageMetadata;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun nameNextToFlagEmoji (Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun nameNextToFlagEmoji$default (Lcom/lagradost/cloudstream3/utils/SubtitleHelper$LanguageMetadata;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/lagradost/cloudstream3/utils/SubtitleHelperKt {
+	public static final fun getCurrentLocale ()Ljava/lang/String;
+}
+

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -5707,12 +5707,6 @@ public final class com/lagradost/cloudstream3/syncproviders/SyncIdName : java/la
 	public static fun values ()[Lcom/lagradost/cloudstream3/syncproviders/SyncIdName;
 }
 
-public final class com/lagradost/cloudstream3/utils/AppDebug {
-	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/AppDebug;
-	public final fun isDebug ()Z
-	public final fun setDebug (Z)V
-}
-
 public final class com/lagradost/cloudstream3/utils/AppUtils {
 	public static final field INSTANCE Lcom/lagradost/cloudstream3/utils/AppUtils;
 	public final fun toJson (Ljava/lang/Object;)Ljava/lang/String;

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -72,6 +72,7 @@ kotlin {
         this.filters {
             exclude {
                 annotatedWith.add("com.lagradost.cloudstream3.Prerelease")
+                annotatedWith.add("com.lagradost.cloudstream3.InternalAPI")
             }
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -64,6 +64,17 @@ kotlin {
             implementation(libs.tmdb.java) // TMDB API v3 Wrapper Made with RetroFit
         }
     }
+
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    // https://kotlinlang.org/docs/gradle-binary-compatibility-validation.html
+    abiValidation {
+        enabled.set(true)
+        this.filters {
+            exclude {
+                annotatedWith.add("com.lagradost.cloudstream3.Prerelease")
+            }
+        }
+    }
 }
 
 tasks.withType<KotlinJvmCompile> {


### PR DESCRIPTION
We need binary validation to prevent breaking changes in the library, and to understand the extent of any breaking changes we are forced to implement. This encourages proper usage of `@Prerelease`.

library.api is generated using ``./gradlew updateKotlinAbi``