### PR TITLE
Library: use api for some dependencies

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -53,19 +53,19 @@ kotlin {
         }
 
         commonMain.dependencies {
-            implementation(libs.annotation) // Annotations
+            api(libs.annotation) // Annotations
+            api(libs.kotlinx.atomicfu)
+            api(libs.kotlinx.coroutines.core)
+            api(libs.kotlinx.datetime)
+            api(libs.kotlinx.io.core)
+            api(libs.kotlinx.serialization.json) // JSON Parser
+            api(libs.ksoup) // HTML Parser
+            api(libs.ktor.http)
+            api(libs.nicehttp) // HTTP Library
+            api(libs.bundles.cryptography) // Cryptography
             implementation(libs.jackson.module.kotlin) // JSON Parser
             implementation(libs.jsoup) // HTML Parser
-            implementation(libs.kotlinx.atomicfu)
-            implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.datetime)
-            implementation(libs.kotlinx.io.core)
-            implementation(libs.kotlinx.serialization.json) // JSON Parser
-            implementation(libs.ksoup) // HTML Parser
-            implementation(libs.ktor.http)
-            implementation(libs.nicehttp) // HTTP Library
             implementation(libs.rhino) // Run JavaScript
-            implementation(libs.bundles.cryptography) // Cryptography
         }
 
         commonTest.dependencies {


### PR DESCRIPTION
I am not 100% sure if we should. This will avoid extensions having to manually add them also allowing us to make sure we standardize versions, but it can also slow the build down according to https://docs.gradle.org/current/userguide/performance.html#use_implementation_for_internal_dependencies