### PR TITLE
Fix posterHeaders not passed in home preview carousel

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeScrollAdapter.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeScrollAdapter.kt
@@ -58,7 +58,7 @@ class HomeScrollAdapter(
 
         when (binding) {
             is HomeScrollViewBinding -> {
-                binding.homeScrollPreview.loadImage(posterUrl)
+                binding.homeScrollPreview.loadImage(posterUrl, item.posterHeaders)
                 binding.homeScrollPreviewTags.apply {
                     text = item.tags?.joinToString(" • ") ?: ""
                     isGone = item.tags.isNullOrEmpty()
@@ -79,7 +79,7 @@ class HomeScrollAdapter(
                 binding.homeScrollPreview.setOnClickListener { view ->
                     callback.invoke(view ?: return@setOnClickListener, position, item)
                 }
-                binding.homeScrollPreview.loadImage(posterUrl)
+                binding.homeScrollPreview.loadImage(posterUrl, item.posterHeaders)
             }
         }
     }


### PR DESCRIPTION
`HomeScrollAdapter.onBindContent()` calls `loadImage(posterUrl)` without passing `item.posterHeaders`, for both `HomeScrollViewBinding` and `HomeScrollViewTvBinding`. This means posters/backgrounds from providers that require custom headers may fail to load in the home preview carousel.