### PR TITLE
feat: update home banner size and match its shimmer

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
@@ -655,7 +655,7 @@ class HomeParentItemAdapterPreview(
         }
 
         private fun updatePreview(preview: Resource<Pair<Boolean, List<LoadResponse>>>) {
-            if (preview is Resource.Success) {
+            if (preview is Resource.Success || isLayout(TV or EMULATOR)) {
                 homeNonePadding.apply {
                     val params = layoutParams
                     params.height = 0

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
@@ -310,6 +310,9 @@ class HomeParentItemAdapterPreview(
         private val previewViewpager: ViewPager2 =
             itemView.findViewById(R.id.home_preview_viewpager)
 
+        private val homePreviewShimmer: com.facebook.shimmer.ShimmerFrameLayout? =
+            itemView.findViewById(R.id.home_preview_shimmer)
+
         private val previewViewpagerText: ViewGroup =
             itemView.findViewById(R.id.home_preview_viewpager_text)
 
@@ -662,6 +665,8 @@ class HomeParentItemAdapterPreview(
 
             when (preview) {
                 is Resource.Success -> {
+                    homePreviewShimmer?.stopShimmer()
+                    homePreviewShimmer?.isGone = true
                     previewAdapter.submitList(preview.value.second)
                     previewAdapter.hasMoreItems = preview.value.first
                     /*if (!.setItems(
@@ -693,7 +698,16 @@ class HomeParentItemAdapterPreview(
                     }
                 }
 
+                is Resource.Loading -> {
+                    previewViewpager.isGone = true
+                    previewViewpagerText.isGone = true
+                    homePreviewShimmer?.isVisible = true
+                    homePreviewShimmer?.startShimmer()
+                }
+
                 else -> {
+                    homePreviewShimmer?.stopShimmer()
+                    homePreviewShimmer?.isGone = true
                     previewAdapter.submitList(listOf())
                     previewViewpager.setCurrentItem(0, false)
                     previewViewpager.isVisible = false

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeParentItemAdapterPreview.kt
@@ -655,7 +655,7 @@ class HomeParentItemAdapterPreview(
         }
 
         private fun updatePreview(preview: Resource<Pair<Boolean, List<LoadResponse>>>) {
-            if (preview is Resource.Success || isLayout(TV or EMULATOR)) {
+            if (preview is Resource.Success) {
                 homeNonePadding.apply {
                     val params = layoutParams
                     params.height = 0

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -41,6 +41,7 @@
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="500dp"
+                    android:alpha="0.25"
                     android:background="@color/grayShimmer" />
 
                 <LinearLayout

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -27,9 +27,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center"
-            android:layout_marginTop="15dp"
             android:orientation="vertical"
-            android:paddingTop="40dp"
             app:shimmer_auto_start="true"
             app:shimmer_base_alpha="0.2"
             app:shimmer_duration="@integer/loading_time"
@@ -40,39 +38,10 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <FrameLayout
+                <View
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-
-                    <androidx.cardview.widget.CardView
-                        android:layout_width="125dp"
-                        android:layout_height="200dp"
-                        android:layout_gravity="center"
-                        android:layout_margin="@dimen/loading_margin"
-                        android:background="@color/grayShimmer"
-                        android:translationX="-164dp"
-                        app:cardCornerRadius="@dimen/loading_radius" />
-
-                    <androidx.cardview.widget.CardView
-                        android:layout_width="148dp"
-                        android:layout_height="234dp"
-                        android:layout_gravity="center"
-                        android:layout_margin="@dimen/loading_margin"
-                        android:background="@color/grayShimmer"
-                        app:cardCornerRadius="@dimen/loading_radius" />
-
-                    <androidx.cardview.widget.CardView
-                        android:layout_width="125dp"
-                        android:layout_height="200dp"
-                        android:layout_gravity="center"
-                        android:layout_margin="@dimen/loading_margin"
-                        android:background="@color/grayShimmer"
-                        android:translationX="164dp"
-                        app:cardCornerRadius="@dimen/loading_radius" />
-                </FrameLayout>
-
-                <include layout="@layout/loading_line_short_center" />
+                    android:layout_height="500dp"
+                    android:background="@color/grayShimmer" />
 
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_home_head.xml
+++ b/app/src/main/res/layout/fragment_home_head.xml
@@ -26,6 +26,8 @@
 
         </androidx.viewpager2.widget.ViewPager2>
 
+        <include layout="@layout/loading_hero_banner" />
+
         <LinearLayout
             android:id="@+id/home_padding"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_home_head_tv.xml
+++ b/app/src/main/res/layout/fragment_home_head_tv.xml
@@ -34,7 +34,7 @@
             <androidx.cardview.widget.CardView
                 android:id="@+id/home_preview_info_btt"
                 android:layout_width="match_parent"
-                android:layout_height="400dp"
+                android:layout_height="260dp"
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="10dp"
                 android:layout_marginEnd="10dp"
@@ -69,15 +69,15 @@
                     android:layout_marginStart="@dimen/navbar_width"
                     android:gravity="bottom"
                     android:orientation="vertical"
-                    android:padding="20dp">
+                    android:padding="16dp">
 
                     <ImageView
                         android:id="@+id/home_background_poster_watermark_badge_holder"
                         android:layout_width="wrap_content"
-                        android:layout_height="72dp"
+                        android:layout_height="48dp"
                         android:contentDescription="LogoURL"
-                        android:minHeight="72dp"
-                        android:maxWidth="220dp"
+                        android:minHeight="48dp"
+                        android:maxWidth="200dp"
                         android:scaleType="fitStart"
                         android:adjustViewBounds="true" />
 
@@ -87,10 +87,10 @@
                         android:id="@+id/home_preview_text"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="10dp"
+                        android:layout_marginTop="4dp"
                         android:ellipsize="end"
                         android:maxLines="1"
-                        android:textSize="25sp"
+                        android:textSize="22sp"
                         android:textStyle="bold"
                         android:shadowColor="#B0000000"
                         android:shadowDx="0"
@@ -102,7 +102,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
-                        android:layout_marginTop="10dp"
+                        android:layout_marginTop="4dp"
                         android:layout_marginBottom="4dp"
                         android:gravity="center_vertical">
 
@@ -142,9 +142,9 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:ellipsize="end"
-                        android:maxLines="3"
-                        android:paddingBottom="5dp"
-                        android:textSize="15sp"
+                        android:maxLines="2"
+                        android:paddingBottom="4dp"
+                        android:textSize="14sp"
                         android:textColor="@color/textColor"
                         android:shadowColor="#B0000000"
                         android:shadowDx="0"
@@ -158,9 +158,9 @@
                         android:layout_height="wrap_content"
                         android:ellipsize="end"
                         android:maxLines="1"
-                        android:textSize="13sp"
+                        android:textSize="12sp"
                         android:textColor="@color/gray_400"
-                        android:paddingBottom="5dp"
+                        android:paddingBottom="2dp"
                         tools:text="Cast: Actor One, Actor Two" />
 
                     <com.google.android.material.chip.ChipGroup

--- a/app/src/main/res/layout/fragment_home_head_tv.xml
+++ b/app/src/main/res/layout/fragment_home_head_tv.xml
@@ -58,6 +58,8 @@
 
                 </androidx.viewpager2.widget.ViewPager2>
 
+                <include layout="@layout/loading_hero_banner" />
+
                 <LinearLayout
                     android:id="@+id/home_preview_viewpager_text"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_home_head_tv.xml
+++ b/app/src/main/res/layout/fragment_home_head_tv.xml
@@ -34,7 +34,7 @@
             <androidx.cardview.widget.CardView
                 android:id="@+id/home_preview_info_btt"
                 android:layout_width="match_parent"
-                android:layout_height="260dp"
+                android:layout_height="400dp"
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="10dp"
                 android:layout_marginEnd="10dp"
@@ -69,15 +69,15 @@
                     android:layout_marginStart="@dimen/navbar_width"
                     android:gravity="bottom"
                     android:orientation="vertical"
-                    android:padding="16dp">
+                    android:padding="20dp">
 
                     <ImageView
                         android:id="@+id/home_background_poster_watermark_badge_holder"
                         android:layout_width="wrap_content"
-                        android:layout_height="48dp"
+                        android:layout_height="72dp"
                         android:contentDescription="LogoURL"
-                        android:minHeight="48dp"
-                        android:maxWidth="200dp"
+                        android:minHeight="72dp"
+                        android:maxWidth="220dp"
                         android:scaleType="fitStart"
                         android:adjustViewBounds="true" />
 
@@ -87,10 +87,10 @@
                         android:id="@+id/home_preview_text"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
+                        android:layout_marginTop="10dp"
                         android:ellipsize="end"
                         android:maxLines="1"
-                        android:textSize="22sp"
+                        android:textSize="25sp"
                         android:textStyle="bold"
                         android:shadowColor="#B0000000"
                         android:shadowDx="0"
@@ -102,7 +102,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
-                        android:layout_marginTop="4dp"
+                        android:layout_marginTop="10dp"
                         android:layout_marginBottom="4dp"
                         android:gravity="center_vertical">
 
@@ -142,9 +142,9 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:ellipsize="end"
-                        android:maxLines="2"
-                        android:paddingBottom="4dp"
-                        android:textSize="14sp"
+                        android:maxLines="3"
+                        android:paddingBottom="5dp"
+                        android:textSize="15sp"
                         android:textColor="@color/textColor"
                         android:shadowColor="#B0000000"
                         android:shadowDx="0"
@@ -158,9 +158,9 @@
                         android:layout_height="wrap_content"
                         android:ellipsize="end"
                         android:maxLines="1"
-                        android:textSize="12sp"
+                        android:textSize="13sp"
                         android:textColor="@color/gray_400"
-                        android:paddingBottom="2dp"
+                        android:paddingBottom="5dp"
                         tools:text="Cast: Actor One, Actor Two" />
 
                     <com.google.android.material.chip.ChipGroup

--- a/app/src/main/res/layout/fragment_home_tv.xml
+++ b/app/src/main/res/layout/fragment_home_tv.xml
@@ -29,9 +29,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center"
-            android:layout_marginTop="15dp"
+            android:layout_marginTop="60dp"
             android:orientation="vertical"
-            android:paddingTop="40dp"
             app:shimmer_auto_start="true"
             app:shimmer_base_alpha="0.2"
             app:shimmer_duration="@integer/loading_time"
@@ -42,39 +41,14 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <FrameLayout
+                <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
-
-                    <androidx.cardview.widget.CardView
-                        android:layout_width="125dp"
-                        android:layout_height="200dp"
-                        android:layout_gravity="center"
-                        android:layout_margin="@dimen/loading_margin"
-                        android:background="@color/grayShimmer"
-                        android:translationX="-164dp"
-                        app:cardCornerRadius="@dimen/loading_radius" />
-
-                    <androidx.cardview.widget.CardView
-                        android:layout_width="148dp"
-                        android:layout_height="234dp"
-                        android:layout_gravity="center"
-                        android:layout_margin="@dimen/loading_margin"
-                        android:background="@color/grayShimmer"
-                        app:cardCornerRadius="@dimen/loading_radius" />
-
-                    <androidx.cardview.widget.CardView
-                        android:layout_width="125dp"
-                        android:layout_height="200dp"
-                        android:layout_gravity="center"
-                        android:layout_margin="@dimen/loading_margin"
-                        android:background="@color/grayShimmer"
-                        android:translationX="164dp"
-                        app:cardCornerRadius="@dimen/loading_radius" />
-                </FrameLayout>
-
-                <include layout="@layout/loading_line_short_center" />
+                    android:layout_height="400dp"
+                    android:layout_marginStart="10dp"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginEnd="10dp"
+                    android:background="@color/grayShimmer"
+                    app:cardCornerRadius="@dimen/rounded_image_radius" />
 
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_home_tv.xml
+++ b/app/src/main/res/layout/fragment_home_tv.xml
@@ -28,7 +28,6 @@
             android:id="@+id/home_loading_shimmer"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_gravity="center"
             android:layout_marginTop="60dp"
             android:orientation="vertical"
             app:shimmer_auto_start="true"
@@ -43,7 +42,7 @@
 
                 <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
-                    android:layout_height="400dp"
+                    android:layout_height="260dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="10dp"
                     android:layout_marginEnd="10dp"
@@ -53,13 +52,10 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/result_padding"
-                    android:layout_marginTop="@dimen/result_padding"
-
-                    android:layout_marginEnd="@dimen/result_padding"
+                    android:layout_marginStart="10dp"
+                    android:layout_marginTop="0dp"
+                    android:layout_marginEnd="10dp"
                     android:orientation="vertical">
-
-                    <include layout="@layout/loading_list" />
 
                     <include layout="@layout/loading_list" />
 

--- a/app/src/main/res/layout/fragment_home_tv.xml
+++ b/app/src/main/res/layout/fragment_home_tv.xml
@@ -13,7 +13,6 @@
         android:id="@+id/home_loading"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginStart="@dimen/navbar_width"
         android:visibility="gone"
         tools:visibility="visible">
 
@@ -46,7 +45,8 @@
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="10dp"
                     android:layout_marginEnd="10dp"
-                    android:background="@color/grayShimmer"
+                    android:alpha="0.25"
+                    app:cardBackgroundColor="@color/grayShimmer"
                     app:cardCornerRadius="@dimen/rounded_image_radius" />
 
                 <LinearLayout

--- a/app/src/main/res/layout/fragment_home_tv.xml
+++ b/app/src/main/res/layout/fragment_home_tv.xml
@@ -41,7 +41,7 @@
 
                 <androidx.cardview.widget.CardView
                     android:layout_width="match_parent"
-                    android:layout_height="260dp"
+                    android:layout_height="400dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="10dp"
                     android:layout_marginEnd="10dp"
@@ -52,10 +52,12 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="10dp"
-                    android:layout_marginTop="0dp"
-                    android:layout_marginEnd="10dp"
+                    android:layout_marginStart="@dimen/result_padding"
+                    android:layout_marginTop="@dimen/result_padding"
+                    android:layout_marginEnd="@dimen/result_padding"
                     android:orientation="vertical">
+
+                    <include layout="@layout/loading_list" />
 
                     <include layout="@layout/loading_list" />
 

--- a/app/src/main/res/layout/home_scroll_view_tv.xml
+++ b/app/src/main/res/layout/home_scroll_view_tv.xml
@@ -17,7 +17,7 @@
     <View
         android:id="@+id/title_shadow"
         android:layout_width="match_parent"
-        android:layout_height="250dp"
+        android:layout_height="180dp"
         android:layout_gravity="bottom"
         android:background="@drawable/background_shadow" />
 

--- a/app/src/main/res/layout/home_scroll_view_tv.xml
+++ b/app/src/main/res/layout/home_scroll_view_tv.xml
@@ -17,7 +17,7 @@
     <View
         android:id="@+id/title_shadow"
         android:layout_width="match_parent"
-        android:layout_height="180dp"
+        android:layout_height="250dp"
         android:layout_gravity="bottom"
         android:background="@drawable/background_shadow" />
 

--- a/app/src/main/res/layout/loading_hero_banner.xml
+++ b/app/src/main/res/layout/loading_hero_banner.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.facebook.shimmer.ShimmerFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/home_preview_shimmer"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:visibility="gone"
+    app:shimmer_auto_start="true"
+    app:shimmer_base_alpha="0.05"
+    app:shimmer_duration="@integer/loading_time"
+    app:shimmer_highlight_alpha="0.18">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/grayShimmer" />
+</com.facebook.shimmer.ShimmerFrameLayout>


### PR DESCRIPTION
# Summary
Fixes the initial loading skeleton on the Home screen to properly match the full-bleed Hero Banner redesign instead of the legacy 3-item carousel skeleton. This is crucial for improving user experience by eliminating jarring layout shifts and visual flickering, especially when content is cached or loads instantly—ensuring a seamless and smooth visual transition on app launch and provider switching.

## Screenshot

### TV
<img width="800" height="450" alt="Screen_recording_20260828_151920" src="https://github.com/user-attachments/assets/acfcb0c4-37e0-419e-ac5c-518da0be41db" />

### Phone
<img width="500" height="1111" alt="Screen_recording_20260828_152100" src="https://github.com/user-attachments/assets/4c99b90a-e9f7-46aa-851d-47099dc3ed79" />
