### PR TITLE
Move versionCode and versionName to version catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,8 +103,8 @@ android {
         applicationId = "com.lagradost.cloudstream3"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 68
-        versionName = "4.7.0"
+        versionCode = libs.versions.versionCode.get().toInt()
+        versionName = libs.versions.versionName.get()
 
         manifestPlaceholders["target_sdk_version"] = libs.versions.targetSdk.get()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,9 @@ minSdk = "23"
 compileSdk = "36"
 targetSdk = "36"
 
+versionCode = "68"
+versionName = "4.7.0"
+
 [libraries]
 activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
 anime-db = { module = "com.github.recloudstream:anime-db", version.ref = "animeDb" }


### PR DESCRIPTION
So that we can later also access versionName without duplication in `:composeApp` and add view buildkonfig so that we can eventually fully move version handling to `:composeApp`. versionCode was only moved to the version catalog to avoid having to change two files when bumping the version.