### PR TITLE
Bump coil to 3.5.0 and jvmTarget to 11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ annotation = "1.10.0"
 appcompat = "1.7.1"
 biometric = "1.4.0-alpha07"
 buildkonfigGradlePlugin = "0.21.2"
-coil = { strictly = "3.3.0" } # Later versions require jvmTarget 11 or later
+coil = "3.5.0"
 colorpicker = "6b46b49"
 conscryptAndroid = { strictly = "2.5.2" } # 2.5.3 crashes everything
 constraintlayout = "2.2.1"
@@ -56,7 +56,7 @@ video = "1.0.0"
 workRuntimeKtx = "2.11.2"
 zipline = "1.27.0"
 
-jvmTarget = "1.8"
+jvmTarget = "11"
 jdkToolchain = "17"
 minSdk = "23"
 compileSdk = "36"


### PR DESCRIPTION
This should still work on minSdk 23. A newer version of coil is necessary for Skiko for compose later on:
```
w: Skiko dependencies' versions are incompatible.
    io.coil-kt.coil3:coil-core-jvm:3.3.0
    \--- org.jetbrains.skiko:skiko:0.9.4.2 -> 0.144.6
This may lead to compilation errors or unexpected behavior at runtime.
Such version mismatch might be caused by dependency constraints in one of the included libraries.
```
I mean in theory we could ignore it but I don't like that runtime warning. Knowing how things have been in the past if runtime issues can happen it probably will and also, Java 8 is way way out of date anyway, and this should still work on all supported devices.