### PR TITLE
fix: resolve error 2004/2001 on Android TV (IPv6, timeouts)

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/network/DohProviders.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/network/DohProviders.kt
@@ -17,6 +17,11 @@ fun OkHttpClient.Builder.addGenericDns(url: String, ips: List<String>) = dns(
         .bootstrapDnsHosts(
             ips.map { InetAddress.getByName(it) }
         )
+        // Android TV often has a broken IPv6 stack — connections time out
+        // silently, causing ExoPlayer errors 2004/2001 on TV while the same
+        // stream works fine on mobile (same Wi-Fi). Force IPv4-only so OkHttp
+        // never attempts the broken IPv6 path.
+        .includeIPv6(false)
         .build()
 )
 

--- a/app/src/main/java/com/lagradost/cloudstream3/network/RequestsHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/network/RequestsHelper.kt
@@ -43,6 +43,11 @@ fun buildDefaultClient(context: Context, ignoreSSL: Boolean = false): OkHttpClie
     val baseClient = OkHttpClient.Builder()
         .followRedirects(true)
         .followSslRedirects(true)
+        // Explicit timeouts — OkHttp defaults (10 s) are too short for TV
+        // network stacks which can be slower than phones on the same Wi-Fi.
+        .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+        .readTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+        .writeTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
         .apply {
             if (ignoreSSL) {
                 ignoreAllSSLErrors()

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -658,7 +658,9 @@ class CS3IPlayer : IPlayer {
     }
 
     companion object {
-        private const val CRONET_TIMEOUT_MS = 15_000
+        // 30 s instead of 15 s: TV network stacks are slower than phones
+        // and were timing out before the stream could start (error 2004/2001).
+        private const val CRONET_TIMEOUT_MS = 30_000
 
         /**
          * Single shared engine, to minimize the overhead of maintaining many as:


### PR DESCRIPTION
Android TV gets ExoPlayer errors 2004/2001 on sources that work fine on 
mobile with the same Wi-Fi. Three fixes:

1. DohProviders: add .includeIPv6(false) — TV firmware often has a broken 
   IPv6 stack. DoH returns both IPv4+IPv6, OkHttp tries IPv6 first and 
   silently fails. Mobile handles the fallback; TV doesn't.

2. RequestsHelper: set explicit 30s timeouts + retryOnConnectionFailure(true)
   — OkHttp's default 10s is too short for slower TV network stacks.

3. CS3IPlayer: increase Cronet timeout 15s → 30s for the same reason.