### PR TITLE
Fix: Leading space in Vids, Closes #3015

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vids.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vids.kt
@@ -10,7 +10,7 @@ import com.lagradost.cloudstream3.utils.newExtractorLink
 @Prerelease
 open class Vids : ExtractorApi() {
     override val name: String = "Vids"
-    override val mainUrl: String = " https://vids.st"
+    override val mainUrl: String = "https://vids.st"
     override val requiresReferer: Boolean = false
 
     private val streamUrlRegex = Regex("""const url = "(.*?)";""")


### PR DESCRIPTION
While this not necessarily fix anything, given that get should work with a leading space, this makes the code a bit better. 