### PR TITLE
Mark UriSerializer InternalAPI

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/serializers/UriSerializer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/serializers/UriSerializer.kt
@@ -1,6 +1,7 @@
 package com.lagradost.cloudstream3.utils.serializers
 
 import android.net.Uri
+import com.lagradost.cloudstream3.InternalAPI
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -26,6 +27,7 @@ import kotlinx.serialization.encoding.Encoder
  *       val uri: Uri,
  *   )
  */
+@InternalAPI
 object UriSerializer : KSerializer<Uri> {
     override val descriptor: SerialDescriptor = 
         PrimitiveSerialDescriptor("Uri", PrimitiveKind.STRING)


### PR DESCRIPTION
We shouldn't really be encouraging extensions to use it and use ktor Url instead which has a serializer for it built into ktor. Eventually I think we should factor out the two usages of an actual Uri in serialization and remove this serializer.