### PR TITLE
Emergency patch to fix updater

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
@@ -93,9 +93,9 @@ object InAppUpdater {
     private suspend fun Activity.getReleaseUpdate(): Update {
         val url = "https://api.github.com/repos/$GITHUB_USER_NAME/$GITHUB_REPO/releases"
         val headers = mapOf("Accept" to "application/vnd.github.v3+json")
-        val response = parseJson<List<GithubRelease>>(
+        val response = parseJson<Array<GithubRelease>>(
             app.get(url, headers = headers).text
-        )
+        ).toList()
 
         val versionRegex = Regex("""(.*?((\d+)\.(\d+)\.(\d+))\.apk)""")
         val versionRegexLocal = Regex("""(.*?((\d+)\.(\d+)\.(\d+)).*)""")
@@ -150,9 +150,9 @@ object InAppUpdater {
             "https://api.github.com/repos/$GITHUB_USER_NAME/$GITHUB_REPO/git/ref/tags/pre-release"
         val releaseUrl = "https://api.github.com/repos/$GITHUB_USER_NAME/$GITHUB_REPO/releases"
         val headers = mapOf("Accept" to "application/vnd.github.v3+json")
-        val response = parseJson<List<GithubRelease>>(
+        val response = parseJson<Array<GithubRelease>>(
             app.get(releaseUrl, headers = headers).text
-        )
+        ).toList()
 
         val found = response.lastOrNull { rel ->
             rel.prerelease || rel.tagName == "pre-release"


### PR DESCRIPTION
Issue caused by https://github.com/recloudstream/cloudstream/pull/2791#discussion_r3313612148

This should fix updater, but we will also need to verify nothing else got screwed up also.

`
05-29 11:02:07.124 6697 8613 E InAppUpdater: java.lang.ClassCastException: java.util.LinkedHashMap cannot be cast to com.lagradost.cloudstream3.utils.lnAppUpdater$GithubRelease
`