### PR TITLE
feat(extractors): fix vidara and update list of mirrors

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidara.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidara.kt
@@ -8,23 +8,45 @@ import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.ExtractorLinkType
 import com.lagradost.cloudstream3.utils.newExtractorLink
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-class Streamix(): Streamup() {
-    override val name: String = "Streamix"
-    override val mainUrl = "https://streamix.so"
+class Vidavaca : Vidara() {
+    override val mainUrl = "https://vidavaca.net"
 }
 
-class Vidara(): Streamup() {
+class VidaaraxNet : Vidara() {
+    override val mainUrl = "https://vidaarax.net"
+}
+
+class VidaaraxCom : Vidara() {
+    override val mainUrl = "https://vidaarax.com"
+}
+
+class Vidaratem : Vidara() {
+    override val mainUrl = "https://vidaratem.com"
+}
+
+class Vidaraw : Vidara() {
+    override val mainUrl = "https://vidaraw.com"
+}
+
+class Vidarax : Vidara() {
+    override val mainUrl = "https://vidarax.cc"
+}
+
+class Vidaraa : Vidara() {
+    override val mainUrl = "https://vidaraa.cc"
+}
+
+class VidaraSo : Vidara() {
+    override val mainUrl = "https://vidara.so"
+}
+
+open class Vidara : ExtractorApi() {
     override val name: String = "Vidara"
     override val mainUrl = "https://vidara.to"
-    override val apiPath: String = "/api/stream"
-}
-
-open class Streamup() : ExtractorApi() {
-    override val name: String = "Streamup"
-    override val mainUrl: String = "https://strmup.to"
     override val requiresReferer: Boolean = false
-    open val apiPath: String = "/ajax/stream"
 
     override suspend fun getUrl(
         url: String,
@@ -33,8 +55,9 @@ open class Streamup() : ExtractorApi() {
         callback: (ExtractorLink) -> Unit
     ) {
         val fileCode = url.substringAfterLast("/")
-        val fileInfo = app.get("$mainUrl$apiPath?filecode=$fileCode")
-            .parsed<StreamUpFileInfo>()
+        val fileInfo =
+            app.post("$mainUrl/api/stream", json = mapOf("filecode" to fileCode, "device" to "web"))
+                .parsed<StreamUpFileInfo>()
 
         callback.invoke(
             newExtractorLink(
@@ -52,18 +75,21 @@ open class Streamup() : ExtractorApi() {
         }
     }
 
+    @Serializable
     private data class StreamUpFileInfo(
         val title: String,
         val thumbnail: String,
+        @SerialName("streaming_url")
         @JsonProperty("streaming_url")
         val streamingUrl: String,
         val subtitles: List<StreamUpSubtitle>?
     )
 
+    @Serializable
     private data class StreamUpSubtitle(
+        @SerialName("file_path")
         @JsonProperty("file_path")
         val filePath: String,
-        @JsonProperty("language")
         val language: String,
     )
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -228,12 +228,10 @@ import com.lagradost.cloudstream3.extractors.StreamWishExtractor
 import com.lagradost.cloudstream3.extractors.StreamhideCom
 import com.lagradost.cloudstream3.extractors.StreamhideTo
 import com.lagradost.cloudstream3.extractors.Streamhub2
-import com.lagradost.cloudstream3.extractors.Streamix
 import com.lagradost.cloudstream3.extractors.Streamlare
 import com.lagradost.cloudstream3.extractors.StreamoUpload
 import com.lagradost.cloudstream3.extractors.Streamplay
 import com.lagradost.cloudstream3.extractors.Streamsss
-import com.lagradost.cloudstream3.extractors.Streamup
 import com.lagradost.cloudstream3.extractors.Streamwish2
 import com.lagradost.cloudstream3.extractors.Strwish
 import com.lagradost.cloudstream3.extractors.Strwish2
@@ -287,7 +285,15 @@ import com.lagradost.cloudstream3.extractors.Vidoza
 import com.lagradost.cloudstream3.extractors.VinovoSi
 import com.lagradost.cloudstream3.extractors.VinovoTo
 import com.lagradost.cloudstream3.extractors.VidNest
+import com.lagradost.cloudstream3.extractors.VidaaraxCom
+import com.lagradost.cloudstream3.extractors.VidaaraxNet
 import com.lagradost.cloudstream3.extractors.Vidara
+import com.lagradost.cloudstream3.extractors.VidaraSo
+import com.lagradost.cloudstream3.extractors.Vidaraa
+import com.lagradost.cloudstream3.extractors.Vidaratem
+import com.lagradost.cloudstream3.extractors.Vidaraw
+import com.lagradost.cloudstream3.extractors.Vidarax
+import com.lagradost.cloudstream3.extractors.Vidavaca
 import com.lagradost.cloudstream3.extractors.Vide0Net
 import com.lagradost.cloudstream3.extractors.Vidsonic
 import com.lagradost.cloudstream3.extractors.VkExtractor
@@ -1160,9 +1166,15 @@ val extractorApis: AtomicMutableList<ExtractorApi> = atomicListOf(
     MoviehabNet(),
     Jeniusplay(),
     StreamoUpload(),
-    Streamup(),
-    Streamix(),
     Vidara(),
+    Vidavaca(),
+    Vidaraa(),
+    Vidaraw(),
+    Vidarax(),
+    VidaraSo(),
+    Vidaratem(),
+    VidaaraxCom(),
+    VidaaraxNet(),
 
     GamoVideo(),
     Gdriveplayerapi(),


### PR DESCRIPTION
Example URL:
- https://vidaarax.net/e/xB5Cf_RkGVbZ?kk111

Side notes:
- Strmup and Streamix are dead, so I removed them.
- I also migrated to KotlinX Serialization with these changes.