### PR TITLE
Feat: Open in browser is now directing immedialetly.

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -31,6 +31,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.chip.Chip
 import com.lagradost.api.Log
 import com.lagradost.cloudstream3.APIHolder.apis
+import com.lagradost.cloudstream3.APIHolder.getApiFromNameNull
 import com.lagradost.cloudstream3.AllLanguagesName
 import com.lagradost.cloudstream3.CommonActivity.showToast
 import com.lagradost.cloudstream3.MainAPI
@@ -66,6 +67,7 @@ import com.lagradost.cloudstream3.utils.AppContextUtils.getApiProviderLangSettin
 import com.lagradost.cloudstream3.utils.AppContextUtils.isNetworkAvailable
 import com.lagradost.cloudstream3.utils.AppContextUtils.isRecyclerScrollable
 import com.lagradost.cloudstream3.utils.AppContextUtils.loadSearchResult
+import com.lagradost.cloudstream3.utils.AppContextUtils.openBrowser
 import com.lagradost.cloudstream3.utils.AppContextUtils.ownHide
 import com.lagradost.cloudstream3.utils.AppContextUtils.ownShow
 import com.lagradost.cloudstream3.utils.AppContextUtils.setDefaultFocus
@@ -835,26 +837,16 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                             homeRandomButtonTv.isGone = true
                         }
                     }
-
+                    //Open browser directly, without a menu.
                     is Resource.Failure -> {
                         homeLoadingShimmer.stopShimmer()
                         homeReloadConnectionerror.setOnClickListener(apiChangeClickListener)
-                        homeReloadConnectionOpenInBrowser.setOnClickListener { view ->
-                            val validAPIs = apis//.filter { api -> api.hasMainPage }
-
-                            view.popupMenuNoIconsAndNoStringRes(validAPIs.mapIndexed { index, api ->
-                                Pair(
-                                    index,
-                                    api.name
-                                )
-                            }) {
-                                try {
-                                    val i = Intent(Intent.ACTION_VIEW)
-                                    i.data = validAPIs[itemId].mainUrl.toUri()
-                                    startActivity(i)
-                                } catch (e: Exception) {
-                                    logError(e)
-                                }
+                        homeReloadConnectionOpenInBrowser.setOnClickListener {
+                            val currentApi = currentApiName?.let { getApiFromNameNull(it) }
+                                ?: homeViewModel.apiName.value?.let { getApiFromNameNull(it) }
+                            val mainUrl = currentApi?.mainUrl
+                            if (!mainUrl.isNullOrBlank()) {
+                                context?.openBrowser(mainUrl)
                             }
                         }
 


### PR DESCRIPTION
**Fixing and changing #2376** 

When an error occurred on the home page, clicking "Open in browser" previously opened an unorganized and non-alphabetical menu listing all extensions instead of directly opening the website. With this PR it directly opens the current extensions website in the browser.

Note: I wasn't sure about completely removing the menu. I thought keeping it and sorting it alphabetically, but decided to remove it for a simple user experience. Alternatively i can revert these changes and just sort the menu alphabetically.