### PR TITLE
ParCollections: remove deprecated methods

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/ParCollections.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/ParCollections.kt
@@ -16,19 +16,6 @@ suspend fun <K, V, R> Map<out K, V>.amap(f: suspend (Map.Entry<K, V>) -> R): Lis
     }
 
 /**
- * Short for "Asynchronous Parallel Map", but is not really parallel, only concurrent.
- */
-@Deprecated(
-    "This blocks with runBlocking, and should not be used inside a suspended context",
-    replaceWith = ReplaceWith("amap(f)", "com.lagradost.cloudstream3.amap"),
-    level = DeprecationLevel.ERROR
-)
-@Throws(CancellationException::class)
-fun <K, V, R> Map<out K, V>.apmap(f: suspend (Map.Entry<K, V>) -> R): List<R> = runBlocking {
-    map { async { f(it) } }.map { it.await() }
-}
-
-/**
  * Short for "Asynchronous Map", runs on all values concurrently,
  * this means that if you are not doing networking, you should use a regular map
  */
@@ -40,32 +27,6 @@ suspend fun <A, B> List<A>.amap(f: suspend (A) -> B): List<B> =
     }
 
 /**
- * Short for "Asynchronous Parallel Map", but is not really parallel, only concurrent.
- */
-@Deprecated(
-    "This blocks with runBlocking, and should not be used inside a suspended context",
-    replaceWith = ReplaceWith("amap(f)", "com.lagradost.cloudstream3.amap"),
-    level = DeprecationLevel.ERROR
-)
-@Throws(CancellationException::class)
-fun <A, B> List<A>.apmap(f: suspend (A) -> B): List<B> = runBlocking {
-    map { async { f(it) } }.map { it.await() }
-}
-
-/**
- * Short for "Asynchronous Parallel Map" with an Index, but is not really parallel, only concurrent.
- */
-@Deprecated(
-    "This blocks with runBlocking, and should not be used inside a suspended context",
-    replaceWith = ReplaceWith("amapIndexed(f)", "com.lagradost.cloudstream3.amapIndexed"),
-    level = DeprecationLevel.ERROR
-)
-@Throws(CancellationException::class)
-fun <A, B> List<A>.apmapIndexed(f: suspend (index: Int, A) -> B): List<B> = runBlocking {
-    mapIndexed { index, a -> async { f(index, a) } }.map { it.await() }
-}
-
-/**
  * Short for "Asynchronous Map" with an Index, runs on all values concurrently,
  * this means that if you are not doing networking, you should use a regular mapIndexed
  */
@@ -75,33 +36,6 @@ suspend fun <A, B> List<A>.amapIndexed(f: suspend (index: Int, A) -> B): List<B>
         ensureActive()
         mapIndexed { index, a -> async { f(index, a) } }.map { it.await() }
     }
-
-/**
- * Short for "Argument Asynchronous Map" because it allows for a variadic number of paramaters.
- *
- * Runs all different functions at the same time and awaits for all to be finished, then returns
- * a list of all those items or null if they fail. However Unit is often used.
- */
-@Deprecated(
-    "This blocks with runBlocking, and should not be used inside a suspended context",
-    replaceWith = ReplaceWith("runAllAsync(transforms)", "com.lagradost.cloudstream3.runAllAsync"),
-    level = DeprecationLevel.ERROR
-)
-@Throws(CancellationException::class)
-fun <R> argamap(
-    vararg transforms: suspend () -> R,
-) : List<R?> = runBlocking {
-    transforms.map {
-        async {
-            try {
-                it.invoke()
-            } catch (e: Exception) {
-                logError(e)
-                null
-            }
-        }
-    }.map { it.await() }
-}
 
 /**
  * Runs all different functions at the same time and awaits for all to be finished, then returns


### PR DESCRIPTION
runBlocking is not available on some platforms, instead of handling that with a temporary expect/actual, we can just remove these. They have been deprecated for awhile anyway.