### PR TITLE
FIX: Vidmoly Extractor

### DIFF
--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -7,28 +7,26 @@ import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 
-@Prerelease
 class Vidmolyme : Vidmoly() {
     override val mainUrl = "https://vidmoly.me"
 }
 
-@Prerelease
 class Vidmolyto : Vidmoly() {
     override val mainUrl = "https://vidmoly.to"
 }
 
-@Prerelease
 class Vidmolybiz : Vidmoly() {
     override val mainUrl = "https://vidmoly.biz"
 }
 
-@Prerelease
 open class Vidmoly : ExtractorApi() {
     override val name = "Vidmoly"
     override val mainUrl = "https://vidmoly.net"
     override val requiresReferer = true
+    @Prerelease
     val downloadUrl = "https://vidmoly.biz"
 
+    @Prerelease
     override suspend fun getUrl(
         url: String,
         referer: String?,

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -35,14 +35,13 @@ open class Vidmoly : ExtractorApi() {
             "Sec-Fetch-Dest" to "iframe"
         )
         
-        val newUrl = if (url.contains("/w/")) 
-            url.replaceFirst("/w/", "/embed-") + ".html" 
-            else url
+        val vidmolyId=url.removeSuffix("/").substringAfterLast("/")
+        val newUrl ="https://vidmoly.biz/embed-${vidmolyId}.html"
 
         val script = app.get(newUrl, headers = headers, referer = referer)
             .document.select("script")
-            .firstOrNull { it.data().contains("sources:") }
-            ?.data()
+            .map { it.data().replace("'", "\"") }
+            .firstOrNull { it.contains("sources:") }
 
         // Extracts and parses videoData
         JwPlayerHelper.extractStreamLinks(script.orEmpty(), name, mainUrl, callback, subtitleCallback)

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -23,6 +23,7 @@ open class Vidmoly : ExtractorApi() {
     override val name = "Vidmoly"
     override val mainUrl = "https://vidmoly.net"
     override val requiresReferer = true
+    val downloadUrl = "https://vidmoly.biz"
 
     override suspend fun getUrl(
         url: String,
@@ -36,7 +37,7 @@ open class Vidmoly : ExtractorApi() {
         )
         
         val vidmolyId=url.removeSuffix("/").substringAfterLast("/")
-        val newUrl ="https://vidmoly.biz/embed-${vidmolyId}.html"
+        val newUrl ="${downloadUrl}/embed-${vidmolyId}.html"
 
         val script = app.get(newUrl, headers = headers, referer = referer)
             .document.select("script")

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -37,9 +37,9 @@ open class Vidmoly : ExtractorApi() {
         )
         
         val vidmolyId=url.removeSuffix("/").substringAfterLast("/")
-        val newUrl ="${downloadUrl}/embed-${vidmolyId}.html"
+        val iframeUrl ="${downloadUrl}/embed-${vidmolyId}.html"
 
-        val script = app.get(newUrl, headers = headers, referer = referer)
+        val script = app.get(iframeUrl, headers = headers, referer = referer)
             .document.select("script")
             .map { it.data().replace("'", "\"") }
             .firstOrNull { it.contains("sources:") }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -1,5 +1,5 @@
 package com.lagradost.cloudstream3.extractors
-
+import com.lagradost.cloudstream3.Prerelease
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.app

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -23,16 +23,14 @@ open class Vidmoly : ExtractorApi() {
     override val name = "Vidmoly"
     override val mainUrl = "https://vidmoly.net"
     override val requiresReferer = true
-    @Prerelease
-    val downloadUrl = "https://vidmoly.biz"
 
-    @Prerelease
     override suspend fun getUrl(
         url: String,
         referer: String?,
         subtitleCallback: (SubtitleFile) -> Unit,
         callback: (ExtractorLink) -> Unit
     ) {
+        val downloadUrl = "https://vidmoly.biz"
         val headers = mapOf(
             "user-agent" to USER_AGENT,
             "Sec-Fetch-Dest" to "iframe"

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -19,6 +19,7 @@ class Vidmolybiz : Vidmoly() {
     override val mainUrl = "https://vidmoly.biz"
 }
 
+@Prerelease
 open class Vidmoly : ExtractorApi() {
     override val name = "Vidmoly"
     override val mainUrl = "https://vidmoly.net"

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -7,14 +7,17 @@ import com.lagradost.cloudstream3.extractors.helper.JwPlayerHelper
 import com.lagradost.cloudstream3.utils.ExtractorApi
 import com.lagradost.cloudstream3.utils.ExtractorLink
 
+@Prerelease
 class Vidmolyme : Vidmoly() {
     override val mainUrl = "https://vidmoly.me"
 }
 
+@Prerelease
 class Vidmolyto : Vidmoly() {
     override val mainUrl = "https://vidmoly.to"
 }
 
+@Prerelease
 class Vidmolybiz : Vidmoly() {
     override val mainUrl = "https://vidmoly.biz"
 }

--- a/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
+++ b/library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/Vidmoly.kt
@@ -1,5 +1,5 @@
 package com.lagradost.cloudstream3.extractors
-import com.lagradost.cloudstream3.Prerelease
+
 import com.lagradost.cloudstream3.SubtitleFile
 import com.lagradost.cloudstream3.USER_AGENT
 import com.lagradost.cloudstream3.app


### PR DESCRIPTION
### BACKGROUND

Vidmoly wasn't working because the address of the iframe where the JWP script was extracted is now different. It also had a problem with single quotes in the JSON.

### CHANGES
1. newUrl is now generated from the vidmolyId
2. Script now doesn't have single quotes and the JWPlayerHelper can properly extract the m3u8 url.

### VERIFICATION
Tested with multiple Vidmoly links.
