### PR TITLE
EmturbovidExtractor: replace selectXpath

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
@@ -14,7 +14,7 @@ open class EmturbovidExtractor : ExtractorApi() {
 
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink>? {
         val response = app.get(url, referer = referer ?: "$mainUrl/")
-        val playerScript2 = response.document
+        val playerScript = response.document
             .select("script")
             .first { it.data().contains("var urlPlay") }
             .html()

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
@@ -13,30 +13,27 @@ open class EmturbovidExtractor : ExtractorApi() {
     override val requiresReferer = false
 
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink>? {
-        val response = app.get(
-            url, referer = referer ?: "$mainUrl/"
-        )
-        val playerScript =
-            response.document.selectXpath("//script[contains(text(),'var urlPlay')]")
-                .html()
+        val response = app.get(url, referer = referer ?: "$mainUrl/")
+        val playerScript = response.document
+            .select("script:contains(var urlPlay)")
+            .html()
 
         val sources = mutableListOf<ExtractorLink>()
         if (playerScript.isNotBlank()) {
-            val m3u8Url =
-                playerScript.substringAfter("var urlPlay = '").substringBefore("'")
-
+            val m3u8Url = playerScript.substringAfter("var urlPlay = '").substringBefore("'")
             sources.add(
                 newExtractorLink(
                     source = name,
                     name = name,
                     url = m3u8Url,
-                    type = ExtractorLinkType.M3U8
+                    type = ExtractorLinkType.M3U8,
                 ) {
                     this.referer = "$mainUrl/"
                     this.quality = Qualities.Unknown.value
                 }
             )
         }
+
         return sources
     }
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
@@ -14,8 +14,9 @@ open class EmturbovidExtractor : ExtractorApi() {
 
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink>? {
         val response = app.get(url, referer = referer ?: "$mainUrl/")
-        val playerScript = response.document
-            .select("script:contains(var urlPlay)")
+        val playerScript2 = response.document
+            .select("script")
+            .first { it.data().contains("var urlPlay") }
             .html()
 
         val sources = mutableListOf<ExtractorLink>()

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/EmturbovidExtractor.kt
@@ -8,8 +8,8 @@ import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.newExtractorLink
 
 open class EmturbovidExtractor : ExtractorApi() {
-    override var name = "Emturbovid"
-    override var mainUrl = "https://emturbovid.com"
+    override val name = "Emturbovid"
+    override val mainUrl = "https://emturbovid.com"
     override val requiresReferer = false
 
     override suspend fun getUrl(url: String, referer: String?): List<ExtractorLink>? {


### PR DESCRIPTION
This will be necessary when we finally fully migrate to ksoup, which currently doesn't have selectXpath, but for our usages that is not necessary. This way is also more consistent with how we do it everywhere else.