### PR TITLE
Fix: Cast text in emulator layout

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
@@ -874,7 +874,6 @@ class ResultFragmentTv : BaseFragment<FragmentResultTvBinding>(
                         resultMetaRating.setText(d.ratingText)
                         resultMetaStatus.setText(d.onGoingText)
                         resultMetaContentRating.setText(d.contentRatingText)
-                        resultCastText.setText(d.actorsText)
                         resultNextAiring.setText(d.nextAiringEpisode)
                         resultNextAiringTime.setText(d.nextAiringDate)
                         resultPoster.loadImage(d.posterImage, headers = d.posterHeaders)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragmentTv.kt
@@ -932,6 +932,7 @@ class ResultFragmentTv : BaseFragment<FragmentResultTvBinding>(
                             true
                         )
 
+                        resultCastText.setText(if (showCast) d.actorsText else null)
                         resultCastItems.isGone = !showCast || d.actors.isNullOrEmpty()
                         (resultCastItems.adapter as? ActorAdaptor)?.submitList(if (showCast) d.actors else emptyList())
 

--- a/app/src/main/res/layout/fragment_result_tv.xml
+++ b/app/src/main/res/layout/fragment_result_tv.xml
@@ -631,6 +631,18 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
                 </LinearLayout>
             </LinearLayout>
 
+            <TextView
+                android:id="@+id/result_cast_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:layout_marginBottom="5dp"
+                android:ellipsize="end"
+                android:maxLines="2"
+                android:textColor="?attr/grayTextColor"
+                android:textSize="15sp"
+                tools:text="Cast: Joe Ligma" />
+
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/result_cast_items"
                 android:layout_width="match_parent"
@@ -991,17 +1003,6 @@ https://developer.android.com/design/ui/tv/samples/jet-fit
                     </LinearLayout>
                 </LinearLayout>
             </LinearLayout>
-
-            <TextView
-                android:id="@+id/result_cast_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="5dp"
-                android:ellipsize="end"
-                android:maxLines="2"
-                android:textColor="?attr/grayTextColor"
-                android:textSize="15sp"
-                tools:text="Cast: Joe Ligma" />
 
             <TextView
                 android:id="@+id/result_vpn"


### PR DESCRIPTION
For a long time, actors without images have been buggy in the emulator layout. This PR fixes the issue and closes #2379

Before

<img width="1408" height="832" alt="resim" src="https://github.com/user-attachments/assets/e91b2e47-745a-495e-bd4d-46637224b3e4" />

After

<img width="1408" height="832" alt="resim" src="https://github.com/user-attachments/assets/f8e59526-0400-499f-aa63-06fe9144858b" />