### PR TITLE
feat: add external player intent filter for HTTP/HTTPS video/audio URLs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -135,6 +135,38 @@
 
                 <data android:scheme="magnet" />
             </intent-filter>
+            <!-- External player: receive video/audio URLs from other apps (e.g. Stremio, browsers) -->
+            <intent-filter android:label="@string/play_with_app_name">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter android:label="@string/play_with_app_name">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:mimeType="application/x-mpegURL" />
+                <data android:mimeType="application/vnd.apple.mpegurl" />
+            </intent-filter>
+            <intent-filter android:label="@string/play_with_app_name">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
             <!--<intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
@@ -79,8 +79,12 @@ class DownloadedPlayerActivity : AppCompatActivity() {
             val item = if (cd != null && cd.itemCount > 0) cd.getItemAt(0) else null
             val url = item?.text?.toString()
             when {
+                item?.uri != null && item.uri.scheme in listOf("http", "https") ->
+                    playLink(this, item.uri.toString())
                 item?.uri != null -> playUri(this, item.uri)
                 url != null -> playLink(this, url)
+                data != null && data.scheme in listOf("http", "https") ->
+                    playLink(this, data.toString())
                 data != null -> playUri(this, data)
                 extraText != null -> playLink(this, extraText)
                 else -> { finish(); return }


### PR DESCRIPTION
## Summary

Allows CloudStream to appear in Android's "Open with" / "Share" menu when clicking video, audio, or HLS URLs from other apps (e.g., Stremio, web browsers, media apps).

Currently, CloudStream's `DownloadedPlayerActivity` only handles `content://` URIs and magnet links via intent filters. If you click an `http`/`https` video URL in another app, CloudStream doesn't show up as an option.

## Changes

### AndroidManifest.xml
Added 3 new `<intent-filter>` blocks to `DownloadedPlayerActivity`:
- `ACTION_VIEW` for `http/https` + `video/*` MIME type
- `ACTION_VIEW` for `http/https` + `application/x-mpegURL` + `application/vnd.apple.mpegurl` (HLS)
- `ACTION_VIEW` for `http/https` + `audio/*` MIME type

All use `@string/play_with_app_name` as the label and include both `DEFAULT` and `BROWSABLE` categories.

### DownloadedPlayerActivity.kt
Fixed URL routing: `http`/`https` URIs are now routed through `playLink()` instead of `playUri()`. Without this fix, network URLs would be passed to `playUri()` which treats them as local content URIs and fails to play.

## Use Case

As an example, Stremio users can now select CloudStream as an external player for streaming URLs. This also works with any app that shares video/audio URLs via Android's standard intent system.

## Testing

- Verified that CloudStream appears in the "Open with" menu when clicking video URLs in browsers
- Verified that HTTP/HTTPS video URLs play correctly via `playLink()` instead of failing via `playUri()`
- Verified that existing functionality (content URIs, magnet links, SEND intents) is unaffected