### PR TITLE
StringUtils: add DeprecationLevel.WARNING to not yet enabled deprecations

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/StringUtils.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/StringUtils.kt
@@ -19,13 +19,15 @@ object StringUtils {
 
     /* @Deprecated(
         message = "Use Ktor 'Url' naming convention instead.",
-        replaceWith = ReplaceWith("this.encodeUrl()")
+        replaceWith = ReplaceWith("this.encodeUrl()"),
+        level = DeprecationLevel.WARNING,
     ) */
     fun String.encodeUri(): String = encodeUrl()
 
     /* @Deprecated(
         message = "Use Ktor 'Url' naming convention instead.",
-        replaceWith = ReplaceWith("this.decodeUrl()")
+        replaceWith = ReplaceWith("this.decodeUrl()"),
+        level = DeprecationLevel.WARNING,
     ) */
     fun String.decodeUri(): String = decodeUrl()
 }


### PR DESCRIPTION
Just makes it a little easier to find and change these later, at least for me.