### PR TITLE
Reduce progress size for improved visual appeal

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -27,9 +27,9 @@
     <dimen name="account_select_linear_item_size">100dp</dimen>
     <dimen name="dialog_buttons_inset">5dp</dimen>
 
-    <dimen name="home_poster_progress_size">42dp</dimen>
+    <dimen name="home_poster_progress_size">40dp</dimen>
     <dimen name="episode_progress_size">40dp</dimen>
     <dimen name="continue_watching_progress_size">25dp</dimen>
-    <dimen name="circular_progress_thickness">3dp</dimen>
+    <dimen name="circular_progress_thickness">2dp</dimen>
     <dimen name="download_header_progress_size">35dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -27,9 +27,9 @@
     <dimen name="account_select_linear_item_size">100dp</dimen>
     <dimen name="dialog_buttons_inset">5dp</dimen>
 
-    <dimen name="home_poster_progress_size">50dp</dimen>
+    <dimen name="home_poster_progress_size">42dp</dimen>
     <dimen name="episode_progress_size">40dp</dimen>
     <dimen name="continue_watching_progress_size">25dp</dimen>
-    <dimen name="circular_progress_thickness">2dp</dimen>
+    <dimen name="circular_progress_thickness">3dp</dimen>
     <dimen name="download_header_progress_size">35dp</dimen>
 </resources>


### PR DESCRIPTION
Original progress bar:
<img width="1206" height="620" alt="original" src="https://github.com/user-attachments/assets/2a74c15d-062e-4138-82d1-d9a691bfb263" />

Reduced version:

<img width="1206" height="620" alt="reduced" src="https://github.com/user-attachments/assets/afeca22b-6006-45f6-8282-d6432b21a6c2" />

Side by side:

<img width="1013" height="620" alt="sidebyside" src="https://github.com/user-attachments/assets/b02b8865-c758-4b62-9334-150dec88892b" />
