### PR TITLE
Set explicitNulls = false for kotlinx serialization

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -90,6 +90,7 @@ class ErrorLoadingException(message: String? = null) : Exception(message)
 @Prerelease
 val json = Json {
     encodeDefaults = true
+    explicitNulls = false
     ignoreUnknownKeys = true
 }
 


### PR DESCRIPTION
This is more inline with Jackson's behavior otherwise for nullable types with non default values, and they don't exist, gives a Missingfield exception whereas it worked on Jackson. We may need coerceInputValues = true also but I am unsure of that right now.