### PR TITLE
SerializationClassTester: skip abstract classes

### DIFF
--- a/app/src/androidTest/java/com/lagradost/cloudstream3/SerializationClassTester.kt
+++ b/app/src/androidTest/java/com/lagradost/cloudstream3/SerializationClassTester.kt
@@ -136,9 +136,9 @@ class SerializationClassTester {
                 runCatching { Class.forName(it).kotlin }.getOrNull()
             }.filter { kClass ->
                 // Not possible to use .hasAnnotation() on newer Android versions.
-                kClass.java.annotations.any {
-                    it is Serializable
-                } && kClass.java.annotations.none { it is SkipSerializationTest }
+                kClass.java.annotations.any { it is Serializable }
+                    && kClass.java.annotations.none { it is SkipSerializationTest }
+                    && !kClass.isAbstract
             }
     }
 


### PR DESCRIPTION
Necessary for some such as LibrarySearchResponse and DownloadCached. Using the skip annotation causes it to also skip child classes which we don't want so just skip abstract classes since Instancio can't create an instance of an abstract class: "It is an abstract class and no subtype was provided".