### PR TITLE
Fix: Remove uiReset for better UX for errors

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -507,7 +507,8 @@ class GeneratorPlayer : FullScreenPlayer() {
 
         showDownloadProgress(DownloadEvent(0, 0, 0, null))
 
-        uiReset()
+        // uiReset() // Removed due to UX
+        
         currentSelectedLink = link
         //  setEpisodes(viewModel.getAllMeta() ?: emptyList())
         setPlayerDimen(null)


### PR DESCRIPTION
Some sources have a lot of error causing the UI to be hidden a lot when loading the next link. This is a bad experience, especially for TV. 