### PR TITLE
fix: disable QUIC in Cronet to fix error 2004/2001 on Android TV

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/CS3IPlayer.kt
@@ -769,7 +769,10 @@ class CS3IPlayer : IPlayer {
                 CronetEngine.Builder(context)
                     .enableBrotli(true)
                     .enableHttp2(true)
-                    .enableQuic(true)
+                    // QUIC runs over UDP port 443, which many TV routers/ISPs block or
+                    // throttle. Phones fall back gracefully; Cronet on TV gets stuck and
+                    // dies with error 2004/2001. Disable QUIC so Cronet always uses TCP.
+                    .enableQuic(false)
                     .setStoragePath(cacheDirectory.absolutePath)
                     .setLibraryLoader(null)
                     .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_DISK, diskCacheSize)


### PR DESCRIPTION
Cronet has enableQuic(true) which uses UDP port 443. Many TV  routers/ISPs block or throttle UDP. Phones recover gracefully;  Cronet on TV gets stuck and fails with error 2004/2001 on sources  that work fine on mobile on the same Wi-Fi.

Fix: enableQuic(false) forces Cronet to always use TCP.