### PR TITLE
Fix regex to match quality case-insensitively for Doodstream

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/DoodExtractor.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/DoodExtractor.kt
@@ -112,7 +112,7 @@ open class DoodLaExtractor : ExtractorApi() {
         val response0 = req.text
         val md5 = host + (Regex("/pass_md5/[^']*").find(response0)?.value ?: return)
         val trueUrl = app.get(md5, referer = req.url).text + createHashTable() + "?token=" + md5.substringAfterLast("/")
-        val quality = Regex("\\d{3,4}p")
+        val quality = Regex("\\d{3,4}[pP]")
             .find(response0.substringAfter("<title>").substringBefore("</title>"))
             ?.groupValues
             ?.getOrNull(0)


### PR DESCRIPTION
The regex used to extract video quality (`\d{3,4}p`) only matched lowercase `p`, causing it to miss titles that use uppercase `P` (e.g. `1080P` instead of `1080p`). As a result, the quality value would return `null` for those cases.

Updated the quality regex from `\d{3,4}p` to `\d{3,4}[pP]` so it matches the resolution suffix regardless of case (`p` or `P`).