### PR TITLE
Move delayed update trigger from onPause to onDestroy

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -653,10 +653,6 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
     override fun onPause() {
         super.onPause()
 
-        // Start any delayed updates
-        if (ApkInstaller.delayedInstaller?.startInstallation() == true) {
-            Toast.makeText(this, R.string.update_started, Toast.LENGTH_LONG).show()
-        }
         try {
             if (isCastApiAvailable()) {
                 mSessionManager?.removeSessionManagerListener(mSessionManagerListener)
@@ -711,6 +707,11 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
     }
 
     override fun onDestroy() {
+        // Start any delayed updates
+        if (ApkInstaller.delayedInstaller?.startInstallation() == true) {
+            Toast.makeText(this, R.string.update_started, Toast.LENGTH_LONG).show()
+        }
+
         filesToDelete.forEach { path ->
             val result = File(path).deleteRecursively()
             if (result) {


### PR DESCRIPTION
## Description

Fixes #1282

Previously, delayed APK updates were triggered in `onPause()`, which also fires when:
- Entering PiP (Picture-in-Picture) mode
- Switching between activities (e.g., going to "Manage Accounts")
- Pressing the Home button

This caused unexpected and inconsistent update installations when the user had no intention of starting an update. In the issue author's words: "if you forget about it or something and go home you inadvertently start the update which force stops the app."

## Changes

- **Removed** the delayed update trigger from `onPause()` in MainActivity
- **Added** the delayed update trigger to `onDestroy()` in MainActivity

This ensures that delayed updates only install when the activity is actually being destroyed (e.g., when the user explicitly exits the app via back button or exit dialog), not on incidental pauses.

## Testing

The change is a straightforward move of the same code block with the same behavior. The `ApkInstaller.delayedInstaller?.startInstallation()` call and associated toast remain unchanged.