### PR TITLE
Add JvmName import to MainAPI

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -41,6 +41,7 @@ import kotlinx.datetime.format.parse
 import kotlinx.datetime.toInstant
 import kotlinx.serialization.json.Json
 import kotlin.io.encoding.Base64
+import kotlin.jvm.JvmName
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 import kotlin.time.Clock


### PR DESCRIPTION
Necessary for non JVM platforms or it won't resolve. On non JVM platforms the annotation is simply erased at compile time but still compiled as long as the import is present.