### PR TITLE
Fix: Subtitle ordering on names

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/AppContextUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/AppContextUtils.kt
@@ -365,8 +365,14 @@ object AppContextUtils {
         }
     }
 
+    /** Sort subtitles by names */
     fun sortSubs(subs: Set<SubtitleData>): List<SubtitleData> {
-        return subs.sortedBy { it.name }
+        // Be aware, sorting by "$originalName $nameSuffix" causes "a (b) 1" < "a 1",
+        // where "originalName then nameSuffix" preserves "a 1" < "a (b) 1", because we do not compare '(' and '1'.
+        return subs
+            .sortedWith(
+                compareBy { subtitle: SubtitleData -> subtitle.originalName }
+                    .thenBy { subtitle: SubtitleData -> subtitle.nameSuffix })
     }
 
     fun Context.getApiSettings(): HashSet<String> {


### PR DESCRIPTION
Fixes an issue where "English (Something else)" gets sorted before "English" due to nameSuffix. This was an issue for auto-selection. 