### PR TITLE
fix: treat KEYCODE_ENTER as select for TV remotes (LG Magic Remote)

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/CommonActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/CommonActivity.kt
@@ -579,8 +579,10 @@ object CommonActivity {
 
             // TODO: Figure out why removing the check for SearchAutoComplete seems
             // to break focus on TV as it shouldn't need to be used.
+            // Also handle KEYCODE_ENTER here because some remotes (e.g. LG Magic Remote)
+            // send KEYCODE_ENTER instead of KEYCODE_DPAD_CENTER when clicking the OK button.
             @SuppressLint("RestrictedApi")
-            if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER &&
+            if ((keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER) &&
                 (act.currentFocus is SearchView || act.currentFocus is SearchView.SearchAutoComplete)
             ) {
                 showInputMethod(act.currentFocus?.findFocus())

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -945,12 +945,18 @@ open class FullScreenPlayer : AbstractPlayerFragment<FragmentPlayerBinding>(
                 player.handleEvent(CSPlayerEvent.SkipCurrentChapter)
             }
 
-            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, KeyEvent.KEYCODE_P, KeyEvent.KEYCODE_SPACE, KeyEvent.KEYCODE_NUMPAD_ENTER, KeyEvent.KEYCODE_ENTER -> { // space is not captured due to navigation
+            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, KeyEvent.KEYCODE_P, KeyEvent.KEYCODE_SPACE, KeyEvent.KEYCODE_NUMPAD_ENTER -> { // space is not captured due to navigation
                 player.handleEvent(CSPlayerEvent.PlayPauseToggle)
             }
 
-            KeyEvent.KEYCODE_DPAD_CENTER -> {
-                if (isShowing) {
+            // KEYCODE_DPAD_CENTER and KEYCODE_ENTER both act as a "select/confirm" button.
+            // Some remotes (e.g. LG Magic Remote) send KEYCODE_ENTER instead of KEYCODE_DPAD_CENTER.
+            // When the player UI or a dialog is visible, we let the event pass through (return null)
+            // so the focused button/item can handle the click normally, rather than always toggling
+            // play/pause. Only when the UI is hidden do we treat it as a play/pause toggle.
+            KeyEvent.KEYCODE_DPAD_CENTER,
+            KeyEvent.KEYCODE_ENTER -> {
+                if (isShowing || isDialogOpen()) {
                     return null
                 }
                 // If UI is not shown make click instantly skip to next chapter even if locked


### PR DESCRIPTION
Some remotes (e.g. LG Magic Remote) send KEYCODE_ENTER instead of
     KEYCODE_DPAD_CENTER. This caused two bugs:

     1. In the video player: clicking any button in source/track/subtitle
        dialogs would pause the video instead of selecting the item
     2. On the search bar: pressing OK never opened the keyboard

     Fix: treat KEYCODE_ENTER the same as KEYCODE_DPAD_CENTER in both places. 