### PR TITLE
Remove fuzzywuzzy from library

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -69,9 +69,6 @@ kotlin {
             implementation(libs.rhino) // Run JavaScript
             implementation(libs.tmdb.java) // TMDB API v3 Wrapper Made with RetroFit
             implementation(libs.bundles.cryptography) // Cryptography
-
-            // Deprecated; will be removed once extensions have time to migrate from using it
-            implementation("me.xdrop:fuzzywuzzy:1.4.0")
         }
 
         commonTest.dependencies {


### PR DESCRIPTION
It doesn't use api(), which means extensions don't inherently have access, and they must already have the dependency explicit to use it. It being in app prevents runtime errors if they use it, but it being an implimentation in the library should be completely unused and unnecessary.