### PR TITLE
Replace javaClass with Kotlin ::class for consistency

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -174,10 +174,13 @@ import com.lagradost.cloudstream3.utils.UIHelper.setNavigationBarColorCompat
 import com.lagradost.cloudstream3.utils.UIHelper.toPx
 import com.lagradost.cloudstream3.utils.USER_PROVIDER_API
 import com.lagradost.cloudstream3.utils.USER_SELECTED_HOMEPAGE_API
+import com.lagradost.cloudstream3.utils.downloader.DownloadQueueManager
 import com.lagradost.cloudstream3.utils.setText
 import com.lagradost.cloudstream3.utils.setTextHtml
 import com.lagradost.cloudstream3.utils.txt
 import com.lagradost.safefile.SafeFile
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.File
@@ -187,10 +190,8 @@ import java.net.URLDecoder
 import java.nio.charset.Charset
 import kotlin.math.abs
 import kotlin.math.absoluteValue
+import kotlin.reflect.full.createInstance
 import kotlin.system.exitProcess
-import com.lagradost.cloudstream3.utils.downloader.DownloadQueueManager
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 
 class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCallback {
     companion object {
@@ -784,7 +785,6 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
             }
         }
 
-
         val builder = NavOptions.Builder().setLaunchSingleTop(true).setRestoreState(true)
             .setEnterAnim(R.anim.enter_anim)
             .setExitAnim(R.anim.exit_anim)
