### PR TITLE
InAppUpdater: migrate to kotlinx serialization

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
@@ -12,7 +12,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.BuildConfig
 import com.lagradost.cloudstream3.CommonActivity.showToast
 import com.lagradost.cloudstream3.MainActivity.Companion.deleteFileOnExit
@@ -27,6 +26,8 @@ import com.lagradost.cloudstream3.utils.Coroutines.ioSafe
 import com.lagradost.cloudstream3.utils.GitInfo.currentCommitHash
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import okio.BufferedSink
 import okio.buffer
 import okio.sink
@@ -42,38 +43,43 @@ object InAppUpdater {
     private const val PRERELEASE_PACKAGE_NAME = "com.lagradost.cloudstream3.prerelease"
     private const val LOG_TAG = "InAppUpdater"
 
+    @Serializable
     private data class GithubAsset(
-        @JsonProperty("name") val name: String,
-        @JsonProperty("size") val size: Int, // Size in bytes
-        @JsonProperty("browser_download_url") val browserDownloadUrl: String,
-        @JsonProperty("content_type") val contentType: String, // application/vnd.android.package-archive
+        @SerialName("name") val name: String,
+        @SerialName("size") val size: Int, // Size in bytes
+        @SerialName("browser_download_url") val browserDownloadUrl: String,
+        @SerialName("content_type") val contentType: String, // application/vnd.android.package-archive
     )
 
+    @Serializable
     private data class GithubRelease(
-        @JsonProperty("tag_name") val tagName: String, // Version code
-        @JsonProperty("body") val body: String, // Description
-        @JsonProperty("assets") val assets: List<GithubAsset>,
-        @JsonProperty("target_commitish") val targetCommitish: String, // Branch
-        @JsonProperty("prerelease") val prerelease: Boolean,
-        @JsonProperty("node_id") val nodeId: String,
+        @SerialName("tag_name") val tagName: String, // Version code
+        @SerialName("body") val body: String, // Description
+        @SerialName("assets") val assets: List<GithubAsset>,
+        @SerialName("target_commitish") val targetCommitish: String, // Branch
+        @SerialName("prerelease") val prerelease: Boolean,
+        @SerialName("node_id") val nodeId: String,
     )
 
+    @Serializable
     private data class GithubObject(
-        @JsonProperty("sha") val sha: String, // SHA-256 hash
-        @JsonProperty("type") val type: String,
-        @JsonProperty("url") val url: String,
+        @SerialName("sha") val sha: String, // SHA-256 hash
+        @SerialName("type") val type: String,
+        @SerialName("url") val url: String,
     )
 
+    @Serializable
     private data class GithubTag(
-        @JsonProperty("object") val githubObject: GithubObject,
+        @SerialName("object") val githubObject: GithubObject,
     )
 
+    @Serializable
     private data class Update(
-        @JsonProperty("shouldUpdate") val shouldUpdate: Boolean,
-        @JsonProperty("updateURL") val updateURL: String?,
-        @JsonProperty("updateVersion") val updateVersion: String?,
-        @JsonProperty("changelog") val changelog: String?,
-        @JsonProperty("updateNodeId") val updateNodeId: String?,
+        @SerialName("shouldUpdate") val shouldUpdate: Boolean,
+        @SerialName("updateURL") val updateURL: String?,
+        @SerialName("updateVersion") val updateVersion: String?,
+        @SerialName("changelog") val changelog: String?,
+        @SerialName("updateNodeId") val updateNodeId: String?,
     )
 
     private suspend fun Activity.getAppUpdate(installPrerelease: Boolean): Update {

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
@@ -46,8 +46,8 @@ object InAppUpdater {
 
     @Serializable
     private data class GithubAsset(
-        @SerialName("name") val name: String,
-        @SerialName("size") val size: Int, // Size in bytes
+        @JsonProperty("name") @SerialName("name") val name: String,
+        @JsonProperty("size") @SerialName("size") val size: Int, // Size in bytes
         @JsonProperty("browser_download_url") @SerialName("browser_download_url") val browserDownloadUrl: String,
         @JsonProperty("content_type") @SerialName("content_type") val contentType: String, // application/vnd.android.package-archive
     )
@@ -55,18 +55,18 @@ object InAppUpdater {
     @Serializable
     private data class GithubRelease(
         @JsonProperty("tag_name") @SerialName("tag_name") val tagName: String, // Version code
-        @SerialName("body") val body: String, // Description
-        @SerialName("assets") val assets: List<GithubAsset>,
+        @JsonProperty("body") @SerialName("body") val body: String, // Description
+        @JsonProperty("assets") @SerialName("assets") val assets: List<GithubAsset>,
         @JsonProperty("target_commitish") @SerialName("target_commitish") val targetCommitish: String, // Branch
-        @SerialName("prerelease") val prerelease: Boolean,
+        @JsonProperty("prerelease") @SerialName("prerelease") val prerelease: Boolean,
         @JsonProperty("node_id") @SerialName("node_id") val nodeId: String,
     )
 
     @Serializable
     private data class GithubObject(
-        @SerialName("sha") val sha: String, // SHA-256 hash
-        @SerialName("type") val type: String,
-        @SerialName("url") val url: String,
+        @JsonProperty("sha") @SerialName("sha") val sha: String, // SHA-256 hash
+        @JsonProperty("type") @SerialName("type") val type: String,
+        @JsonProperty("url") @SerialName("url") val url: String,
     )
 
     @Serializable
@@ -76,11 +76,11 @@ object InAppUpdater {
 
     @Serializable
     private data class Update(
-        @SerialName("shouldUpdate") val shouldUpdate: Boolean,
-        @SerialName("updateURL") val updateURL: String?,
-        @SerialName("updateVersion") val updateVersion: String?,
-        @SerialName("changelog") val changelog: String?,
-        @SerialName("updateNodeId") val updateNodeId: String?,
+        @JsonProperty("shouldUpdate") @SerialName("shouldUpdate") val shouldUpdate: Boolean,
+        @JsonProperty("updateURL") @SerialName("updateURL") val updateURL: String?,
+        @JsonProperty("updateVersion") @SerialName("updateVersion") val updateVersion: String?,
+        @JsonProperty("changelog") @SerialName("changelog") val changelog: String?,
+        @JsonProperty("updateNodeId") @SerialName("updateNodeId") val updateNodeId: String?,
     )
 
     private suspend fun Activity.getAppUpdate(installPrerelease: Boolean): Update {

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/InAppUpdater.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.BuildConfig
 import com.lagradost.cloudstream3.CommonActivity.showToast
 import com.lagradost.cloudstream3.MainActivity.Companion.deleteFileOnExit
@@ -47,18 +48,18 @@ object InAppUpdater {
     private data class GithubAsset(
         @SerialName("name") val name: String,
         @SerialName("size") val size: Int, // Size in bytes
-        @SerialName("browser_download_url") val browserDownloadUrl: String,
-        @SerialName("content_type") val contentType: String, // application/vnd.android.package-archive
+        @JsonProperty("browser_download_url") @SerialName("browser_download_url") val browserDownloadUrl: String,
+        @JsonProperty("content_type") @SerialName("content_type") val contentType: String, // application/vnd.android.package-archive
     )
 
     @Serializable
     private data class GithubRelease(
-        @SerialName("tag_name") val tagName: String, // Version code
+        @JsonProperty("tag_name") @SerialName("tag_name") val tagName: String, // Version code
         @SerialName("body") val body: String, // Description
         @SerialName("assets") val assets: List<GithubAsset>,
-        @SerialName("target_commitish") val targetCommitish: String, // Branch
+        @JsonProperty("target_commitish") @SerialName("target_commitish") val targetCommitish: String, // Branch
         @SerialName("prerelease") val prerelease: Boolean,
-        @SerialName("node_id") val nodeId: String,
+        @JsonProperty("node_id") @SerialName("node_id") val nodeId: String,
     )
 
     @Serializable
@@ -70,7 +71,7 @@ object InAppUpdater {
 
     @Serializable
     private data class GithubTag(
-        @SerialName("object") val githubObject: GithubObject,
+        @JsonProperty("object") @SerialName("object") val githubObject: GithubObject,
     )
 
     @Serializable


### PR DESCRIPTION
This one shouldn't need to wait for next stable like the library ones might. I also tested this when fixing the updater the first time to ensure my fix worked with both versions. So this should still work unless something changed since then.