### PR TITLE
Fix: Search menu focus and suggestions

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainActivity.kt
@@ -764,7 +764,7 @@ class MainActivity : AppCompatActivity(), ColorPickerDialogListener, BiometricCa
             // when first loading up the app
 
             // R.id.navigation_home -> R.id.home_preview_change_api
-            R.id.navigation_search -> R.id.main_search
+            R.id.navigation_search -> R.id.search_autofit_results
             R.id.navigation_library -> R.id.main_search
             R.id.navigation_downloads -> R.id.download_appbar
             else -> null

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/CustomRecyclerViews.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/CustomRecyclerViews.kt
@@ -19,7 +19,7 @@ class GrdLayoutManager(val context: Context, spanCount: Int) :
     ): View? {
         return try {
             val fromPos = getPosition(focused)
-            val nextPos = getNextViewPos(fromPos, focusDirection)
+            val nextPos = getNextViewPos(fromPos, focusDirection) ?: return null
             findViewByPosition(nextPos)
         } catch (e: Exception) {
             null
@@ -50,18 +50,18 @@ class GrdLayoutManager(val context: Context, spanCount: Int) :
     override fun onInterceptFocusSearch(focused: View, direction: Int): View? {
         return try {
             val fromPos = getPosition(focused)
-            val nextPos = getNextViewPos(fromPos, direction)
+            val nextPos = getNextViewPos(fromPos, direction) ?: return null
             findViewByPosition(nextPos)
         } catch (e: Exception) {
             null
         }
     }
 
-    private fun getNextViewPos(fromPos: Int, direction: Int): Int {
+    private fun getNextViewPos(fromPos: Int, direction: Int): Int? {
         val offset = calcOffsetToNextView(direction)
 
         if (hitBorder(fromPos, offset)) {
-            return fromPos
+            return null
         }
 
         return fromPos + offset

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/search/SearchFragment.kt
@@ -149,6 +149,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(
 
     override fun onResume() {
         super.onResume()
+        searchViewModel.clearSuggestions()
         afterPluginsLoadedEvent += ::reloadRepos
     }
 
@@ -167,6 +168,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(
      **/
     fun search(query: String?) {
         if (query == null) return
+        searchViewModel.clearSuggestions()
         // don't resume state from prev search
         (binding?.searchMasterRecycler?.adapter as? BaseAdapter<*, *>)?.clearState()
         context?.let { ctx ->
@@ -202,18 +204,24 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(
     private fun reloadRepos(success: Boolean = false) = main {
         searchViewModel.reloadRepos()
         context?.filterProviderByPreferredMedia()?.let { validAPIs ->
+            val isAdvanced = context?.let { PreferenceManager.getDefaultSharedPreferences(it) }
+                ?.getBoolean("advanced_search", true) ?: true
+            val nextFocusDownId = if (isAdvanced) R.id.search_master_recycler else R.id.search_autofit_results
             bindChips(
                 binding?.tvtypesChipsScroll?.tvtypesChips,
                 selectedSearchTypes,
-                validAPIs.flatMap { api -> api.supportedTypes }.distinct()
-            ) { list ->
-                if (selectedSearchTypes.toSet() != list.toSet()) {
-                    DataStoreHelper.searchPreferenceTags = list
-                    selectedSearchTypes.clear()
-                    selectedSearchTypes.addAll(list)
-                    search(binding?.mainSearch?.query?.toString())
-                }
-            }
+                validAPIs.flatMap { api -> api.supportedTypes }.distinct(),
+                { list ->
+                    if (selectedSearchTypes.toSet() != list.toSet()) {
+                        DataStoreHelper.searchPreferenceTags = list
+                        selectedSearchTypes.clear()
+                        selectedSearchTypes.addAll(list)
+                        search(binding?.mainSearch?.query?.toString())
+                    }
+                },
+                nextFocusDown = nextFocusDownId,
+                nextFocusUp = null
+            )
         }
     }
 


### PR DESCRIPTION
**I tried to fix 2 problems which is happen on TV UI.**

**1.Suggestions**

When suggestions appear, the user closes them, opens content and comes back, but suggestions show up again.

**2.Focus**

When a user searches for content and presses the down button to focus on the poster, focus jumps to the left sidebar instead. Similarly, pressing the right button from the left sidebar to reach the poster sends the focus back up to the search bar. 

**Video for Focus;**

https://github.com/user-attachments/assets/2c10183d-e987-4bdc-8c0e-6f7b321ee7bd

**Screenshot for Suggestions (It also happend to me so its a very common problem.);**

<img width="920" height="166" alt="resim" src="https://github.com/user-attachments/assets/02971ffd-21cd-477e-bf10-cabb0227ec96" />


**AI Usage:**

I used AI Guidance for focus issue.

**Tests;**

I tested these two problems with the prerelease and my debug version. All problems are fixed in the debug version. If someone wants to reproduce them, suggestions can easily be reproduced, but search might not be.