@@ -815,22 +815,24 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
                     try {
                         getKey<Array<SettingsGeneral.CustomSite>>(USER_PROVIDER_API)?.let { list ->
                             list.forEach { custom ->
-                                allProviders.firstOrNull { it.javaClass.simpleName == custom.parentJavaClass }
-                                    ?.let {
-                                        allProviders.add(
-                                            it.javaClass.getDeclaredConstructor().newInstance()
-                                                .apply {
-                                                    name = custom.name
-                                                    lang = custom.lang
-                                                    mainUrl = custom.url.trimEnd('/')
-                                                    canBeOverridden = false
-                                                })
-                                    }
+                                allProviders.firstOrNull {
+                                    it::class.simpleName == custom.parentClassName
+                                }?.let {
+                                    allProviders.add(
+                                        it::class.createInstance().apply {
+                                            name = custom.name
+                                            lang = custom.lang
+                                            mainUrl = custom.url.trimEnd('/')
+                                            canBeOverridden = false
+                                        }
+                                    )
+                                }
                             }
                         }
                         // it.hashCode() is not enough to make sure they are distinct
-                        apis =
-                            allProviders.distinctBy { it.lang + it.name + it.mainUrl + it.javaClass.name }
+                        apis = allProviders.distinctBy {
+                            it.lang + it.name + it.mainUrl + it::class.qualifiedName
+                        }
                         APIHolder.apiMap = null
                     } catch (e: Exception) {
                         logError(e)

--- a/app/src/main/java/com/lagradost/cloudstream3/actions/VideoClickAction.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/actions/VideoClickAction.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.concurrent.Callable
 import java.util.concurrent.FutureTask
-import kotlin.reflect.jvm.jvmName
 
 object VideoClickActionHolder {
     val allVideoClickActions = atomicListOf(
@@ -161,7 +160,7 @@ abstract class VideoClickAction {
         }
     }
 
-    fun uniqueId() = "$sourcePlugin:${this::class.jvmName}"
+    fun uniqueId() = "$sourcePlugin:${this::class.qualifiedName}"
 
     @Throws
     abstract fun shouldShow(context: Context?, video: ResultEpisode?): Boolean

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -1525,7 +1525,7 @@ class GeneratorPlayer : FullScreenPlayer() {
         Log.e(
             TAG,
             "playerError: $currentSelectedLink, " +
-                    "type=${exception::class.java.canonicalName}, " +
+                    "type=${exception::class.qualifiedName}, " +
                     "message=${exception.message}, url=$currentUrl, headers=$headers, " +
                     "referer=$referer, position=${player.getPosition() ?: "unknown"}, " +
                     "duration=${player.getDuration() ?: "unknown"}, " +

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsGeneral.kt
@@ -10,6 +10,7 @@ import androidx.core.content.edit
 import androidx.core.os.ConfigurationCompat
 import androidx.fragment.app.Fragment
 import androidx.preference.PreferenceManager
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.lagradost.cloudstream3.APIHolder.allProviders
 import com.lagradost.cloudstream3.CloudStreamApp
@@ -48,8 +49,10 @@ import com.lagradost.cloudstream3.utils.USER_PROVIDER_API
 import com.lagradost.cloudstream3.utils.downloader.DownloadFileManagement
 import com.lagradost.cloudstream3.utils.downloader.DownloadFileManagement.getBasePath
 import com.lagradost.cloudstream3.utils.downloader.DownloadQueueManager
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 import java.util.Locale
 
 // Change local language settings in the app.
@@ -147,9 +150,12 @@ class SettingsGeneral : BasePreferenceFragmentCompat() {
         setToolBarScrollFlags()
     }
 
+    @OptIn(ExperimentalSerializationApi::class) // JsonNames is an experimental annotation for now
     @Serializable
     data class CustomSite(
-        @JsonProperty("parentJavaClass") @SerialName("parentJavaClass") val parentJavaClass: String, // javaClass.simpleName
+        @JsonProperty("parentClassName") @JsonAlias("parentJavaClass")
+        @SerialName("parentClassName") @JsonNames("parentJavaClass")
+        val parentClassName: String, // ::class.simpleName
         @JsonProperty("name") @SerialName("name") val name: String,
         @JsonProperty("url") @SerialName("url") val url: String,
         @JsonProperty("lang") @SerialName("lang") val lang: String,
@@ -242,13 +248,14 @@ class SettingsGeneral : BasePreferenceFragmentCompat() {
                     val url = binding.siteUrlInput.text?.toString()
                     val lang = binding.siteLangInput.text?.toString()
                     val realLang = if (lang.isNullOrBlank()) provider.lang else lang
-                    if (url.isNullOrBlank() || name.isNullOrBlank()) {
+                    val simpleName = provider::class.simpleName
+                    if (url.isNullOrBlank() || name.isNullOrBlank() || simpleName == null) {
                         showToast(R.string.error_invalid_data, Toast.LENGTH_SHORT)
                         return@setOnClickListener
                     }
 
                     val current = getCurrent()
-                    val newSite = CustomSite(provider.javaClass.simpleName, name, url, realLang)
+                    val newSite = CustomSite(simpleName, name, url, realLang)
                     current.add(newSite)
                     setKey(USER_PROVIDER_API, current.toTypedArray())
                     // reload apis

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsPlayer.kt
@@ -205,29 +205,35 @@ class SettingsPlayer : BasePreferenceFragmentCompat() {
         }
 
         getPref(R.string.player_default_key)?.setOnPreferenceClickListener {
-            val players = VideoClickActionHolder.getPlayers(activity)
-            val prefNames = buildList {
-                add(getString(R.string.player_settings_play_in_app))
-                addAll(players.map { it.name.asStringNull(activity) ?: it.javaClass.simpleName })
+            // Pair each player with its display name, dropping any with none,
+            // which would mean something is definitely wrong.
+            val players = VideoClickActionHolder.getPlayers(activity).mapNotNull { player ->
+                (player.name.asStringNull(activity) ?: player::class.simpleName)?.let { player to it }
             }
-            val prefValues = buildList {
-                add("")
-                addAll(players.map { it.uniqueId() })
-            }
-            val current =
-                settingsManager.getString(getString(R.string.player_default_key), "") ?: ""
 
+            val prefNames = buildList {
+                add(getString(R.string.player_settings_play_in_app)) // built-in player display name
+                addAll(players.map { (_, name) -> name })
+            }
+
+            val prefValues = buildList {
+                add("") // "" = built-in player, matches default
+                addAll(players.map { (player, _) -> player.uniqueId() })
+            }
+
+            val current = settingsManager.getString(getString(R.string.player_default_key), "") ?: ""
             activity?.showBottomDialog(
                 prefNames.toList(),
-                prefValues.indexOf(current),
+                prefValues.indexOf(current), // finds index of currently selected player
                 getString(R.string.player_pref),
                 true,
-                {}
+                {},
             ) {
                 settingsManager.edit {
                     putString(getString(R.string.player_default_key), prefValues[it])
                 }
             }
+
             return@setOnPreferenceClickListener true
         }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/TestingUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/TestingUtils.kt
@@ -200,7 +200,7 @@ object TestingUtils {
                 }
 
                 else -> {
-                    logger.error("Unknown load response: ${loadResponse.javaClass.name}")
+                    logger.error("Unknown load response: ${loadResponse::class.qualifiedName}")
                     return TestResult.Fail
                 }
             } ?: return TestResult.Fail


### PR DESCRIPTION
I was originally just going to replace it in CustomSite, but figured I would do it all for consistency. When retrieving the data from CustomSite they would both resolve to the same thing so is backwards compatible. However, `::class.simpleName` can return null if something really goes wrong so we do handle that a little different for PlayerSettings, and bail out rather than setting to an empty string for CustomSite just to ensure consistency with current behavior also.

Eventually this will be needed anyway as we migrate more to KMP in library and Compose Multiplatform for UI, which as I am building compose, I am avoiding JVM specific stuff also so if we later expand to other platforms besides Android and JVM Desktop we can more easily do that as well.

I used Jackson's JsonAlias and Kotlinx Serialization's JsonNames annotations for CustomSite to maintain backwards compatibility for deserialization but future serialization would use the new name, so `parentClassName` rather than `parentJavaClass`.

I also added some extra comments to SettingsPlayer as the code kinda confused me, like what `add("")` was for, while I figured it out fairly quickly, I figured it didn't hurt to add comments to make it more clear in the future.