### PR TITLE
Fix: Sync delay, Progress on sync button and runOnMainThreadNative fix

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -171,6 +171,7 @@ import com.lagradost.cloudstream3.utils.UIHelper.hideKeyboard
 import com.lagradost.cloudstream3.utils.UIHelper.navigate
 import com.lagradost.cloudstream3.utils.UIHelper.requestRW
 import com.lagradost.cloudstream3.utils.UIHelper.setNavigationBarColorCompat
+import com.lagradost.cloudstream3.utils.UIHelper.showProgress
 import com.lagradost.cloudstream3.utils.UIHelper.toPx
 import com.lagradost.cloudstream3.utils.USER_PROVIDER_API
 import com.lagradost.cloudstream3.utils.USER_SELECTED_HOMEPAGE_API
@@ -1428,8 +1429,9 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
 
                     else -> {
                         resultviewPreviewBookmark.isEnabled = false
-                        resultviewPreviewBookmark.setIconResource(R.drawable.ic_baseline_bookmark_border_24)
-                        resultviewPreviewBookmark.setText(R.string.loading)
+                        resultviewPreviewBookmark.showProgress()
+                        //resultviewPreviewBookmark.setIconResource(R.drawable.ic_baseline_bookmark_border_24)
+                        //resultviewPreviewBookmark.setText(R.string.loading)
                     }
                 }
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/SyncViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/SyncViewModel.kt
@@ -182,6 +182,7 @@ class SyncViewModel : ViewModel() {
     fun publishUserData() = ioSafe {
         Log.i(TAG, "publishUserData")
         val user = userData.value
+        _userDataResponse.postValue(Resource.Loading())
         if (user is Resource.Success) {
             syncs.forEach { (prefix, id) ->
                 repos.firstOrNull { it.idPrefix == prefix }?.updateStatus(id, user.value)

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/UIHelper.kt
@@ -597,6 +597,10 @@ object UIHelper {
     fun MaterialButton.showProgress(@ColorInt tintColor: Int = this.iconTint.defaultColor) =
         // Use runOnMainThreadNative to allow process on io threads, to make the code a bit cleaner
         runOnMainThreadNative {
+            // No need to set it again, as then it will reset the animation
+            if(this.icon is IndeterminateDrawable<*>) {
+                return@runOnMainThreadNative
+            }
             val spec = CircularProgressIndicatorSpec(
                 context, null, 0,
                 com.google.android.material.R.style.Widget_Material3_CircularProgressIndicator_ExtraSmall

--- a/library/src/androidMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.android.kt
+++ b/library/src/androidMain/kotlin/com/lagradost/cloudstream3/utils/Coroutines.android.kt
@@ -1,14 +1,20 @@
 package com.lagradost.cloudstream3.utils
 
+import android.annotation.SuppressLint
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.AnyThread
 import androidx.annotation.MainThread
 
+@SuppressLint("ThreadConstraint") // mainLooper.isCurrentThread does not switch the context
 @AnyThread
 actual fun runOnMainThreadNative(@MainThread work: () -> Unit) {
-    val mainHandler = Handler(Looper.getMainLooper())
-    mainHandler.post {
+    val mainLooper = Looper.getMainLooper()
+    if (mainLooper.isCurrentThread) {
+        // Do the work directly if we already are on the main thread, no need to enqueue it
         work()
+    } else {
+        // Otherwise post it to the other main thread
+        Handler(mainLooper).post(work)
     }
 }


### PR DESCRIPTION
1. Makes runOnMainThreadNative run instantly on a main thread, this fixes possible out of order issues when using runOnMainThreadNative. 
2. Makes publishUserData instantly post Resource.Loading to prevent a delay for better UX
3. Makes resultviewPreviewBookmark show a ciruclar progress instead of "Loading..." for better UI
4. Makes showProgress idempotent, aka calls to make the IndeterminateDrawable not reset if called twice for better UI. 