### PR TITLE
feat: add settings button to provider selection in home

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -24,6 +24,8 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.RecyclerView
+import com.lagradost.cloudstream3.plugins.PluginManager
+import com.lagradost.cloudstream3.CloudStreamApp.Companion.getActivity
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.chip.Chip
@@ -43,6 +45,7 @@ import com.lagradost.cloudstream3.mvvm.Resource
 import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.mvvm.observe
 import com.lagradost.cloudstream3.mvvm.observeNullable
+import com.lagradost.cloudstream3.plugins.Plugin
 import com.lagradost.cloudstream3.ui.APIRepository.Companion.noneApi
 import com.lagradost.cloudstream3.ui.APIRepository.Companion.randomApi
 import com.lagradost.cloudstream3.ui.BaseFragment
@@ -424,11 +427,30 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                             .inflate(R.layout.sort_bottom_single_provider_choice, parent, false)
                         val titleText = view.findViewById<TextView>(R.id.text1)
                         val pinIcon = view.findViewById<ImageView>(R.id.pinicon)
+                        val settingsIcon = view.findViewById<ImageView>(R.id.action_settings)
+
                         val name = getItem(position)
                         titleText?.text = name
+                        val providerApi = currentValidApis[position]
                         val isPinned =
-                            pinnedphashset.contains(currentValidApis[position].name)
+                            pinnedphashset.contains(providerApi.name)
                         pinIcon.visibility = if (isPinned) View.VISIBLE else View.GONE
+
+                        val pluginInstance = providerApi.sourcePlugin?.let { PluginManager.plugins[it] } as? Plugin
+                        val isDownloadedPluginWithSettings = pluginInstance?.openSettings != null && !isLayout(TV)
+
+                        settingsIcon.visibility = if (isDownloadedPluginWithSettings) View.VISIBLE else View.GONE
+                        if (isDownloadedPluginWithSettings) {
+                            settingsIcon.setOnClickListener {
+                                try {
+                                    val activityContext = it.context.getActivity() ?: it.context
+                                    pluginInstance.openSettings?.invoke(activityContext)
+                                } catch (e: Throwable) {
+                                    logError(e)
+                                }
+                            }
+                        }
+
                         return view
                     }
                 }

--- a/app/src/main/res/layout/sort_bottom_single_provider_choice.xml
+++ b/app/src/main/res/layout/sort_bottom_single_provider_choice.xml
@@ -10,13 +10,31 @@
         style="@style/CheckLabel"
         android:layout_gravity="center"
         tools:text="hello" />
-    <ImageView
-        android:id="@+id/pinicon"
-        android:layout_width="50dp"
-        android:layout_height="24dp"
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="end|center_vertical"
-        android:src="@drawable/pin_ic"
-        android:visibility="gone"
-        tools:visibility="visible"
-        tools:ignore="RtlHardcoded" />
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/action_settings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_baseline_tune_24"
+            android:visibility="gone"
+            tools:visibility="visible"
+            android:contentDescription="@string/title_settings" />
+
+        <ImageView
+            android:id="@+id/pinicon"
+            android:layout_width="50dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center_vertical"
+            android:src="@drawable/pin_ic"
+            android:visibility="gone"
+            tools:visibility="visible"
+            tools:ignore="RtlHardcoded" />
+    </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
- Added action_settings button to sort_bottom_single_provider_choice layout.
- Enabled quick access to plugin settings directly from the home provider list.
- Restricted visibility to non-TV layouts to avoid focus issues.

https://github.com/user-attachments/assets/3bc80d8b-f315-4878-9b4c-2c2959efc9a2

