### PR TITLE
test: add an IgnoreOnWeb annotation

### DIFF
--- a/library/src/commonTest/kotlin/com/lagradost/cloudstream3/utils/Ignore.kt
+++ b/library/src/commonTest/kotlin/com/lagradost/cloudstream3/utils/Ignore.kt
@@ -1,0 +1,6 @@
+package com.lagradost.cloudstream3.utils
+
+@OptIn(ExperimentalMultiplatform::class) // OptionalExpectation is an experimental annotation for now
+@OptionalExpectation
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+expect annotation class IgnoreOnWeb()

--- a/library/src/commonTest/kotlin/com/lagradost/cloudstream3/utils/JsInterpreterTest.kt
+++ b/library/src/commonTest/kotlin/com/lagradost/cloudstream3/utils/JsInterpreterTest.kt
@@ -2129,6 +2129,7 @@ class JsInterpreterTest {
     }
 
     @Test
+    @IgnoreOnWeb
     fun suspendEvalJsWithTimeoutCancelsInfiniteLoop() = runTest {
         /**
          * activeScope() provides a real CoroutineScope with a real Job, so withTimeout
@@ -2326,6 +2327,7 @@ class JsInterpreterTest {
     }
 
     @Test
+    @IgnoreOnWeb
     fun jsContextEvalCancelledWhenEnclosingCoroutineCancelledViaWithTimeout() = runTest {
         val done = Channel<Unit>()
         var elapsed = Duration.ZERO
@@ -2361,6 +2363,7 @@ class JsInterpreterTest {
     }
 
     @Test
+    @IgnoreOnWeb
     fun jsContextJsTryCatchCannotSwallowEnclosingCancellation() = runTest {
         val done = Channel<Unit>()
         var elapsed = Duration.ZERO


### PR DESCRIPTION
For some things like coroutines, when compiled to JS tests will fail because it is single threaded, and it can't cancel a synchronous operation from a single threaded system. That causes a few tests from #2812 to fail on JS only, rather than splitting the location for the tests per platform, which can make it harder to find, just ignoring the tests would be better. With this we could then just add `@IgnoreOnWeb` to the tests we don't care about. The actual in `webTest` would later be:

```kt
package com.lagradost.cloudstream3.utils

import kotlin.test.Ignore

actual typealias IgnoreOnWeb = Ignore
```
and because of `@OptionalExpectation`, we don't need to add actual to any other source sets. I decided to do this as a different PR rather than in #2812 because it is kinda different scope after all, and I don't want to drift that scope to much.

I also used `Ignore.kt` as the file name because `IgnoreOnWeb.kt` would mean for `webTest` it would be `IgnoreOnWeb.web.kt` which just seems a bit odd. Additionally this way if we ever need we could also add more in the same file like `IgnoreOnJvm` or `IgnoreOnAndroid`.