### PR TITLE
feat: add exit confirmation dialog to prevent accidental player exits

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/DownloadedPlayerActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.KeyEvent
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.lagradost.cloudstream3.CommonActivity
 import com.lagradost.cloudstream3.R
@@ -60,7 +61,28 @@ class DownloadedPlayerActivity : AppCompatActivity() {
         Log.i(TAG, "onCreate")
 
         handleIntent(intent)
-        attachBackPressedCallback("DownloadedPlayerActivity") { finish() }
+        attachBackPressedCallback("DownloadedPlayerActivity") {
+            if (exitDialog?.isShowing == true) {
+                exitDialog?.dismiss()
+                return@attachBackPressedCallback
+            }
+            showExitConfirmDialog()
+        }
+    }
+
+    private var exitDialog: AlertDialog? = null
+
+    private fun showExitConfirmDialog() {
+        if (isFinishing || isDestroyed) return
+        exitDialog = AlertDialog.Builder(this, R.style.AlertDialogCustom)
+            .setTitle(R.string.exit_player_confirm_title)
+            .setMessage(R.string.exit_player_confirm_message)
+            .setPositiveButton(R.string.yes) { _, _ ->
+                finish()
+            }
+            .setNegativeButton(R.string.no, null)
+            .setOnDismissListener { exitDialog = null }
+            .show()
     }
 
     private fun handleIntent(intent: Intent) {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/FullScreenPlayer.kt
@@ -442,6 +442,26 @@ open class FullScreenPlayer : AbstractPlayerFragment<FragmentPlayerBinding>(
         }
     }
 
+    private var exitConfirmDialog: AlertDialog? = null
+
+    private fun showExitConfirmDialog() {
+        val act = activity ?: return
+        if (exitConfirmDialog?.isShowing == true) return
+        if (act.isFinishing || act.isDestroyed) return
+        exitConfirmDialog = AlertDialog.Builder(act, R.style.AlertDialogCustom)
+            .setTitle(R.string.exit_player_confirm_title)
+            .setMessage(R.string.exit_player_confirm_message)
+            .setPositiveButton(R.string.yes) { _, _ ->
+                activity?.popCurrentPage("FullScreenPlayer")
+            }
+            .setNegativeButton(R.string.no, null)
+            .setOnDismissListener {
+                exitConfirmDialog = null
+                activity?.hideSystemUI()
+            }
+            .show()
+    }
+
     private fun setupKeyEventListener() {
         keyEventListener = { (event, hasNavigated) ->
             when {
@@ -473,7 +493,7 @@ open class FullScreenPlayer : AbstractPlayerFragment<FragmentPlayerBinding>(
                 // netflix capture back and hide ~monke
                 onClickChange()
             } else {
-                activity?.popCurrentPage("FullScreenPlayer")
+                showExitConfirmDialog()
             }
         }
         playerHostView?.requestUpdateBrightnessOverlayOnNextLayout()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -439,8 +439,8 @@
     <!--
     Example text (pangram) can optionally be translated; if you do, include all the letters in the alphabet,
     see: 
-	https://en.wikipedia.org/w/index.php?title=Pangram&oldid=225849300
-	https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog
+        https://en.wikipedia.org/w/index.php?title=Pangram&oldid=225849300
+        https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog
     -->
     <string name="subtitles_example_text">The quick brown fox jumps over the lazy dog</string>
     <string name="recommended">Recommended</string>
@@ -572,6 +572,8 @@
     <string name="action_mark_as_watched">Mark as watched</string>
     <string name="action_remove_from_watched">Remove from watched</string>
     <string name="confirm_exit_dialog">Are you sure you want to exit\?</string>
+    <string name="exit_player_confirm_title">Exit Player?</string>
+    <string name="exit_player_confirm_message">Your buffered stream will be lost. Are you sure you want to exit?</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="ok">OK</string>


### PR DESCRIPTION
## Summary

Shows a confirmation dialog when pressing back during video playback, preventing accidental exits that would lose the buffered stream.

Currently, a single back press instantly exits the player, discarding the entire buffered stream. This is especially frustrating on devices with sensitive back buttons or gesture navigation where accidental presses are common.

## Changes

### FullScreenPlayer.kt
- Added `showExitConfirmDialog()` method that shows an `AlertDialog` with "Exit Player?" title and "Your buffered stream will be lost" message
- Replaced `activity?.popCurrentPage("FullScreenPlayer")` with `showExitConfirmDialog()` in the back press handler
- Restores immersive mode (`hideSystemUI()`) when dialog is dismissed without exiting
- Handles edge cases: prevents showing dialog if activity is finishing/destroyed, prevents duplicate dialogs

### DownloadedPlayerActivity.kt
- Added same `showExitConfirmDialog()` method for external player intents
- Replaced `finish()` with `showExitConfirmDialog()` in the back press callback
- Pressing back while dialog is showing dismisses it instead of creating a new one

### strings.xml
- Added `exit_player_confirm_title` ("Exit Player?")
- Added `exit_player_confirm_message` ("Your buffered stream will be lost. Are you sure you want to exit?")
- Reuses existing `yes` and `no` string resources for dialog buttons

## User Experience

**Before:** Back press = instant exit, stream and buffer lost
**After:** Back press = confirmation dialog = user chooses Yes to exit or No to continue watching

The dialog uses the existing `AlertDialogCustom` style for visual consistency with the rest of the app.