### PR TITLE
Fix posterHeaders not passed in TV detail menu

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
@@ -877,7 +877,7 @@ class ResultFragmentTv : BaseFragment<FragmentResultTvBinding>(
                         resultCastText.setText(d.actorsText)
                         resultNextAiring.setText(d.nextAiringEpisode)
                         resultNextAiringTime.setText(d.nextAiringDate)
-                        resultPoster.loadImage(d.posterImage)
+                        resultPoster.loadImage(d.posterImage, headers = d.posterHeaders)
 
                         var isExpanded = false
                         resultDescription.apply {
@@ -910,7 +910,7 @@ class ResultFragmentTv : BaseFragment<FragmentResultTvBinding>(
                             R.drawable.profile_bg_teal
                         ).random()
 
-                        backgroundPoster.loadImage(d.posterBackgroundImage) {
+                        backgroundPoster.loadImage(d.posterBackgroundImage, headers = d.posterHeaders) {
                             error { getImageFromDrawable(context ?: return@error null, error) }
                         }
 


### PR DESCRIPTION
`ResultFragmentTv.kt` calls loadImage() for poster and background without passing 
`d.posterHeaders`, unlike `ResultFragmentPhone.kt` which does this correctly.