### PR TITLE
feat(tv): add plugin settings button to home top bar

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -811,10 +811,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                 homeChangeApi.text = apiName
                 homePreviewReloadProvider.isGone = (apiName == noneApi.name)
                 homePreviewSearchButton.isGone = (apiName == noneApi.name)
-                if (isLayout(TV)) {
+                if (isLayout(TV or EMULATOR)) {
                     val plugin = APIHolder.getApiFromNameNull(apiName)
                         ?.sourcePlugin?.let { PluginManager.plugins[it] } as? Plugin
-                    homePreviewSettingsButton.isVisible = plugin?.openSettings != null
+                    homePreviewSettingsButton.isGone = plugin?.openSettings == null
                 }
             }
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -30,6 +30,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.chip.Chip
 import com.lagradost.api.Log
+import com.lagradost.cloudstream3.APIHolder
 import com.lagradost.cloudstream3.APIHolder.apis
 import com.lagradost.cloudstream3.AllLanguagesName
 import com.lagradost.cloudstream3.CommonActivity.showToast
@@ -701,6 +702,21 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                 homeViewModel.queryTextSubmit("")
             }
 
+            homePreviewSettingsButton.setOnClickListener { view ->
+                val apiName = homeViewModel.apiName.value
+                val plugin = APIHolder.getApiFromNameNull(apiName)
+                    ?.sourcePlugin?.let { PluginManager.plugins[it] } as? Plugin
+                val openSettings = plugin?.openSettings
+                if (openSettings != null) {
+                    try {
+                        val activityContext = view.context.getActivity() ?: view.context
+                        openSettings.invoke(activityContext)
+                    } catch (e: Throwable) {
+                        logError(e)
+                    }
+                }
+            }
+
             // Load value for toggling Tv layout real time clock. Hide by default at startup
             // set visibility first, to apply a scroll effect later
             context?.let {
@@ -795,6 +811,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                 homeChangeApi.text = apiName
                 homePreviewReloadProvider.isGone = (apiName == noneApi.name)
                 homePreviewSearchButton.isGone = (apiName == noneApi.name)
+                if (isLayout(TV)) {
+                    val plugin = APIHolder.getApiFromNameNull(apiName)
+                        ?.sourcePlugin?.let { PluginManager.plugins[it] } as? Plugin
+                    homePreviewSettingsButton.isVisible = plugin?.openSettings != null
+                }
             }
         }
 

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -816,6 +816,12 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
 
         observe(homeViewModel.page) { data ->
             binding.apply {
+                if (isLayout(TV or EMULATOR)) {
+                    val plugin = APIHolder.getApiFromNameNull(homeViewModel.apiName.value)
+                        ?.sourcePlugin?.let { PluginManager.plugins[it] } as? Plugin
+                    homePreviewSettingsButton.isGone = plugin?.openSettings == null
+                }
+                
                 when (data) {
                     is Resource.Success -> {
                         val d = data.value
@@ -832,11 +838,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                         homeMasterRecycler.isVisible = true
                         homeLoadingShimmer.stopShimmer()
 
-                        if (isLayout(TV or EMULATOR)) {
-                            val plugin = APIHolder.getApiFromNameNull(homeViewModel.apiName.value)
-                                ?.sourcePlugin?.let { PluginManager.plugins[it] } as? Plugin
-                            homePreviewSettingsButton.isGone = plugin?.openSettings == null
-                        }
                         //home_loaded?.isVisible = true
                         if (toggleRandomButton) {
                             val distinct = d.values

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -811,11 +811,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                 homeChangeApi.text = apiName
                 homePreviewReloadProvider.isGone = (apiName == noneApi.name)
                 homePreviewSearchButton.isGone = (apiName == noneApi.name)
-                if (isLayout(TV or EMULATOR)) {
-                    val plugin = APIHolder.getApiFromNameNull(apiName)
-                        ?.sourcePlugin?.let { PluginManager.plugins[it] } as? Plugin
-                    homePreviewSettingsButton.isGone = plugin?.openSettings == null
-                }
             }
         }
 
@@ -836,6 +831,12 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                         homeLoadingError.isVisible = false
                         homeMasterRecycler.isVisible = true
                         homeLoadingShimmer.stopShimmer()
+
+                        if (isLayout(TV or EMULATOR)) {
+                            val plugin = APIHolder.getApiFromNameNull(homeViewModel.apiName.value)
+                                ?.sourcePlugin?.let { PluginManager.plugins[it] } as? Plugin
+                            homePreviewSettingsButton.isGone = plugin?.openSettings == null
+                        }
                         //home_loaded?.isVisible = true
                         if (toggleRandomButton) {
                             val distinct = d.values

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -260,4 +260,11 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:visibility="gone" />
+
+    <!-- Placeholder for TV layout settings button - always hidden on phone -->
+    <ImageView
+        android:id="@+id/home_preview_settings_button"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone" />
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_home_tv.xml
+++ b/app/src/main/res/layout/fragment_home_tv.xml
@@ -200,10 +200,27 @@
             android:gravity="center"
             android:nextFocusLeft="@id/navigation_home"
             tools:text="Hello!"
-            android:nextFocusRight="@id/home_preview_reload_provider"
+            android:nextFocusRight="@id/home_preview_settings_button"
             android:nextFocusDown="@id/home_preview_info_btt" >
             <requestFocus />
         </com.google.android.material.button.MaterialButton>
+
+        <ImageView
+            android:id="@+id/home_preview_settings_button"
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="end"
+            android:background="@drawable/player_button_tv_attr_no_bg"
+            android:contentDescription="@string/title_settings"
+            android:focusable="true"
+            android:nextFocusLeft="@id/home_change_api"
+            android:nextFocusRight="@id/home_preview_reload_provider"
+            android:nextFocusDown="@id/home_preview_info_btt"
+            android:padding="10dp"
+            android:src="@drawable/ic_baseline_tune_24"
+            android:tag="@string/tv_no_focus_tag"
+            android:visibility="gone"
+            app:tint="@color/player_on_button_tv_attr" />
 
         <ImageView
             android:id="@+id/home_preview_reload_provider"
@@ -213,7 +230,7 @@
             android:background="@drawable/player_button_tv_attr_no_bg"
             android:contentDescription="@string/reload_provider"
             android:focusable="true"
-            android:nextFocusLeft="@id/home_change_api"
+            android:nextFocusLeft="@id/home_preview_settings_button"
             android:nextFocusRight="@id/home_preview_search_button"
             android:nextFocusUp="@id/home_preview_reload_provider"
             android:nextFocusDown="@id/home_preview_info_btt"


### PR DESCRIPTION
Adds a plugin settings button to the TV home page top bar (the home_api_holder group with plugin dropdown, reload, quick search, random).

- New `home_preview_settings_button` in `fragment_home_tv.xml`, placed right after the plugin dropdown button, with the same focus-chain pattern as the other icons
- Visibility driven by the active plugin: shown only when the active provider's plugin exposes `openSettings`; hidden via `isGone` (matches sibling buttons, no dead layout slot)
- Click resolves the active plugin from `apiName` via `APIHolder.getApiFromNameNull` and invokes `openSettings`
- `fragment_home.xml` gets a 0dp placeholder so `FragmentHomeBinding` exposes the field (phone stays unaffected)

TV/emulator only: the button is `isLayout(TV or EMULATOR)` gated for visibility; phone layout keeps a hidden 0dp placeholder.

## AI usage

This PR was developed with AI assistance (opencode). AI usage included design brainstorming, implementation, and testing on TV and phone emulators. The code was built, linted, and verified on the emulators before opening this PR. I can explain every line and fix any issues found in review.