### PR TITLE
Remove flickering from bottom dialog sheets

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -472,6 +472,9 @@
     </style>
 
     <style name="AppBottomSheetDialogTheme">
+        <item name="android:windowIsFloating">true</item>
+        <!-- To remove the background dim of bottom sheets use android:backgroundDimEnabled -->
+        <!-- <item name="android:backgroundDimEnabled">false</item> -->
         <item name="android:navigationBarColor">?attr/boxItemBackground</item>
         <item name="android:windowCloseOnTouchOutside">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>


### PR DESCRIPTION
Fixes https://github.com/recloudstream/cloudstream/issues/2944

The issue occurs due to bottom sheets automatically dimming the status bar. By making the window floating we solve the issue and automatically get a background dimming effect. The dim is consistent with alert dialogs, but not previous behavior. 