### PR TITLE
Fix delayed updater trigger

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.annotation.MainThread
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.cardview.widget.CardView
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.core.view.children
@@ -90,6 +91,7 @@ import com.lagradost.cloudstream3.plugins.PluginManager
 import com.lagradost.cloudstream3.plugins.PluginManager.___DO_NOT_CALL_FROM_A_PLUGIN_loadAllOnlinePlugins
 import com.lagradost.cloudstream3.plugins.PluginManager.loadSinglePlugin
 import com.lagradost.cloudstream3.receivers.VideoDownloadRestartReceiver
+import com.lagradost.cloudstream3.services.PackageInstallerService
 import com.lagradost.cloudstream3.services.SubscriptionWorkManager
 import com.lagradost.cloudstream3.syncproviders.AccountManager
 import com.lagradost.cloudstream3.syncproviders.AccountManager.Companion.APP_STRING
@@ -651,10 +653,6 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
     override fun onPause() {
         super.onPause()
 
-        // Start any delayed updates
-        if (ApkInstaller.delayedInstaller?.startInstallation() == true) {
-            Toast.makeText(this, R.string.update_started, Toast.LENGTH_LONG).show()
-        }
         try {
             if (isCastApiAvailable()) {
                 mSessionManager?.removeSessionManagerListener(mSessionManagerListener)
@@ -709,6 +707,10 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
     }
 
     override fun onDestroy() {
+        if (ApkInstaller.hasDelayedInstaller()) {
+            val intent = PackageInstallerService.getDelayedInstallIntent(this)
+            ContextCompat.startForegroundService(this, intent)
+        }
         filesToDelete.forEach { path ->
             val result = File(path).deleteRecursively()
             if (result) {

--- a/app/src/main/java/com/lagradost/cloudstream3/services/PackageInstallerService.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/services/PackageInstallerService.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3.services
 
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
@@ -121,6 +122,7 @@ class PackageInstallerService : Service() {
 
         val newNotification = baseNotification
             .setContentTitle(getString(text))
+            .setOngoing(state != ApkInstaller.InstallProgressStatus.Failed)
             .apply {
                 if (state == ApkInstaller.InstallProgressStatus.Failed) {
                     setSmallIcon(R.drawable.rderror)
@@ -143,10 +145,56 @@ class PackageInstallerService : Service() {
         notificationManager.notify(id, newNotification)
     }
 
+    private fun updateNotificationDelayed() {
+        val flags = when {
+            SDK_INT >= 23 -> PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            else -> PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        val updateIntent = getDelayedInstallIntent(this)
+        val updatePendingIntent = PendingIntent.getService(this, 0, updateIntent, flags)
+
+        val newNotification = baseNotification
+            .setContentTitle(getString(R.string.delayed_update_notice))
+            .setProgress(0, 0, false)
+            .setOngoing(true)
+            .addAction(
+                R.drawable.ic_baseline_system_update_24,
+                getString(R.string.update),
+                updatePendingIntent
+            )
+            .build()
+
+        val notificationManager =
+            getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+        notificationManager.notify(UPDATE_NOTIFICATION_ID, newNotification)
+    }
+
+    private suspend fun startDelayedInstallation() {
+        if (ApkInstaller.startDelayedInstallation()) {
+            updateNotificationProgress(0f, ApkInstaller.InstallProgressStatus.Installing)
+            delay(10_000)
+        } else {
+            updateNotificationProgress(0f, ApkInstaller.InstallProgressStatus.Failed)
+        }
+        stopSelf()
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_START_DELAYED_INSTALL) {
+            ioSafe {
+                startDelayedInstallation()
+            }
+            return START_NOT_STICKY
+        }
+
         val url = intent?.getStringExtra(EXTRA_URL) ?: return START_NOT_STICKY
         ioSafe {
             downloadUpdate(url)
+            if (ApkInstaller.hasDelayedInstaller()) {
+                updateNotificationDelayed()
+                return@ioSafe
+            }
             // Close the service after the update is done
             // If no sleep then the install prompt may not appear and the notification
             // will disappear instantly
@@ -172,6 +220,8 @@ class PackageInstallerService : Service() {
 
     companion object {
         private const val EXTRA_URL = "EXTRA_URL"
+        private const val ACTION_START_DELAYED_INSTALL =
+            "com.lagradost.cloudstream3.action.START_DELAYED_INSTALL"
 
         const val UPDATE_CHANNEL_ID = "cloudstream3.updates"
         const val UPDATE_CHANNEL_NAME = "App Updates"
@@ -184,6 +234,11 @@ class PackageInstallerService : Service() {
         ): Intent {
             return Intent(context, PackageInstallerService::class.java)
                 .putExtra(EXTRA_URL, url)
+        }
+
+        fun getDelayedInstallIntent(context: Context): Intent {
+            return Intent(context, PackageInstallerService::class.java)
+                .setAction(ACTION_START_DELAYED_INSTALL)
         }
     }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/PackageInstaller.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/PackageInstaller.kt
@@ -29,6 +29,12 @@ class ApkInstaller(private val service: PackageInstallerService) {
         var delayedInstaller: DelayedInstaller? = null
         private var isReceiverRegistered = false
         private const val TAG = "ApkInstaller"
+
+        fun hasDelayedInstaller(): Boolean = delayedInstaller != null
+
+        fun startDelayedInstallation(): Boolean {
+            return delayedInstaller?.startInstallation() == true
+        }
     }
 
     inner class DelayedInstaller(


### PR DESCRIPTION
## Summary
- keep delayed app updates from starting during MainActivity.onPause()
- start delayed installs when MainActivity is destroyed instead
- keep the update foreground notification available with an Update action while the install is pending

Fixes #1282.

## Testing
- ./gradlew.bat --no-daemon "-Dorg.gradle.java.installations.paths=C:\Program Files\Java\jdk-17.0.5" :app:compileStableDebugKotlin
