### PR TITLE
feat(extractors): add flyfile.app extractor

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Flyfile.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Flyfile.kt
@@ -1,0 +1,48 @@
+package com.lagradost.cloudstream3.extractors
+
+import com.lagradost.cloudstream3.Prerelease
+import com.lagradost.cloudstream3.SubtitleFile
+import com.lagradost.cloudstream3.app
+import com.lagradost.cloudstream3.utils.ExtractorApi
+import com.lagradost.cloudstream3.utils.ExtractorLink
+import com.lagradost.cloudstream3.utils.ExtractorLinkType
+import com.lagradost.cloudstream3.utils.newExtractorLink
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Prerelease
+open class Flyfile : ExtractorApi() {
+    override val name: String = "FlyFile"
+    override val mainUrl: String = "https://flyfile.app"
+    open val apiUrl: String = "https://api.flyfile.app"
+    override val requiresReferer: Boolean = false
+
+    override suspend fun getUrl(
+        url: String,
+        referer: String?,
+        subtitleCallback: (SubtitleFile) -> Unit,
+        callback: (ExtractorLink) -> Unit
+    ) {
+        val videoId = url.substringAfterLast("/")
+        val videoInfo = app.get("$apiUrl/api/streaming/assign/$videoId")
+            .parsed<StreamInfo>()
+
+        val streamUrl = "${videoInfo.url}/hls/${videoInfo.token}/master.m3u8"
+        callback.invoke(
+            newExtractorLink(
+                source = name,
+                name = name,
+                url = streamUrl,
+                type = ExtractorLinkType.M3U8
+            )
+        )
+    }
+
+    @Serializable
+    private data class StreamInfo(
+        @SerialName("url")
+        val url: String,
+        @SerialName("token")
+        val token: String
+    )
+}

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -81,6 +81,7 @@ import com.lagradost.cloudstream3.extractors.FilemoonV2
 import com.lagradost.cloudstream3.extractors.Filesim
 import com.lagradost.cloudstream3.extractors.Multimoviesshg
 import com.lagradost.cloudstream3.extractors.FlaswishCom
+import com.lagradost.cloudstream3.extractors.Flyfile
 import com.lagradost.cloudstream3.extractors.FourCX
 import com.lagradost.cloudstream3.extractors.FourPichive
 import com.lagradost.cloudstream3.extractors.FourPlayRu
@@ -1298,6 +1299,7 @@ val extractorApis: AtomicMutableList<ExtractorApi> = atomicListOf(
     GUpload(),
     HlsWish(),
     ByseQekaho(),
+    Flyfile()
 )
 
 


### PR DESCRIPTION
- Example URL to test with: https://flyfile.app/v/vsSkhe3XMBZ0yN8
- From my tests, the player timed out 90% of times. I'm not sure if that's only a temporary issue or if the service is generally so slow (it's the same on the website). The API always assigned me to `https://streaming-de-2.flyfile.app`, so maybe in other regions, it's faster.

I've already used KotlinX for this, I'm not really 100% sure of the state of it in Cloudstream, but it seems to work.

Great work on KotlinX btw @Luna712!