### PR TITLE
Add expect/actual for WorkerThread

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/mvvm/ArchComponentExt.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/mvvm/ArchComponentExt.kt
@@ -1,8 +1,10 @@
 package com.lagradost.cloudstream3.mvvm
 
+import androidx.annotation.AnyThread
 import com.lagradost.api.Log
 import com.lagradost.cloudstream3.ErrorLoadingException
 import com.lagradost.cloudstream3.utils.AppDebug
+import com.lagradost.cloudstream3.utils.WorkerThread
 import kotlinx.coroutines.*
 import java.io.InterruptedIOException
 import java.net.SocketTimeoutException
@@ -232,8 +234,9 @@ fun <T> throwAbleToResource(
     }
 }
 
+@AnyThread
 suspend fun <T> safeApiCall(
-    apiCall: suspend () -> T,
+    @WorkerThread apiCall: suspend () -> T,
 ): Resource<T> {
     return withContext(Dispatchers.IO) {
         try {

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.kt
@@ -2,7 +2,6 @@ package com.lagradost.cloudstream3.utils
 
 import androidx.annotation.AnyThread
 import androidx.annotation.MainThread
-import androidx.annotation.WorkerThread
 import com.lagradost.cloudstream3.Prerelease
 import com.lagradost.cloudstream3.mvvm.launchSafe
 import com.lagradost.cloudstream3.mvvm.logError
@@ -10,6 +9,9 @@ import kotlinx.coroutines.*
 
 @AnyThread
 expect fun runOnMainThreadNative(@MainThread work: (() -> Unit))
+
+internal expect annotation class WorkerThread()
+
 object Coroutines {
     @AnyThread
     fun <T> T.main(@MainThread work: suspend ((T) -> Unit)): Job {

--- a/library/src/jvmCommonMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.jvmCommon.kt
+++ b/library/src/jvmCommonMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.jvmCommon.kt
@@ -1,0 +1,3 @@
+package com.lagradost.cloudstream3.utils
+
+internal actual typealias WorkerThread = androidx.annotation.WorkerThread


### PR DESCRIPTION
This will later be necessary for other targets as it only exists on JVM platforms. Other targets would just define it as a base annoation that doesn't do anything, allows us to keep thread safety on JVM platforms but still be able to compile for others that don't have it.