### PR TITLE
More robust date parsing

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -2576,13 +2576,21 @@ constructor(
 
 @OptIn(FormatStringsInDatetimeFormats::class)
 fun Episode.addDate(date: String?, format: String = "yyyy-MM-dd") {
-    if (date == null) return
+    if (date.isNullOrBlank()) return
     this.date = runCatching {
         // First try standard ISO 8601 (e.g. "2026-01-01T12:30:00.000Z", "2026-05-17T14:35+02:00")
         runCatching { Instant.parse(date).toEpochMilliseconds() }
             .getOrElse {
                 val fmt = DateTimeComponents.Format { byUnicodePattern(format) }
-                val components = DateTimeComponents.parse(date, fmt)
+
+                // Try parsing the full date first then only parse the beginning of the string
+                // May lose time, but better than failing.
+                val components = runCatching {
+                    DateTimeComponents.parse(date, fmt)
+                }.recoverCatching {
+                    DateTimeComponents.parse(date.trimStart().take(format.length), fmt)
+                }.getOrThrow()
+
                 /**
                  * Try multiple conversions in order of precision for non-ISO-8601 formats,
                  * since the date string may or may not include time and/or timezone offset:

--- a/library/src/commonTest/kotlin/com/lagradost/cloudstream3/EpisodeDateTest.kt
+++ b/library/src/commonTest/kotlin/com/lagradost/cloudstream3/EpisodeDateTest.kt
@@ -32,6 +32,26 @@ class EpisodeDateTest {
     }
 
     @Test
+    fun addDateDefaultFormatParsesExtraTime() {
+        val ep = episode()
+        ep.addDate("2026-05-17 12:30:45")
+        val expected = LocalDate(2026, 5, 17)
+            .atStartOfDayIn(TimeZone.currentSystemDefault())
+            .toEpochMilliseconds()
+        assertEquals(expected, ep.date)
+    }
+
+    @Test
+    fun addDateDefaultFormatParsesExtraJunk() {
+        val ep = episode()
+        ep.addDate("  2026-05-17 random data")
+        val expected = LocalDate(2026, 5, 17)
+            .atStartOfDayIn(TimeZone.currentSystemDefault())
+            .toEpochMilliseconds()
+        assertEquals(expected, ep.date)
+    }
+
+    @Test
     fun addDateNullDoesNotSetDate() {
         val ep = episode()
         ep.addDate(null as String?)


### PR DESCRIPTION
The date parsing fails at "2026-05-17 12:30:45" when the previous implementation managed to parse it. This was the best solution but it still loses the "12:30:45" part, which is fair considering the format is "yyyy-MM-dd".