### PR TITLE
Add more space to fix last menu item half-cut

### DIFF
--- a/app/src/main/res/layout/bottom_selection_dialog.xml
+++ b/app/src/main/res/layout/bottom_selection_dialog.xml
@@ -37,6 +37,7 @@
         android:paddingTop="10dp"
         android:dividerHeight="1dp"
         android:requiresFadingEdge="vertical"
+        android:paddingBottom="32dp"
         android:nextFocusRight="@id/cancel_btt"
         android:nextFocusLeft="@id/apply_btt"
         tools:listitem="@layout/sort_bottom_single_choice" />


### PR DESCRIPTION
Fixes last item in the `BottomSheetDialog` half-cut on TV