### PR TITLE
MainAPI: use data rather than requestBody for Anilist API

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/MainAPI.kt
@@ -21,14 +21,11 @@ import com.lagradost.cloudstream3.utils.Coroutines.atomicListOf
 import com.lagradost.cloudstream3.utils.Coroutines.mainWork
 import com.lagradost.cloudstream3.utils.SubtitleHelper.fromCodeToLangTagIETF
 import com.lagradost.cloudstream3.utils.SubtitleHelper.fromLanguageToTagIETF
-import com.lagradost.nicehttp.RequestBodyTypes
 import io.ktor.http.Url
 import io.ktor.http.URLBuilder
 import io.ktor.http.encodedPath
 import io.ktor.http.takeFrom
 import okhttp3.Interceptor
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
@@ -322,10 +319,10 @@ object APIHolder {
                 "search" to title,
                 "sort" to "SEARCH_MATCH",
                 "type" to "ANIME",
-            )
-        ).toJson().toRequestBody(RequestBodyTypes.JSON.toMediaTypeOrNull())
+            ).toJson()
+        )
 
-        return app.post("https://graphql.anilist.co", requestBody = data)
+        return app.post("https://graphql.anilist.co", data = data)
             .parsedSafe<AniSearch>()
     }
 }


### PR DESCRIPTION
Consistent with the actual AnilistApi class, as well as will make it easier for the backward compatible NiceHttp migration I am working on to do soon. This should hopefully work because it is how it is done for the same type of request in the AnilistApi class itself also.

This also might be able to use `json =` instead of `data =` but wasn't sure. I did it this way just because it is how AnilistApi does it.